### PR TITLE
Bug fix not reporting long term power of plugs connected to USB-stick

### DIFF
--- a/plugwise/messages/responses.py
+++ b/plugwise/messages/responses.py
@@ -217,7 +217,7 @@ class StickInitResponse(NodeResponse):
         self.unknown1 = Int(0, length=2)
         self.network_is_online = Int(0, length=2)
         self.circle_plus_mac = String(None, length=16)
-        self.network_id = Int(0, length=4)
+        self.network_id = Int(0, 4, False)
         self.unknown2 = Int(0, length=2)
         self.params += [
             self.unknown1,
@@ -245,7 +245,7 @@ class NodePingResponse(NodeResponse):
         super().__init__()
         self.in_RSSI = Int(0, length=2)
         self.out_RSSI = Int(0, length=2)
-        self.ping_ms = Int(0, length=4)
+        self.ping_ms = Int(0, 4, False)
         self.params += [
             self.in_RSSI,
             self.out_RSSI,
@@ -290,7 +290,7 @@ class CirclePlusScanResponse(NodeResponse):
     def __init__(self):
         super().__init__()
         self.node_mac = String(None, length=16)
-        self.node_address = Int(0, length=2)
+        self.node_address = Int(0, 2, False)
         self.params += [self.node_mac, self.node_address]
 
 
@@ -371,7 +371,7 @@ class CirclePlusRealTimeClockResponse(NodeResponse):
         super().__init__()
 
         self.time = RealClockTime()
-        self.day_of_week = Int(0, length=2)
+        self.day_of_week = Int(0, 2, False)
         self.date = RealClockDate()
         self.params += [self.time, self.day_of_week, self.date]
 
@@ -388,7 +388,7 @@ class CircleClockResponse(NodeResponse):
     def __init__(self):
         super().__init__()
         self.time = Time()
-        self.day_of_week = Int(0, 2)
+        self.day_of_week = Int(0, 2, False)
         self.unknown = Int(0, 2)
         self.unknown2 = Int(0, 4)
         self.params += [self.time, self.day_of_week, self.unknown, self.unknown2]
@@ -446,7 +446,7 @@ class NodeAwakeResponse(NodeResponse):
 
     def __init__(self):
         super().__init__()
-        self.awake_type = Int(0, length=2)
+        self.awake_type = Int(0, 2, False)
         self.params += [self.awake_type]
 
 
@@ -463,7 +463,7 @@ class NodeSwitchGroupResponse(NodeResponse):
 
     def __init__(self):
         super().__init__()
-        self.group = Int(0, length=2)
+        self.group = Int(0, 2, False)
         self.power_state = Int(0, length=2)
         self.params += [
             self.group,
@@ -514,7 +514,7 @@ class NodeAckResponse(NodeResponse):
 
     def __init__(self):
         super().__init__()
-        self.ack_id = Int(0, length=2)
+        self.ack_id = Int(0, 2, False)
 
 
 class SenseReportResponse(NodeResponse):

--- a/plugwise/util.py
+++ b/plugwise/util.py
@@ -200,7 +200,7 @@ class SInt(BaseType):
 
 class UnixTimestamp(Int):
     def __init__(self, value, length=8):
-        Int.__init__(self, value, length=length)
+        Int.__init__(self, value, length, False)
 
     def deserialize(self, val):
         Int.deserialize(self, val)

--- a/plugwise/util.py
+++ b/plugwise/util.py
@@ -222,7 +222,7 @@ class DateTime(CompositeType):
     and last four bytes are offset from the beginning of the month in minutes
     """
 
-    def __init__(self, year=0, month=0, minutes=0):
+    def __init__(self, year=0, month=1, minutes=0):
         CompositeType.__init__(self)
         self.year = Year2k(year - PLUGWISE_EPOCH, 2)
         self.month = Int(month, 2, False)
@@ -232,16 +232,21 @@ class DateTime(CompositeType):
     def deserialize(self, val):
         CompositeType.deserialize(self, val)
         minutes = self.minutes.value
-        if minutes == 65535:
+        if minutes == 0:
+            self.value = datetime.datetime(PLUGWISE_EPOCH, 1, 1, 0, 0)
+        elif minutes == 65535:
             self.value = None
         else:
             hours = minutes // 60
             days = hours // 24
             hours -= days * 24
             minutes -= (days * 24 * 60) + (hours * 60)
-            self.value = datetime.datetime(
-                self.year.value, self.month.value, days + 1, hours, minutes
-            )
+            try:
+                self.value = datetime.datetime(
+                    self.year.value, self.month.value, days + 1, hours, minutes
+                )
+            except:
+                self.value = None
 
 
 class Time(CompositeType):

--- a/plugwise/util.py
+++ b/plugwise/util.py
@@ -245,7 +245,7 @@ class DateTime(CompositeType):
                 self.value = datetime.datetime(
                     self.year.value, self.month.value, days + 1, hours, minutes
                 )
-            except:
+            except datetime.datetime.ValueError:
                 self.value = None
 
 


### PR DESCRIPTION
The power usage/production values locally stored at legacy Circle, Circle+ and Stealth devices where not updated/reported for periods from day 22 until the last day of the month.

Some high values of date/time field where deserialized as a negative value, which is not the case for i.e. date/time values.
This PR disables the negative Int deserialize for values which are known to be always positive.