### PR TITLE
Check codefactor

### DIFF
--- a/plugwise/__init__.py
+++ b/plugwise/__init__.py
@@ -1,6 +1,6 @@
 """Plugwise module."""
 
-__version__ = "0.8.2"
+__version__ = "0.8.3"
 
 from plugwise.smile import Smile
 from plugwise.stick import stick

--- a/plugwise/smile.py
+++ b/plugwise/smile.py
@@ -66,7 +66,7 @@ class Smile:
     def __init__(
         self,
         host,
-        smile_id,
+        password,
         username=DEFAULT_USERNAME,
         port=DEFAULT_PORT,
         timeout=DEFAULT_TIMEOUT,
@@ -86,7 +86,7 @@ class Smile:
         else:
             self.websession = websession
 
-        self._auth = aiohttp.BasicAuth(username, password=smile_id)
+        self._auth = aiohttp.BasicAuth(username, password=password)
         # Work-around for Stretchv2-aiohttp-deflate-error, can be removed for aiohttp v3.7
         self._headers = {"Accept-Encoding": "gzip"}
 

--- a/tests/test_smile.py
+++ b/tests/test_smile.py
@@ -7,14 +7,14 @@ import logging
 import os
 from pprint import PrettyPrinter
 
+# String generation
+import random
+import string
+
 # Testing
 import aiohttp
 import jsonpickle as json
 import pytest
-
-# String genration
-import random
-import string
 
 from plugwise.exceptions import (
     ConnectionFailedError,
@@ -207,7 +207,7 @@ class TestPlugwise:
         smile = Smile(
             host=server.host,
             username="smile",
-            password=''.join(random.choice(string.ascii_lowercase) for i in range(8)),
+            password="".join(random.choice(string.ascii_lowercase) for i in range(8)),
             port=server.port,
             websession=websession,
         )

--- a/tests/test_smile.py
+++ b/tests/test_smile.py
@@ -12,6 +12,10 @@ import aiohttp
 import jsonpickle as json
 import pytest
 
+# String genration
+import random
+import string
+
 from plugwise.exceptions import (
     ConnectionFailedError,
     DeviceTimeoutError,
@@ -200,11 +204,10 @@ class TestPlugwise:
             text = await resp.text()
             assert "xml" in text
 
-        fake_pass="abcdefh"
         smile = Smile(
             host=server.host,
             username="smile",
-            password=fake_pass,
+            password=''.join(random.choice(string.ascii_lowercase) for i in range(8)),
             port=server.port,
             websession=websession,
         )

--- a/tests/test_smile.py
+++ b/tests/test_smile.py
@@ -200,10 +200,11 @@ class TestPlugwise:
             text = await resp.text()
             assert "xml" in text
 
+        fake_pass="abcdefh"
         smile = Smile(
             host=server.host,
             username="smile",
-            smile_id="abcdefgh",
+            password=fake_pass,
             port=server.port,
             websession=websession,
         )


### PR DESCRIPTION
Rework to have `passwd` stay in place (for upstream, as discussed) and codefactor check for passwords to be 'ok' with the testing password.

Needs bump on `plugwise-beta` to revert to password (from smile_id)