### PR TITLE
Fix installing within HA core

### DIFF
--- a/plugwise/__init__.py
+++ b/plugwise/__init__.py
@@ -1,6 +1,6 @@
 """Plugwise module."""
 
-__version__ = "0.8.0a1"
+__version__ = "0.8.0a2"
 
 from plugwise.smile import Smile
 from plugwise.stick import stick

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 license      = MIT License
-license_file = LICENSE.md
+license_file = LICENSE
 platforms    = any
 description  = Plugwise Smile, Stretch and USB module for Python 3.
 long_description = file: README.md


### PR DESCRIPTION
`setup.cfg` is pointing to `LICENSE.md` instead of `LICENSE`