### PR TITLE
Add notifications like 112 in Plugwise-Smile

### DIFF
--- a/tests/test_smile.py
+++ b/tests/test_smile.py
@@ -265,6 +265,7 @@ class TestPlugwise:
         _LOGGER.info("Asserting testdata:")
         device_list = smile.get_all_devices()
         self._write_json("get_all_devices", device_list)
+        self._write_json("notifications", smile.notifications)
 
         location_list, dummy = smile.scan_thermostats()
 


### PR DESCRIPTION
Copied from `Also create notification fixtures - create new test set #112` https://github.com/plugwise/Plugwise-Smile/pull/112 

_When bumping to 1.6.0 we forgot the fixture update (i.e. tests/testdata) which is relevant for the core tests.
More pressing issue is that there is no fixture for notifications yet, hence we couldn't test..._