### PR TITLE
0.9.0 - API change for stick

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,6 @@
   The old methods are still available but will give a deprecate warning
   - Stick
     - `devices` (dict) - All discovered and supported plugwise devices with the MAC address as their key
-    - `discovered_nodes` (list) - List of MAC addresses of all discovered nodes
     - `joined_nodes` (integer) - Total number of registered nodes at Plugwise Circle+
     - `mac` (string) - The MAC address of the USB-Stick
     - `network_state` (boolean) - The state (on-line/off-line) of the Plugwise network.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,48 @@
 # Changelog
 
+## 0.8.7 - API change for stick
+
+- Improvement: Debounce relay state
+- Added: New property attributes for USB-stick.
+  The old functions are still available but will give a deprecate warning
+  - Stick
+    - `discovered_nodes` (list) - List of MAC addresses of all discovered nodes
+    - `joined_nodes` (integer) - Total number of registered nodes at Plugwise Circle+
+    - `mac` (string) - The MAC address of the USB-Stick
+    - `network_state` (boolean) - The state (on-line/off-line) of the Plugwise network.
+    - `network_id` (integer) - The ID of the Plugwise network.
+    - `port` (string) - The port connection string
+  - All plugwise devices
+    - `available` (boolean) - The current network availability state of the device
+    - `battery_powered` (boolean) - Indicates if device is battery powered
+    - `ha_components` (tuple) - All supported Home Assistant [components](https://developers.home-assistant.io/docs/core/entity#component) the device supports
+    - `hardware_model` (string) - Hardware model name
+    - `hardware_version` (string) - Hardware version of device
+    - `firmware_version` (string) - Firmware version device is running
+    - `last_update` (datetime) - Date/time stamp of last received update from device
+    - `mac` (string) - MAC address of device
+    - `measures_power` (boolean) - Indicates if device supports power measurement
+    - `name` (string) - Name of device based om hardware model and MAC address
+    - `ping` (integer) - Network roundtrip time in milliseconds
+    - `rssi_in` (DBm) - Inbound RSSI level
+    - `rssi_out` (DBm) - Outbound RSSI level based on the received inbound RSSI level of the neighbor node
+    - `sensors` (tuple) - All supported sensors
+    - `switches` (tuple) - All supported switches
+  - Sense devices
+    - `humidity`  (integer) - Last reported humidity value.
+    - `temperature` (integer) - Last reported temperature value.
+  - Scan devices
+    - `motion` (boolean) - Current detection state of motion.
+  - Circle/Circle+/Stealth devices
+    - `current_power_usage` (float) - Current power usage (Watts) during the last second
+    - `current_power_usage_8_sec` (float) - Current power usage (Watts) during the last 8 seconds
+    - `power_consumption_current_hour` (float) - Total power consumption (kWh) this running hour
+    - `power_consumption_previous_hour` (float) - Total power consumption (kWh) during the previous hour
+    - `power_consumption_today` (float) - Total power consumption (kWh) of today
+    - `power_consumption_yesterday` (float) - Total power consumption (kWh) during yesterday
+    - `power_production_current_hour` (float) - Total power production (kWh) this hour
+    - `relay_state` (boolean) - State of the output power relay. Setting this property will operate the relay
+
 ## 0.8.6 - Code quality improvements for stick
 
 - Bug-fix: Power history was not reported (0 value) during last week of the month

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -62,9 +62,10 @@
 - Improvement: Resolves all flake8 comments
 
 ## 0.8.5 - Fix sensor scaling
-  - Fix for via HA Core issue #44349
-  - Fix other value scaling bugs
-  - Remove aiohttp-workaround - issue solved in aiohttp 3.7.1
+
+- Fix for via HA Core issue #44349
+- Fix other value scaling bugs
+- Remove aiohttp-workaround - issue solved in aiohttp 3.7.1
 
 (## 0.8.4 - Not released: Fix "Gas Consumed Interval stays 0" )
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 - Added: New property attributes for USB-stick.
   The old methods are still available but will give a deprecate warning
   - Stick
+    - `devices` (dict) - All discovered and supported plugwise devices with the MAC address as their key
     - `discovered_nodes` (list) - List of MAC addresses of all discovered nodes
     - `joined_nodes` (integer) - Total number of registered nodes at Plugwise Circle+
     - `mac` (string) - The MAC address of the USB-Stick

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,11 +26,11 @@
     - `ping` (integer) - Network roundtrip time in milliseconds
     - `rssi_in` (DBm) - Inbound RSSI level
     - `rssi_out` (DBm) - Outbound RSSI level based on the received inbound RSSI level of the neighbor node
+  - Scan devices
+    - `motion` (boolean) - Current detection state of motion.
   - Sense devices
     - `humidity`  (integer) - Last reported humidity value.
     - `temperature` (integer) - Last reported temperature value.
-  - Scan devices
-    - `motion` (boolean) - Current detection state of motion.
   - Circle/Circle+/Stealth devices
     - `current_power_usage` (float) - Current power usage (Watts) during the last second
     - `current_power_usage_8_sec` (float) - Current power usage (Watts) during the last 8 seconds

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,8 +26,8 @@
     - `measures_power` (boolean) - Indicates if device supports power measurement
     - `name` (string) - Name of device based om hardware model and MAC address
     - `ping` (integer) - Network roundtrip time in milliseconds
-    - `rssi_in` (DBm) - Inbound RSSI level
-    - `rssi_out` (DBm) - Outbound RSSI level based on the received inbound RSSI level of the neighbor node
+    - `rssi_in` (integer) - Inbound RSSI level in DBm
+    - `rssi_out` (integer) - Outbound RSSI level based on the received inbound RSSI level of the neighbor node in DBm
   - Scan devices
     - `motion` (boolean) - Current detection state of motion.
   - Sense devices

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,10 +1,12 @@
 # Changelog
 
-## 0.8.7 - API change for stick
+## 0.9.0 - API change for stick
 
 - Improvement: Debounce relay state
+- Improvement: Prioritize request so requests like switching a relay get send out before power measurement requests.
+- Improvement: Dynamically change the refresh interval based on the actual discovered nodes with power measurement capabilities
 - Added: New property attributes for USB-stick.
-  The old functions are still available but will give a deprecate warning
+  The old methods are still available but will give a deprecate warning
   - Stick
     - `discovered_nodes` (list) - List of MAC addresses of all discovered nodes
     - `joined_nodes` (integer) - Total number of registered nodes at Plugwise Circle+

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,10 +15,10 @@
   - All plugwise devices
     - `available` (boolean) - The current network availability state of the device
     - `battery_powered` (boolean) - Indicates if device is battery powered
-    - `ha_components` (tuple) - All supported Home Assistant [components](https://developers.home-assistant.io/docs/core/entity#component) the device supports
+    - `features` (tuple) - List of supported attribute IDs
+    - `firmware_version` (string) - Firmware version device is running
     - `hardware_model` (string) - Hardware model name
     - `hardware_version` (string) - Hardware version of device
-    - `firmware_version` (string) - Firmware version device is running
     - `last_update` (datetime) - Date/time stamp of last received update from device
     - `mac` (string) - MAC address of device
     - `measures_power` (boolean) - Indicates if device supports power measurement
@@ -26,8 +26,6 @@
     - `ping` (integer) - Network roundtrip time in milliseconds
     - `rssi_in` (DBm) - Inbound RSSI level
     - `rssi_out` (DBm) - Outbound RSSI level based on the received inbound RSSI level of the neighbor node
-    - `sensors` (tuple) - All supported sensors
-    - `switches` (tuple) - All supported switches
   - Sense devices
     - `humidity`  (integer) - Last reported humidity value.
     - `temperature` (integer) - Last reported temperature value.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,6 +40,8 @@
     - `power_consumption_yesterday` (float) - Total power consumption (kWh) during yesterday
     - `power_production_current_hour` (float) - Total power production (kWh) this hour
     - `relay_state` (boolean) - State of the output power relay. Setting this property will operate the relay
+  - Switch devices
+    - `switch`  (boolean) - Last reported state of switch
 
 ## 0.8.6 - Code quality improvements for stick
 

--- a/plugwise/__init__.py
+++ b/plugwise/__init__.py
@@ -1,6 +1,6 @@
 """Plugwise module."""
 
-__version__ = "0.9.0.a3"
+__version__ = "0.9.0"
 
 from plugwise.smile import Smile
 from plugwise.stick import stick

--- a/plugwise/__init__.py
+++ b/plugwise/__init__.py
@@ -1,6 +1,6 @@
 """Plugwise module."""
 
-__version__ = "0.8.7"
+__version__ = "0.9.0.a0"
 
 from plugwise.smile import Smile
 from plugwise.stick import stick

--- a/plugwise/__init__.py
+++ b/plugwise/__init__.py
@@ -1,6 +1,6 @@
 """Plugwise module."""
 
-__version__ = "0.8.6"
+__version__ = "0.8.7"
 
 from plugwise.smile import Smile
 from plugwise.stick import stick

--- a/plugwise/__init__.py
+++ b/plugwise/__init__.py
@@ -1,6 +1,6 @@
 """Plugwise module."""
 
-__version__ = "0.9.0.a1"
+__version__ = "0.9.0.a2"
 
 from plugwise.smile import Smile
 from plugwise.stick import stick

--- a/plugwise/__init__.py
+++ b/plugwise/__init__.py
@@ -1,6 +1,6 @@
 """Plugwise module."""
 
-__version__ = "0.9.0.a0"
+__version__ = "0.9.0.a1"
 
 from plugwise.smile import Smile
 from plugwise.stick import stick

--- a/plugwise/__init__.py
+++ b/plugwise/__init__.py
@@ -1,6 +1,6 @@
 """Plugwise module."""
 
-__version__ = "0.9.0.a2"
+__version__ = "0.9.0.a3"
 
 from plugwise.smile import Smile
 from plugwise.stick import stick

--- a/plugwise/constants.py
+++ b/plugwise/constants.py
@@ -220,86 +220,92 @@ SENSE_TEMPERATURE_OFFSET = 46.85
 CB_NEW_NODE = "NEW_NODE"
 CB_JOIN_REQUEST = "JOIN_REQUEST"
 
-# Sensors
-SENSOR_AVAILABLE = {
+# Stick device features
+FEATURE_AVAILABLE = {
     "id": "available",
     "name": "Available",
     "state": "available",
     "unit": "state",
 }
-SENSOR_HUMIDITY = {
+FEATURE_HUMIDITY = {
     "id": "humidity",
     "name": "Humidity",
     "state": "humidity",
     "unit": "%",
 }
-SENSOR_MOTION = {
+FEATURE_MOTION = {
     "id": "motion",
     "name": "Motion",
     "state": "motion",
     "unit": "state",
 }
-SENSOR_PING = {
+FEATURE_PING = {
     "id": "ping",
     "name": "Ping roundtrip",
     "state": "ping",
     "unit": TIME_MILLISECONDS,
 }
-SENSOR_POWER_USE = {
+FEATURE_POWER_USE = {
     "id": "power_1s",
     "name": "Power usage",
     "state": "current_power_usage",
     "unit": POWER_WATT,
 }
-SENSOR_POWER_USE_LAST_8_SEC = {
+FEATURE_POWER_USE_LAST_8_SEC = {
     "id": "power_8s",
     "name": "Power usage 8 seconds",
     "state": "current_power_usage_8_sec",
     "unit": POWER_WATT,
 }
-SENSOR_POWER_CONSUMPTION_CURRENT_HOUR = {
+FEATURE_POWER_CONSUMPTION_CURRENT_HOUR = {
     "id": "power_con_cur_hour",
     "name": "Power consumption current hour",
     "state": "power_consumption_current_hour",
     "unit": ENERGY_KILO_WATT_HOUR,
 }
-SENSOR_POWER_CONSUMPTION_PREVIOUS_HOUR = {
+FEATURE_POWER_CONSUMPTION_PREVIOUS_HOUR = {
     "id": "power_con_prev_hour",
     "name": "Power consumption previous hour",
     "state": "power_consumption_previous_hour",
     "unit": ENERGY_KILO_WATT_HOUR,
 }
-SENSOR_POWER_CONSUMPTION_TODAY = {
+FEATURE_POWER_CONSUMPTION_TODAY = {
     "id": "power_con_today",
     "name": "Power consumption today",
     "state": "power_consumption_today",
     "unit": ENERGY_KILO_WATT_HOUR,
 }
-SENSOR_POWER_CONSUMPTION_YESTERDAY = {
+FEATURE_POWER_CONSUMPTION_YESTERDAY = {
     "id": "power_con_yesterday",
     "name": "Power consumption yesterday",
     "state": "power_consumption_yesterday",
     "unit": ENERGY_KILO_WATT_HOUR,
 }
-SENSOR_POWER_PRODUCTION_CURRENT_HOUR = {
+FEATURE_POWER_PRODUCTION_CURRENT_HOUR = {
     "id": "power_prod_cur_hour",
     "name": "Power production current hour",
     "state": "power_production_current_hour",
     "unit": ENERGY_KILO_WATT_HOUR,
 }
-SENSOR_POWER_PRODUCTION_PREVIOUS_HOUR = {
+FEATURE_POWER_PRODUCTION_PREVIOUS_HOUR = {
     "id": "power_prod_prev_hour",
     "name": "Power production previous hour",
     "state": "power_production_previous_hour",
     "unit": ENERGY_KILO_WATT_HOUR,
 }
-SENSOR_SWITCH = {
+FEATURE_RELAY = {
+    "id": "relay",
+    "name": "Relay state",
+    "state": "relay_state",
+    "unit": "state",
+}
+FEATURE_SWITCH = {
     "id": "switch",
-    "name": "switch",
+    "name": "Switch state",
     "state": "switch_state",
     "unit": "state",
 }
-SENSOR_TEMPERATURE = {
+FEATURE_TEMPERATURE = {
     "id": "temperature",
     "name": "Temperature",
     "state": "temperature",
@@ -307,32 +313,18 @@ SENSOR_TEMPERATURE = {
 }
 
 # TODO: Need to validate RSSI sensors
-SENSOR_RSSI_IN = {
+FEATURE_RSSI_IN = {
     "id": "RSSI_in",
     "name": "RSSI in",
     "state": "rssi_in",
     "unit": "Unknown",
 }
-SENSOR_RSSI_OUT = {
+FEATURE_RSSI_OUT = {
     "id": "RSSI_out",
     "name": "RSSI out",
     "state": "rssi_out",
     "unit": "Unknown",
 }
-
-# Switches
-SWITCH_RELAY = {
-    "id": "relay",
-    "name": "Relay state",
-    "state": "relay_state",
-    "switch": "relay_state",
-}
-
-# Home Assistant entities
-HA_SWITCH = "switch"
-HA_SENSOR = "sensor"
-HA_BINARY_SENSOR = "binary_sensor"
-
 
 ### Smile constants ###
 

--- a/plugwise/constants.py
+++ b/plugwise/constants.py
@@ -290,13 +290,13 @@ SENSOR_POWER_PRODUCTION_CURRENT_HOUR = {
 SENSOR_POWER_PRODUCTION_PREVIOUS_HOUR = {
     "id": "power_prod_prev_hour",
     "name": "Power production previous hour",
-    "state": "get_power_production_previous_hour",
+    "state": "power_production_previous_hour",
     "unit": ENERGY_KILO_WATT_HOUR,
 }
 SENSOR_SWITCH = {
     "id": "switch",
     "name": "switch",
-    "state": "get_switch_state",
+    "state": "switch_state",
     "unit": "state",
 }
 SENSOR_TEMPERATURE = {

--- a/plugwise/constants.py
+++ b/plugwise/constants.py
@@ -272,7 +272,7 @@ SENSOR_POWER_CONSUMPTION_PREVIOUS_HOUR = {
 SENSOR_POWER_CONSUMPTION_TODAY = {
     "id": "power_con_today",
     "name": "Power consumption today",
-    "state": "get_power_consumption_today",
+    "state": "power_consumption_today",
     "unit": ENERGY_KILO_WATT_HOUR,
 }
 SENSOR_POWER_CONSUMPTION_YESTERDAY = {

--- a/plugwise/constants.py
+++ b/plugwise/constants.py
@@ -266,7 +266,7 @@ SENSOR_POWER_CONSUMPTION_CURRENT_HOUR = {
 SENSOR_POWER_CONSUMPTION_PREVIOUS_HOUR = {
     "id": "power_con_prev_hour",
     "name": "Power consumption previous hour",
-    "state": "get_power_consumption_previous_hour",
+    "state": "power_consumption_previous_hour",
     "unit": ENERGY_KILO_WATT_HOUR,
 }
 SENSOR_POWER_CONSUMPTION_TODAY = {

--- a/plugwise/constants.py
+++ b/plugwise/constants.py
@@ -284,7 +284,7 @@ SENSOR_POWER_CONSUMPTION_YESTERDAY = {
 SENSOR_POWER_PRODUCTION_CURRENT_HOUR = {
     "id": "power_prod_cur_hour",
     "name": "Power production current hour",
-    "state": "get_power_production_current_hour",
+    "state": "power_production_current_hour",
     "unit": ENERGY_KILO_WATT_HOUR,
 }
 SENSOR_POWER_PRODUCTION_PREVIOUS_HOUR = {

--- a/plugwise/constants.py
+++ b/plugwise/constants.py
@@ -230,7 +230,7 @@ SENSOR_AVAILABLE = {
 SENSOR_HUMIDITY = {
     "id": "humidity",
     "name": "Humidity",
-    "state": "get_humidity",
+    "state": "humidity",
     "unit": "%",
 }
 SENSOR_MOTION = {
@@ -302,7 +302,7 @@ SENSOR_SWITCH = {
 SENSOR_TEMPERATURE = {
     "id": "temperature",
     "name": "Temperature",
-    "state": "get_temperature",
+    "state": "temperature",
     "unit": TEMP_CELSIUS,
 }
 

--- a/plugwise/constants.py
+++ b/plugwise/constants.py
@@ -236,7 +236,7 @@ SENSOR_HUMIDITY = {
 SENSOR_MOTION = {
     "id": "motion",
     "name": "Motion",
-    "state": "get_motion",
+    "state": "motion",
     "unit": "state",
 }
 SENSOR_PING = {

--- a/plugwise/constants.py
+++ b/plugwise/constants.py
@@ -248,7 +248,7 @@ SENSOR_PING = {
 SENSOR_POWER_USE = {
     "id": "power_1s",
     "name": "Power usage",
-    "state": "get_power_usage",
+    "state": "current_power_usage",
     "unit": POWER_WATT,
 }
 SENSOR_POWER_USE_LAST_8_SEC = {

--- a/plugwise/constants.py
+++ b/plugwise/constants.py
@@ -138,8 +138,8 @@ SLEEP_TIME = 150 / 1000
 
 # Message priority levels
 PRIORITY_HIGH = 1
-PRIORITY_LOW = 2
-PRIORITY_MEDIUM = 3
+PRIORITY_LOW = 3
+PRIORITY_MEDIUM = 2
 
 # Max seconds the internal clock of plugwise nodes
 # are allowed to drift in seconds

--- a/plugwise/constants.py
+++ b/plugwise/constants.py
@@ -254,7 +254,7 @@ SENSOR_POWER_USE = {
 SENSOR_POWER_USE_LAST_8_SEC = {
     "id": "power_8s",
     "name": "Power usage 8 seconds",
-    "state": "get_power_usage_8_sec",
+    "state": "current_power_usage_8_sec",
     "unit": POWER_WATT,
 }
 SENSOR_POWER_CONSUMPTION_CURRENT_HOUR = {

--- a/plugwise/constants.py
+++ b/plugwise/constants.py
@@ -136,6 +136,11 @@ LOGADDR_OFFSET = 278528
 # Default sleep between sending messages
 SLEEP_TIME = 150 / 1000
 
+# Message priority levels
+PRIORITY_HIGH = 1
+PRIORITY_LOW = 2
+PRIORITY_MEDIUM = 3
+
 # Max seconds the internal clock of plugwise nodes
 # are allowed to drift in seconds
 MAX_TIME_DRIFT = 30

--- a/plugwise/constants.py
+++ b/plugwise/constants.py
@@ -278,7 +278,7 @@ SENSOR_POWER_CONSUMPTION_TODAY = {
 SENSOR_POWER_CONSUMPTION_YESTERDAY = {
     "id": "power_con_yesterday",
     "name": "Power consumption yesterday",
-    "state": "get_power_consumption_yesterday",
+    "state": "power_consumption_yesterday",
     "unit": ENERGY_KILO_WATT_HOUR,
 }
 SENSOR_POWER_PRODUCTION_CURRENT_HOUR = {

--- a/plugwise/constants.py
+++ b/plugwise/constants.py
@@ -260,7 +260,7 @@ SENSOR_POWER_USE_LAST_8_SEC = {
 SENSOR_POWER_CONSUMPTION_CURRENT_HOUR = {
     "id": "power_con_cur_hour",
     "name": "Power consumption current hour",
-    "state": "get_power_consumption_current_hour",
+    "state": "power_consumption_current_hour",
     "unit": ENERGY_KILO_WATT_HOUR,
 }
 SENSOR_POWER_CONSUMPTION_PREVIOUS_HOUR = {

--- a/plugwise/controller.py
+++ b/plugwise/controller.py
@@ -63,7 +63,7 @@ class StickMessageController:
         """
         Connect to USB-Stick and startup all worker threads
 
-        Return: True when connection is successfull.
+        Return: True when connection is successful.
         """
         self.init_callback = callback
         # Open connection to USB Stick

--- a/plugwise/controller.py
+++ b/plugwise/controller.py
@@ -5,7 +5,7 @@ The controller will:
 - handle the connection (connect/disconnect) to the USB-Stick
 - take care for message acknowledgements based on sequence id's
 - resend message requests when timeouts occurs
-- holds a sending queue (fifo)
+- holds a sending queue and submit messages based on the message priority (high, medium, low)
 - passes received messages back to message processor (stick.py)
 - execution of callbacks after processing the response message
 
@@ -63,7 +63,7 @@ class StickMessageController:
         """
         Connect to USB-Stick and startup all worker threads
 
-        Return: True when if successfully.
+        Return: True when connection is successfull.
         """
         self.init_callback = callback
         # Open connection to USB Stick

--- a/plugwise/controller.py
+++ b/plugwise/controller.py
@@ -142,7 +142,7 @@ class StickMessageController:
                     if self.expected_responses[seq_id][1]:
                         self.expected_responses[seq_id][1]()
                 else:
-                    _LOGGER.warning(
+                    _LOGGER.info(
                         "Resend %s for %s, retry %s of %s",
                         _request,
                         _mac,

--- a/plugwise/controller.py
+++ b/plugwise/controller.py
@@ -12,8 +12,8 @@ The controller will:
 """
 
 from datetime import datetime, timedelta
-from queue import Empty, PriorityQueue
 import logging
+from queue import Empty, PriorityQueue
 import threading
 import time
 

--- a/plugwise/messages/responses.py
+++ b/plugwise/messages/responses.py
@@ -495,7 +495,7 @@ class NodeFeaturesResponse(NodeResponse):
 
     def __init__(self):
         super().__init__()
-        self.features = Int(0, 16)
+        self.features = String(None, length=16)
         self.params += [self.features]
 
 

--- a/plugwise/nodes/__init__.py
+++ b/plugwise/nodes/__init__.py
@@ -56,37 +56,6 @@ class PlugwiseNode:
         self._features = None
 
     @property
-    def mac(self) -> str:
-        """Return the MAC address in string."""
-        return self._mac.decode(UTF8_DECODE)
-
-    @property
-    def hardware_model(self) -> str:
-        """Return hardware model."""
-        if self._hardware_version:
-            return version_to_model(self._hardware_version)
-        return None
-
-    @property
-    def hardware_version(self) -> str:
-        """Return hardware version."""
-        if self._hardware_version is not None:
-            return self._hardware_version
-        return "Unknown"
-
-    @property
-    def firmware_version(self) -> str:
-        """Return firmware version."""
-        if self._firmware_version is not None:
-            return str(self._firmware_version)
-        return "Unknown"
-
-    @property
-    def name(self) -> str:
-        """Return unique name."""
-        return self.hardware_model + " (" + str(self._address) + ")"
-
-    @property
     def available(self) -> bool:
         """Current network state of plugwise node."""
         return self._available
@@ -112,9 +81,55 @@ class PlugwiseNode:
                 self.do_callback(SENSOR_AVAILABLE["id"])
 
     @property
+    def battery_powered(self) -> bool:
+        """Return True if node is a SED (battery powered) device."""
+        return self._battery_powered
+
+    @property
+    def categories(self) -> tuple:
+        """Return Home Assistant categories supported by plugwise node."""
+        return self._categories
+
+    @property
+    def hardware_model(self) -> str:
+        """Return hardware model."""
+        if self._hardware_version:
+            return version_to_model(self._hardware_version)
+        return None
+
+    @property
+    def hardware_version(self) -> str:
+        """Return hardware version."""
+        if self._hardware_version is not None:
+            return self._hardware_version
+        return "Unknown"
+
+    @property
+    def firmware_version(self) -> str:
+        """Return firmware version."""
+        if self._firmware_version is not None:
+            return str(self._firmware_version)
+        return "Unknown"
+
+    @property
     def last_update(self) -> datetime:
         """Return datetime of last received update."""
         return self._last_update
+
+    @property
+    def mac(self) -> str:
+        """Return the MAC address in string."""
+        return self._mac.decode(UTF8_DECODE)
+
+    @property
+    def measures_power(self) -> bool:
+        """Return True if node can measure power usage."""
+        return self._measures_power
+
+    @property
+    def name(self) -> str:
+        """Return unique name."""
+        return self.hardware_model + " (" + str(self._address) + ")"
 
     @property
     def ping(self) -> int:
@@ -138,29 +153,14 @@ class PlugwiseNode:
         return 0
 
     @property
-    def switches(self) -> tuple:
-        """Return switches supported by plugwise node."""
-        return self._switches
-
-    @property
     def sensors(self) -> tuple:
         """Return sensors supported by plugwise node."""
         return self._sensors
 
     @property
-    def categories(self) -> tuple:
-        """Return Home Assistant categories supported by plugwise node."""
-        return self._categories
-
-    @property
-    def battery_powered(self) -> bool:
-        """Return True if node is a SED (battery powered) device."""
-        return self._battery_powered
-
-    @property
-    def measures_power(self) -> bool:
-        """Return True if node can measure power usage."""
-        return self._measures_power
+    def switches(self) -> tuple:
+        """Return switches supported by plugwise node."""
+        return self._switches
 
     def _request_info(self, callback=None):
         """Request info from node."""

--- a/plugwise/nodes/__init__.py
+++ b/plugwise/nodes/__init__.py
@@ -162,7 +162,7 @@ class PlugwiseNode:
         """Return True if node can measure power usage."""
         return self._measures_power
 
-    def request_info(self, callback=None):
+    def _request_info(self, callback=None):
         """Request info from node."""
         self.message_sender(
             NodeInfoRequest(self._mac),
@@ -198,7 +198,7 @@ class PlugwiseNode:
                 self._last_update = message.timestamp
             if not self._available:
                 self.available = True
-                self.request_info()
+                self._request_info()
             if isinstance(message, NodePingResponse):
                 self._process_ping_response(message)
             elif isinstance(message, NodeInfoResponse):

--- a/plugwise/nodes/__init__.py
+++ b/plugwise/nodes/__init__.py
@@ -8,6 +8,7 @@ from ..constants import (
     FEATURE_RELAY,
     FEATURE_RSSI_IN,
     FEATURE_RSSI_OUT,
+    PRIORITY_LOW,
     UTF8_DECODE,
 )
 from ..messages.requests import NodeFeaturesRequest, NodeInfoRequest, NodePingRequest
@@ -155,6 +156,8 @@ class PlugwiseNode:
         self.message_sender(
             NodeInfoRequest(self._mac),
             callback,
+            0,
+            PRIORITY_LOW,
         )
 
     def _request_features(self, callback=None):

--- a/plugwise/nodes/__init__.py
+++ b/plugwise/nodes/__init__.py
@@ -287,7 +287,7 @@ class PlugwiseNode:
             callback,
         )
 
-    def ping(self, callback=None, sensor=True):
+    def do_ping(self, callback=None, sensor=True):
         """Ping node."""
         if sensor or SENSOR_PING["id"] in self._callbacks:
             self.message_sender(

--- a/plugwise/nodes/__init__.py
+++ b/plugwise/nodes/__init__.py
@@ -427,7 +427,7 @@ class PlugwiseNode:
         self.last_info_message = message.timestamp
         if self._last_log_address != message.last_logaddr.value:
             self._last_log_address = message.last_logaddr.value
-        _LOGGER.debug("Node type        = %s", self.hardware_model())
+        _LOGGER.debug("Node type        = %s", self.hardware_model)
         if not self.is_sed:
             _LOGGER.debug("Relay state      = %s", str(self._relay_state))
         _LOGGER.debug("Hardware version = %s", str(self._hardware_version))

--- a/plugwise/nodes/__init__.py
+++ b/plugwise/nodes/__init__.py
@@ -35,7 +35,7 @@ class PlugwiseNode:
             )
         self._mac = bytes(mac, encoding=UTF8_DECODE)
         self.message_sender = message_sender
-        self.categories = ()
+        self._categories = ()
         self._sensors = ()
         self._switches = ()
         self._address = address
@@ -145,6 +145,11 @@ class PlugwiseNode:
         """Return sensors supported by plugwise node."""
         return self._sensors
 
+    @property
+    def categories(self) -> tuple:
+        """Return Home Assistant categories supported by plugwise node."""
+        return self._categories
+
     def get_node_type(self) -> str:
         """Return hardware model."""
         # TODO: Can be removed when HA component is changed to use property
@@ -165,7 +170,11 @@ class PlugwiseNode:
 
     def get_categories(self) -> tuple:
         """Return Home Assistant categories supported by plugwise node."""
-        return self.categories
+        # TODO: Can be removed when HA component is changed to use property
+        _LOGGER.warning(
+            "Function 'get_categories' will be removed in future, use the 'categories' property instead !",
+        )
+        return self._categories
 
     def get_sensors(self) -> tuple:
         """Return sensors supported by plugwise node."""

--- a/plugwise/nodes/__init__.py
+++ b/plugwise/nodes/__init__.py
@@ -176,9 +176,9 @@ class PlugwiseNode:
             callback,
         )
 
-    def _request_ping(self, callback=None, sensor=True):
+    def _request_ping(self, callback=None, ignore_sensor=True):
         """Ping node."""
-        if sensor or SENSOR_PING["id"] in self._callbacks:
+        if ignore_sensor or SENSOR_PING["id"] in self._callbacks:
             self.message_sender(
                 NodePingRequest(self._mac),
                 callback,

--- a/plugwise/nodes/__init__.py
+++ b/plugwise/nodes/__init__.py
@@ -5,9 +5,9 @@ import logging
 from ..constants import (
     FEATURE_AVAILABLE,
     FEATURE_PING,
+    FEATURE_RELAY,
     FEATURE_RSSI_IN,
     FEATURE_RSSI_OUT,
-    FEATURE_RELAY,
     UTF8_DECODE,
 )
 from ..messages.requests import NodeFeaturesRequest, NodeInfoRequest, NodePingRequest

--- a/plugwise/nodes/__init__.py
+++ b/plugwise/nodes/__init__.py
@@ -42,6 +42,7 @@ class PlugwiseNode:
         self._callbacks = {}
         self._last_update = None
         self._available = False
+        self._battery_powered = False
         self._RSSI_in = None
         self._RSSI_out = None
         self._ping = None
@@ -150,6 +151,11 @@ class PlugwiseNode:
         """Return Home Assistant categories supported by plugwise node."""
         return self._categories
 
+    @property
+    def battery_powered(self) -> bool:
+        """Return True if node is a SED (battery powered) device."""
+        return self._battery_powered
+
     def get_node_type(self) -> str:
         """Return hardware model."""
         # TODO: Can be removed when HA component is changed to use property
@@ -162,6 +168,10 @@ class PlugwiseNode:
 
     def is_sed(self) -> bool:
         """Return True if node SED (battery powered)."""
+        # TODO: Can be removed when HA component is changed to use property
+        _LOGGER.warning(
+            "Function 'is_sed' will be removed in future, use the 'battery_powered' property instead !",
+        )
         return False
 
     def measure_power(self) -> bool:

--- a/plugwise/nodes/__init__.py
+++ b/plugwise/nodes/__init__.py
@@ -162,146 +162,6 @@ class PlugwiseNode:
         """Return True if node can measure power usage."""
         return self._measures_power
 
-    def get_node_type(self) -> str:
-        """Return hardware model."""
-        # TODO: Can be removed when HA component is changed to use property
-        _LOGGER.warning(
-            "Function 'get_node_type' will be removed in future, use the 'hardware_model' property instead !",
-        )
-        if self._hardware_version:
-            return version_to_model(self._hardware_version)
-        return None
-
-    def is_sed(self) -> bool:
-        """Return True if node SED (battery powered)."""
-        # TODO: Can be removed when HA component is changed to use property
-        _LOGGER.warning(
-            "Function 'is_sed' will be removed in future, use the 'battery_powered' property instead !",
-        )
-        return False
-
-    def measure_power(self) -> bool:
-        """Return True if node can measure power usage."""
-        # TODO: Can be removed when HA component is changed to use property
-        _LOGGER.warning(
-            "Function 'measure_power' will be removed in future, use the 'measures_power' property instead !",
-        )
-        return self._measures_power
-
-    def get_categories(self) -> tuple:
-        """Return Home Assistant categories supported by plugwise node."""
-        # TODO: Can be removed when HA component is changed to use property
-        _LOGGER.warning(
-            "Function 'get_categories' will be removed in future, use the 'categories' property instead !",
-        )
-        return self._categories
-
-    def get_sensors(self) -> tuple:
-        """Return sensors supported by plugwise node."""
-        # TODO: Can be removed when HA component is changed to use property
-        _LOGGER.warning(
-            "Function 'get_sensors' will be removed in future, use the 'sensors' property instead !",
-        )
-        return self._sensors
-
-    def get_switches(self) -> tuple:
-        """Return switches supported by plugwise node."""
-        # TODO: Can be removed when HA component is changed to use property
-        _LOGGER.warning(
-            "Function 'get_switches' will be removed in future, use the 'switches' property instead !",
-        )
-        return self._switches
-
-    def get_available(self) -> bool:
-        """Return current network state of plugwise node."""
-        # TODO: Can be removed when HA component is changed to use property
-        _LOGGER.warning(
-            "Function 'get_available' will be removed in future, use the 'available' property instead !",
-        )
-        return self.available
-
-    def set_available(self, state, request_info=False):
-        """Set current network availability state of plugwise node."""
-        # TODO: Can be removed when HA component is changed to use property
-        _LOGGER.warning(
-            "Function 'set_available' will be removed in future, use the 'available' property instead !",
-        )
-        self.available = state
-
-    def get_mac(self) -> str:
-        """Return mac address."""
-        # TODO: Can be removed when HA component is changed to use property
-        _LOGGER.warning(
-            "Function 'get_mac' will be removed in future, use the 'mac' property instead !",
-        )
-        return self._mac.decode(UTF8_DECODE)
-
-    def get_name(self) -> str:
-        """Return unique name."""
-        # TODO: Can be removed when HA component is changed to use property
-        _LOGGER.warning(
-            "Function 'get_name' will be removed in future, use the 'name' property instead !",
-        )
-        return self.self.hardware_model + " (" + str(self._address) + ")"
-
-    def get_hardware_version(self) -> str:
-        """Return hardware version."""
-        # TODO: Can be removed when HA component is changed to use property
-        _LOGGER.warning(
-            "Function 'get_hardware_version' will be removed in future, use the 'hardware_version' property instead !",
-        )
-        if self._hardware_version is not None:
-            return self._hardware_version
-        return "Unknown"
-
-    def get_firmware_version(self) -> str:
-        """Return firmware version."""
-        # TODO: Can be removed when HA component is changed to use property
-        _LOGGER.warning(
-            "Function 'get_firmware_version' will be removed in future, use the 'firmware_version' property instead !",
-        )
-        if self._firmware_version is not None:
-            return str(self._firmware_version)
-        return "Unknown"
-
-    def get_last_update(self) -> datetime:
-        """Return  version."""
-        # TODO: Can be removed when HA component is changed to use property
-        _LOGGER.warning(
-            "Function 'get_last_update' will be removed in future, use the 'last_update' property instead !",
-        )
-        return self._last_update
-
-    def get_in_RSSI(self) -> int:
-        """Return inbound RSSI level."""
-        # TODO: Can be removed when HA component is changed to use property
-        _LOGGER.warning(
-            "Function 'get_in_RSSI' will be removed in future, use the 'rssi_in' property instead !",
-        )
-        if self._RSSI_in is not None:
-            return self._RSSI_in
-        return 0
-
-    def get_out_RSSI(self) -> int:
-        """Return outbound RSSI level."""
-        # TODO: Can be removed when HA component is changed to use property
-        _LOGGER.warning(
-            "Function 'get_out_RSSI' will be removed in future, use the 'rssi_out' property instead !",
-        )
-        if self._RSSI_out is not None:
-            return self._RSSI_out
-        return 0
-
-    def get_ping(self) -> int:
-        """Return ping roundtrip."""
-        # TODO: Can be removed when HA component is changed to use property
-        _LOGGER.warning(
-            "Function 'get_ping' will be removed in future, use the 'ping' property instead !",
-        )
-        if self._ping is not None:
-            return self._ping
-        return 0
-
     def request_info(self, callback=None):
         """Request info from node."""
         self.message_sender(
@@ -439,3 +299,128 @@ class PlugwiseNode:
             "Node %s supports features %s", self.mac, str(message.features.value)
         )
         self._features = message.features.value
+
+    ## TODO: All functions below can be removed when HA component is changed to use the property values ##
+    def get_node_type(self) -> str:
+        """Return hardware model."""
+        _LOGGER.warning(
+            "Function 'get_node_type' will be removed in future, use the 'hardware_model' property instead !",
+        )
+        if self._hardware_version:
+            return version_to_model(self._hardware_version)
+        return None
+
+    def is_sed(self) -> bool:
+        """Return True if node SED (battery powered)."""
+        _LOGGER.warning(
+            "Function 'is_sed' will be removed in future, use the 'battery_powered' property instead !",
+        )
+        return False
+
+    def measure_power(self) -> bool:
+        """Return True if node can measure power usage."""
+        _LOGGER.warning(
+            "Function 'measure_power' will be removed in future, use the 'measures_power' property instead !",
+        )
+        return self._measures_power
+
+    def get_categories(self) -> tuple:
+        """Return Home Assistant categories supported by plugwise node."""
+        _LOGGER.warning(
+            "Function 'get_categories' will be removed in future, use the 'categories' property instead !",
+        )
+        return self._categories
+
+    def get_sensors(self) -> tuple:
+        """Return sensors supported by plugwise node."""
+        _LOGGER.warning(
+            "Function 'get_sensors' will be removed in future, use the 'sensors' property instead !",
+        )
+        return self._sensors
+
+    def get_switches(self) -> tuple:
+        """Return switches supported by plugwise node."""
+        _LOGGER.warning(
+            "Function 'get_switches' will be removed in future, use the 'switches' property instead !",
+        )
+        return self._switches
+
+    def get_available(self) -> bool:
+        """Return current network state of plugwise node."""
+        _LOGGER.warning(
+            "Function 'get_available' will be removed in future, use the 'available' property instead !",
+        )
+        return self.available
+
+    def set_available(self, state, request_info=False):
+        """Set current network availability state of plugwise node."""
+        _LOGGER.warning(
+            "Function 'set_available' will be removed in future, use the 'available' property instead !",
+        )
+        self.available = state
+
+    def get_mac(self) -> str:
+        """Return mac address."""
+        _LOGGER.warning(
+            "Function 'get_mac' will be removed in future, use the 'mac' property instead !",
+        )
+        return self._mac.decode(UTF8_DECODE)
+
+    def get_name(self) -> str:
+        """Return unique name."""
+        _LOGGER.warning(
+            "Function 'get_name' will be removed in future, use the 'name' property instead !",
+        )
+        return self.self.hardware_model + " (" + str(self._address) + ")"
+
+    def get_hardware_version(self) -> str:
+        """Return hardware version."""
+        _LOGGER.warning(
+            "Function 'get_hardware_version' will be removed in future, use the 'hardware_version' property instead !",
+        )
+        if self._hardware_version is not None:
+            return self._hardware_version
+        return "Unknown"
+
+    def get_firmware_version(self) -> str:
+        """Return firmware version."""
+        _LOGGER.warning(
+            "Function 'get_firmware_version' will be removed in future, use the 'firmware_version' property instead !",
+        )
+        if self._firmware_version is not None:
+            return str(self._firmware_version)
+        return "Unknown"
+
+    def get_last_update(self) -> datetime:
+        """Return  version."""
+        _LOGGER.warning(
+            "Function 'get_last_update' will be removed in future, use the 'last_update' property instead !",
+        )
+        return self._last_update
+
+    def get_in_RSSI(self) -> int:
+        """Return inbound RSSI level."""
+        _LOGGER.warning(
+            "Function 'get_in_RSSI' will be removed in future, use the 'rssi_in' property instead !",
+        )
+        if self._RSSI_in is not None:
+            return self._RSSI_in
+        return 0
+
+    def get_out_RSSI(self) -> int:
+        """Return outbound RSSI level."""
+        _LOGGER.warning(
+            "Function 'get_out_RSSI' will be removed in future, use the 'rssi_out' property instead !",
+        )
+        if self._RSSI_out is not None:
+            return self._RSSI_out
+        return 0
+
+    def get_ping(self) -> int:
+        """Return ping roundtrip."""
+        _LOGGER.warning(
+            "Function 'get_ping' will be removed in future, use the 'ping' property instead !",
+        )
+        if self._ping is not None:
+            return self._ping
+        return 0

--- a/plugwise/nodes/__init__.py
+++ b/plugwise/nodes/__init__.py
@@ -316,7 +316,7 @@ class PlugwiseNode:
             callback,
         )
 
-    def do_ping(self, callback=None, sensor=True):
+    def _request_ping(self, callback=None, sensor=True):
         """Ping node."""
         if sensor or SENSOR_PING["id"] in self._callbacks:
             self.message_sender(

--- a/plugwise/nodes/__init__.py
+++ b/plugwise/nodes/__init__.py
@@ -99,7 +99,7 @@ class PlugwiseNode:
                 self._available = True
                 _LOGGER.debug(
                     "Mark node %s available",
-                    self.get_mac(),
+                    self.mac,
                 )
                 self.do_callback(SENSOR_AVAILABLE["id"])
         else:
@@ -107,7 +107,7 @@ class PlugwiseNode:
                 self._available = False
                 _LOGGER.debug(
                     "Mark node %s unavailable",
-                    self.get_mac(),
+                    self.mac,
                 )
                 self.do_callback(SENSOR_AVAILABLE["id"])
 
@@ -332,7 +332,7 @@ class PlugwiseNode:
                 _LOGGER.debug(
                     "Previous update %s of node %s, last message %s",
                     str(self._last_update),
-                    self.get_mac(),
+                    self.mac,
                     str(message.timestamp),
                 )
                 self._last_update = message.timestamp
@@ -354,7 +354,7 @@ class PlugwiseNode:
             _LOGGER.debug(
                 "Skip message, mac of node (%s) != mac at message (%s)",
                 message.mac.decode(UTF8_DECODE),
-                self.get_mac(),
+                self.mac,
             )
 
     def message_for_circle(self, message):
@@ -395,7 +395,7 @@ class PlugwiseNode:
         """Process join acknowledge response message"""
         _LOGGER.info(
             "Node %s has (re)joined plugwise network",
-            self.get_mac(),
+            self.mac,
         )
 
     def _process_ping_response(self, message):
@@ -412,7 +412,7 @@ class PlugwiseNode:
 
     def _process_info_response(self, message):
         """Process info response message."""
-        _LOGGER.debug("Response info message for node %s", self.get_mac())
+        _LOGGER.debug("Response info message for node %s", self.mac)
         if message.relay_state.serialize() == b"01":
             if not self._relay_state:
                 self._relay_state = True
@@ -436,6 +436,6 @@ class PlugwiseNode:
     def _process_features_response(self, message):
         """Process features message."""
         _LOGGER.info(
-            "Node %s supports features %s", self.get_mac(), str(message.features.value)
+            "Node %s supports features %s", self.mac, str(message.features.value)
         )
         self._features = message.features.value

--- a/plugwise/nodes/__init__.py
+++ b/plugwise/nodes/__init__.py
@@ -43,6 +43,7 @@ class PlugwiseNode:
         self._last_update = None
         self._available = False
         self._battery_powered = False
+        self._measures_power = False
         self._RSSI_in = None
         self._RSSI_out = None
         self._ping = None
@@ -156,6 +157,11 @@ class PlugwiseNode:
         """Return True if node is a SED (battery powered) device."""
         return self._battery_powered
 
+    @property
+    def measures_power(self) -> bool:
+        """Return True if node can measure power usage."""
+        return self._measures_power
+
     def get_node_type(self) -> str:
         """Return hardware model."""
         # TODO: Can be removed when HA component is changed to use property
@@ -176,7 +182,11 @@ class PlugwiseNode:
 
     def measure_power(self) -> bool:
         """Return True if node can measure power usage."""
-        return False
+        # TODO: Can be removed when HA component is changed to use property
+        _LOGGER.warning(
+            "Function 'measure_power' will be removed in future, use the 'measures_power' property instead !",
+        )
+        return self._measures_power
 
     def get_categories(self) -> tuple:
         """Return Home Assistant categories supported by plugwise node."""

--- a/plugwise/nodes/circle.py
+++ b/plugwise/nodes/circle.py
@@ -255,7 +255,6 @@ class PlugwiseCircle(PlugwiseNode):
                 str(message.ack_id),
                 self.mac,
             )
-        self._request_features()
 
     def _response_power_usage(self, message):
         # Sometimes the circle returns -1 for some of the pulse counters

--- a/plugwise/nodes/circle.py
+++ b/plugwise/nodes/circle.py
@@ -176,7 +176,7 @@ class PlugwiseCircle(PlugwiseNode):
             callback,
         )
 
-    def update_power_usage(self, callback=None):
+    def _request_power_update(self, callback=None):
         """Request power usage and power logs of last hour"""
         if self._available:
             self.message_sender(
@@ -212,7 +212,7 @@ class PlugwiseCircle(PlugwiseNode):
                     "Received power update for %s before calibration information is known",
                     self.mac,
                 )
-                self._request_calibration(self.update_power_usage)
+                self._request_calibration(self._request_power_update)
         elif isinstance(message, NodeAckLargeResponse):
             self._node_ack_response(message)
         elif isinstance(message, CircleCalibrationResponse):

--- a/plugwise/nodes/circle.py
+++ b/plugwise/nodes/circle.py
@@ -75,6 +75,7 @@ class PlugwiseCircle(PlugwiseNode):
         self._gain_b = None
         self._off_noise = None
         self._off_tot = None
+        self._measures_power = True
         self.power_history = {}
         self.power_consumption_prev_hour = None
         self.power_consumption_today = None
@@ -107,10 +108,6 @@ class PlugwiseCircle(PlugwiseNode):
         # Predict new state
         self._new_relay_state = state
         self._new_relay_stamp = datetime.now()
-
-    def measure_power(self) -> bool:
-        """Return True if node can measure power usage."""
-        return True
 
     def _request_calibration(self, callback=None):
         """Request calibration info"""

--- a/plugwise/nodes/circle.py
+++ b/plugwise/nodes/circle.py
@@ -89,25 +89,6 @@ class PlugwiseCircle(PlugwiseNode):
         self._request_calibration()
 
     @property
-    def relay_state(self) -> bool:
-        """
-        Return last known relay state or the new switch state by anticipating
-        the acknowledge for new state is getting in before message timeout.
-        """
-        if self._new_relay_stamp + timedelta(seconds=MESSAGE_TIME_OUT) > datetime.now():
-            return self._new_relay_state
-        return self._relay_state
-
-    @relay_state.setter
-    def relay_state(self, state):
-        """Request the relay to switch state."""
-        self._request_switch(state)
-        self._new_relay_state = state
-        self._new_relay_stamp = datetime.now()
-        if state != self._relay_state:
-            self.do_callback(SWITCH_RELAY["id"])
-
-    @property
     def current_power_usage(self):
         """
         Returns power usage during the last second in Watts
@@ -138,16 +119,6 @@ class PlugwiseCircle(PlugwiseNode):
         return None
 
     @property
-    def power_production_current_hour(self):
-        """
-        Returns the power production during this running hour in kWh
-        Based on last received power usage information
-        """
-        if self._pulses_produced_1h is not None:
-            return self.pulses_to_kWs(self._pulses_produced_1h, 3600)
-        return None
-
-    @property
     def power_consumption_previous_hour(self):
         """Returns power consumption during the previous hour in kWh"""
         return self._power_consumption_prev_hour
@@ -161,6 +132,35 @@ class PlugwiseCircle(PlugwiseNode):
     def power_consumption_yesterday(self):
         """Total power consumption of yesterday in kWh"""
         return self._power_consumption_yesterday
+
+    @property
+    def power_production_current_hour(self):
+        """
+        Returns the power production during this running hour in kWh
+        Based on last received power usage information
+        """
+        if self._pulses_produced_1h is not None:
+            return self.pulses_to_kWs(self._pulses_produced_1h, 3600)
+        return None
+
+    @property
+    def relay_state(self) -> bool:
+        """
+        Return last known relay state or the new switch state by anticipating
+        the acknowledge for new state is getting in before message timeout.
+        """
+        if self._new_relay_stamp + timedelta(seconds=MESSAGE_TIME_OUT) > datetime.now():
+            return self._new_relay_state
+        return self._relay_state
+
+    @relay_state.setter
+    def relay_state(self, state):
+        """Request the relay to switch state."""
+        self._request_switch(state)
+        self._new_relay_state = state
+        self._new_relay_stamp = datetime.now()
+        if state != self._relay_state:
+            self.do_callback(SWITCH_RELAY["id"])
 
     def _request_calibration(self, callback=None):
         """Request calibration info"""

--- a/plugwise/nodes/circle.py
+++ b/plugwise/nodes/circle.py
@@ -206,13 +206,13 @@ class PlugwiseCircle(PlugwiseNode):
                 self._response_power_usage(message)
                 _LOGGER.debug(
                     "Power update for %s, last update %s",
-                    self.get_mac(),
+                    self.mac,
                     str(self._last_update),
                 )
             else:
                 _LOGGER.info(
                     "Received power update for %s before calibration information is known",
-                    self.get_mac(),
+                    self.mac,
                 )
                 self._request_calibration(self.update_power_usage)
         elif isinstance(message, NodeAckLargeResponse):
@@ -225,7 +225,7 @@ class PlugwiseCircle(PlugwiseNode):
             else:
                 _LOGGER.debug(
                     "Received power buffer log for %s before calibration information is known",
-                    self.get_mac(),
+                    self.mac,
                 )
                 self._request_calibration(self.request_power_buffer)
         elif isinstance(message, CircleClockResponse):
@@ -335,7 +335,7 @@ class PlugwiseCircle(PlugwiseNode):
             if not self._relay_state:
                 _LOGGER.debug(
                     "Switch relay on for %s",
-                    self.get_mac(),
+                    self.mac,
                 )
                 self._relay_state = True
                 self.do_callback(SWITCH_RELAY["id"])
@@ -343,7 +343,7 @@ class PlugwiseCircle(PlugwiseNode):
             if self._relay_state:
                 _LOGGER.debug(
                     "Switch relay off for %s",
-                    self.get_mac(),
+                    self.mac,
                 )
                 self._relay_state = False
                 self.do_callback(SWITCH_RELAY["id"])
@@ -351,7 +351,7 @@ class PlugwiseCircle(PlugwiseNode):
             _LOGGER.debug(
                 "Unmanaged _node_ack_response %s received for %s",
                 str(message.ack_id),
-                self.get_mac(),
+                self.mac,
             )
 
     def _response_power_usage(self, message):
@@ -365,7 +365,7 @@ class PlugwiseCircle(PlugwiseNode):
             message.pulse_1s.value = 0
             _LOGGER.debug(
                 "1 sec power pulse counter for node %s has value of -1, corrected to 0",
-                self.get_mac(),
+                self.mac,
             )
         self._pulses_1s = message.pulse_1s.value
         if message.pulse_1s.value != 0:
@@ -385,7 +385,7 @@ class PlugwiseCircle(PlugwiseNode):
             message.pulse_8s.value = 0
             _LOGGER.debug(
                 "8 sec power pulse counter for node %s has value of -1, corrected to 0",
-                self.get_mac(),
+                self.mac,
             )
         if message.pulse_8s.value != 0:
             if message.nanosecond_offset.value != 0:
@@ -404,7 +404,7 @@ class PlugwiseCircle(PlugwiseNode):
             message.pulse_hour_consumed.value = 0
             _LOGGER.debug(
                 "1 hour consumption power pulse counter for node %s has value of -1, corrected to 0",
-                self.get_mac(),
+                self.mac,
             )
         if self._pulses_consumed_1h != message.pulse_hour_consumed.value:
             self._pulses_consumed_1h = message.pulse_hour_consumed.value
@@ -414,7 +414,7 @@ class PlugwiseCircle(PlugwiseNode):
             message.pulse_hour_produced.value = 0
             _LOGGER.debug(
                 "1 hour power production pulse counter for node %s has value of -1, corrected to 0",
-                self.get_mac(),
+                self.mac,
             )
         if self._pulses_produced_1h != message.pulse_hour_produced.value:
             self._pulses_produced_1h = message.pulse_hour_produced.value
@@ -541,7 +541,7 @@ class PlugwiseCircle(PlugwiseNode):
             self._clock_offset = clock_offset.seconds
         _LOGGER.debug(
             "Clock of node %s has drifted %s sec",
-            self.get_mac(),
+            self.mac,
             str(self._clock_offset),
         )
 
@@ -567,7 +567,7 @@ class PlugwiseCircle(PlugwiseNode):
             if (self._clock_offset > max_drift) or (self._clock_offset < -(max_drift)):
                 _LOGGER.info(
                     "Reset clock of node %s because time has drifted %s sec",
-                    self.get_mac(),
+                    self.mac,
                     str(self._clock_offset),
                 )
                 self.set_clock()

--- a/plugwise/nodes/circle.py
+++ b/plugwise/nodes/circle.py
@@ -17,6 +17,8 @@ from ..constants import (
     FEATURE_RSSI_OUT,
     MAX_TIME_DRIFT,
     MESSAGE_TIME_OUT,
+    PRIORITY_HIGH,
+    PRIORITY_LOW,
     PULSES_PER_KW_SECOND,
     RELAY_SWITCHED_OFF,
     RELAY_SWITCHED_ON,
@@ -163,6 +165,8 @@ class PlugwiseCircle(PlugwiseNode):
         self.message_sender(
             CircleCalibrationRequest(self._mac),
             callback,
+            0,
+            PRIORITY_HIGH,
         )
 
     def _request_switch(self, state, callback=None):
@@ -170,6 +174,8 @@ class PlugwiseCircle(PlugwiseNode):
         self.message_sender(
             CircleSwitchRelayRequest(self._mac, state),
             callback,
+            0,
+            PRIORITY_HIGH,
         )
 
     def _request_power_update(self, callback=None):
@@ -358,10 +364,15 @@ class PlugwiseCircle(PlugwiseNode):
                 # Only request last 2 power buffer logs
                 self.message_sender(
                     CirclePowerBufferRequest(self._mac, log_address - 1),
+                    None,
+                    0,
+                    PRIORITY_LOW,
                 )
                 self.message_sender(
                     CirclePowerBufferRequest(self._mac, log_address),
                     callback,
+                    0,
+                    PRIORITY_LOW,
                 )
             else:
                 # Collect power history info of today and yesterday
@@ -369,10 +380,15 @@ class PlugwiseCircle(PlugwiseNode):
                 for req_log_address in range(log_address - 13, log_address):
                     self.message_sender(
                         CirclePowerBufferRequest(self._mac, req_log_address),
+                        None,
+                        0,
+                        PRIORITY_LOW,
                     )
                 self.message_sender(
                     CirclePowerBufferRequest(self._mac, log_address),
                     callback,
+                    0,
+                    PRIORITY_LOW,
                 )
 
     def _response_power_buffer(self, message):
@@ -452,6 +468,8 @@ class PlugwiseCircle(PlugwiseNode):
         self.message_sender(
             CircleClockGetRequest(self._mac),
             callback,
+            0,
+            PRIORITY_LOW,
         )
 
     def set_clock(self, callback=None):

--- a/plugwise/nodes/circle.py
+++ b/plugwise/nodes/circle.py
@@ -77,7 +77,7 @@ class PlugwiseCircle(PlugwiseNode):
         self._off_tot = None
         self._measures_power = True
         self.power_history = {}
-        self.power_consumption_prev_hour = None
+        self._power_consumption_prev_hour = None
         self.power_consumption_today = None
         self.power_consumption_yesterday = None
         self.last_log_collected = False
@@ -148,6 +148,11 @@ class PlugwiseCircle(PlugwiseNode):
         if self._pulses_produced_1h is not None:
             return self.pulses_to_kWs(self._pulses_produced_1h, 3600)
         return None
+
+    @property
+    def power_consumption_previous_hour(self):
+        """Returns power consumption during the previous hour in kWh"""
+        return self._power_consumption_prev_hour
 
     def _request_calibration(self, callback=None):
         """Request calibration info"""
@@ -292,7 +297,11 @@ class PlugwiseCircle(PlugwiseNode):
 
     def get_power_consumption_prev_hour(self):
         """Returns power consumption during the previous hour in kWh"""
-        return self.power_consumption_prev_hour
+        # TODO: Can be removed when HA component is changed to use property
+        _LOGGER.warning(
+            "Function 'get_power_consumption_prev_hour' will be removed in future, use the 'power_consumption_previous_hour' property instead !",
+        )
+        return self._power_consumption_prev_hour
 
     def get_power_consumption_today(self):
         """Total power consumption during today in kWh"""
@@ -486,8 +495,8 @@ class PlugwiseCircle(PlugwiseNode):
                 datetime.now().today().date() - timedelta(days=1)
             ):
                 yesterday_power += self.power_history[dt]
-        if self.power_consumption_prev_hour != last_hour_usage:
-            self.power_consumption_prev_hour = last_hour_usage
+        if self._power_consumption_prev_hour != last_hour_usage:
+            self._power_consumption_prev_hour = last_hour_usage
             self.do_callback(SENSOR_POWER_CONSUMPTION_PREVIOUS_HOUR["id"])
         if self.power_consumption_today != today_power:
             self.power_consumption_today = today_power

--- a/plugwise/nodes/circle.py
+++ b/plugwise/nodes/circle.py
@@ -48,7 +48,7 @@ class PlugwiseCircle(PlugwiseNode):
 
     def __init__(self, mac, address, message_sender):
         super().__init__(mac, address, message_sender)
-        self.categories = (HA_SWITCH, HA_SENSOR)
+        self._categories = (HA_SWITCH, HA_SENSOR)
         self._sensors = (
             SENSOR_AVAILABLE["id"],
             SENSOR_PING["id"],

--- a/plugwise/nodes/circle.py
+++ b/plugwise/nodes/circle.py
@@ -69,7 +69,7 @@ class PlugwiseCircle(PlugwiseNode):
         self._pulses_1s = None
         self._pulses_8s = None
         self._pulses_consumed_1h = None
-        self.pulses_produced_1h = None
+        self._pulses_produced_1h = None
         self.calibration = False
         self._gain_a = None
         self._gain_b = None
@@ -137,6 +137,16 @@ class PlugwiseCircle(PlugwiseNode):
         """
         if self._pulses_consumed_1h is not None:
             return self.pulses_to_kWs(self._pulses_consumed_1h, 3600)
+        return None
+
+    @property
+    def power_production_current_hour(self):
+        """
+        Returns the power production during this running hour in kWh
+        Based on last received power usage information
+        """
+        if self._pulses_produced_1h is not None:
+            return self.pulses_to_kWs(self._pulses_produced_1h, 3600)
         return None
 
     def _request_calibration(self, callback=None):
@@ -272,8 +282,12 @@ class PlugwiseCircle(PlugwiseNode):
         Returns the power production during this running hour in kWh
         Based on last received power usage information
         """
-        if self.pulses_produced_1h is not None:
-            return self.pulses_to_kWs(self.pulses_produced_1h, 3600)
+        # TODO: Can be removed when HA component is changed to use property
+        _LOGGER.warning(
+            "Function 'get_power_production_current_hour' will be removed in future, use the 'power_production_current_hour' property instead !",
+        )
+        if self._pulses_produced_1h is not None:
+            return self.pulses_to_kWs(self._pulses_produced_1h, 3600)
         return None
 
     def get_power_consumption_prev_hour(self):
@@ -375,8 +389,8 @@ class PlugwiseCircle(PlugwiseNode):
                 "1 hour power production pulse counter for node %s has value of -1, corrected to 0",
                 self.get_mac(),
             )
-        if self.pulses_produced_1h != message.pulse_hour_produced.value:
-            self.pulses_produced_1h = message.pulse_hour_produced.value
+        if self._pulses_produced_1h != message.pulse_hour_produced.value:
+            self._pulses_produced_1h = message.pulse_hour_produced.value
             self.do_callback(SENSOR_POWER_PRODUCTION_CURRENT_HOUR["id"])
 
     def _response_calibration(self, message):

--- a/plugwise/nodes/circle.py
+++ b/plugwise/nodes/circle.py
@@ -191,7 +191,7 @@ class PlugwiseCircle(PlugwiseNode):
                     microsecond=0,
                 )
             ):
-                self.request_info(self.request_power_buffer)
+                self._request_info(self.request_power_buffer)
             if not self.last_log_collected:
                 self.request_power_buffer()
 

--- a/plugwise/nodes/circle.py
+++ b/plugwise/nodes/circle.py
@@ -65,7 +65,7 @@ class PlugwiseCircle(PlugwiseNode):
         )
         self._switches = (SWITCH_RELAY["id"],)
         self._new_relay_state = False
-        self._new_relay_stamp = datetime.now()
+        self._new_relay_stamp = datetime.now() - timedelta(seconds=MESSAGE_TIME_OUT)
         self._pulses_1s = None
         self._pulses_8s = None
         self._pulses_consumed_1h = None
@@ -101,13 +101,11 @@ class PlugwiseCircle(PlugwiseNode):
     @relay_state.setter
     def relay_state(self, state):
         """Request the relay to switch state."""
-        self.message_sender(
-            CircleSwitchRelayRequest(self._mac, state),
-            None,
-        )
-        # Predict new state
+        self._request_switch(state)
         self._new_relay_state = state
         self._new_relay_stamp = datetime.now()
+        if state != self._relay_state:
+            self.do_callback(SWITCH_RELAY["id"])
 
     @property
     def current_power_usage(self):

--- a/plugwise/nodes/circle.py
+++ b/plugwise/nodes/circle.py
@@ -78,7 +78,7 @@ class PlugwiseCircle(PlugwiseNode):
         self._measures_power = True
         self.power_history = {}
         self._power_consumption_prev_hour = None
-        self.power_consumption_today = None
+        self._power_consumption_today = None
         self.power_consumption_yesterday = None
         self.last_log_collected = False
         self.timezone_delta = datetime.now().replace(
@@ -153,6 +153,11 @@ class PlugwiseCircle(PlugwiseNode):
     def power_consumption_previous_hour(self):
         """Returns power consumption during the previous hour in kWh"""
         return self._power_consumption_prev_hour
+
+    @property
+    def power_consumption_today(self):
+        """Total power consumption during today in kWh"""
+        return self._power_consumption_today
 
     def _request_calibration(self, callback=None):
         """Request calibration info"""
@@ -305,7 +310,11 @@ class PlugwiseCircle(PlugwiseNode):
 
     def get_power_consumption_today(self):
         """Total power consumption during today in kWh"""
-        return self.power_consumption_today
+        # TODO: Can be removed when HA component is changed to use property
+        _LOGGER.warning(
+            "Function 'get_power_consumption_today' will be removed in future, use the 'power_consumption_today' property instead !",
+        )
+        return self._power_consumption_today
 
     def get_power_consumption_yesterday(self):
         """Total power consumption of yesterday in kWh"""
@@ -498,8 +507,8 @@ class PlugwiseCircle(PlugwiseNode):
         if self._power_consumption_prev_hour != last_hour_usage:
             self._power_consumption_prev_hour = last_hour_usage
             self.do_callback(SENSOR_POWER_CONSUMPTION_PREVIOUS_HOUR["id"])
-        if self.power_consumption_today != today_power:
-            self.power_consumption_today = today_power
+        if self._power_consumption_today != today_power:
+            self._power_consumption_today = today_power
             self.do_callback(SENSOR_POWER_CONSUMPTION_TODAY["id"])
         if self.power_consumption_yesterday != yesterday_power:
             self.power_consumption_yesterday = yesterday_power

--- a/plugwise/nodes/circle.py
+++ b/plugwise/nodes/circle.py
@@ -79,7 +79,7 @@ class PlugwiseCircle(PlugwiseNode):
         self.power_history = {}
         self._power_consumption_prev_hour = None
         self._power_consumption_today = None
-        self.power_consumption_yesterday = None
+        self._power_consumption_yesterday = None
         self.last_log_collected = False
         self.timezone_delta = datetime.now().replace(
             minute=0, second=0, microsecond=0
@@ -158,6 +158,11 @@ class PlugwiseCircle(PlugwiseNode):
     def power_consumption_today(self):
         """Total power consumption during today in kWh"""
         return self._power_consumption_today
+
+    @property
+    def power_consumption_yesterday(self):
+        """Total power consumption of yesterday in kWh"""
+        return self._power_consumption_yesterday
 
     def _request_calibration(self, callback=None):
         """Request calibration info"""
@@ -318,7 +323,11 @@ class PlugwiseCircle(PlugwiseNode):
 
     def get_power_consumption_yesterday(self):
         """Total power consumption of yesterday in kWh"""
-        return self.power_consumption_yesterday
+        # TODO: Can be removed when HA component is changed to use property
+        _LOGGER.warning(
+            "Function 'get_power_consumption_yesterday' will be removed in future, use the 'power_consumption_yesterday' property instead !",
+        )
+        return self._power_consumption_yesterday
 
     def _node_ack_response(self, message):
         """Process switch response message"""
@@ -510,8 +519,8 @@ class PlugwiseCircle(PlugwiseNode):
         if self._power_consumption_today != today_power:
             self._power_consumption_today = today_power
             self.do_callback(SENSOR_POWER_CONSUMPTION_TODAY["id"])
-        if self.power_consumption_yesterday != yesterday_power:
-            self.power_consumption_yesterday = yesterday_power
+        if self._power_consumption_yesterday != yesterday_power:
+            self._power_consumption_yesterday = yesterday_power
             self.do_callback(SENSOR_POWER_CONSUMPTION_YESTERDAY["id"])
 
     def _response_clock(self, message):

--- a/plugwise/nodes/circle.py
+++ b/plugwise/nodes/circle.py
@@ -3,7 +3,6 @@ from datetime import datetime, timedelta
 import logging
 
 from ..constants import (
-    FEATURE_AVAILABLE,
     FEATURE_PING,
     FEATURE_POWER_CONSUMPTION_CURRENT_HOUR,
     FEATURE_POWER_CONSUMPTION_PREVIOUS_HOUR,

--- a/plugwise/nodes/circle.py
+++ b/plugwise/nodes/circle.py
@@ -237,98 +237,6 @@ class PlugwiseCircle(PlugwiseNode):
         """Pass messages to PlugwiseCirclePlus class"""
         pass
 
-    def get_relay_state(self) -> bool:
-        """Return last known relay state."""
-        # TODO: Can be removed when HA component is changed to use property
-        _LOGGER.warning(
-            "Function 'get_relay_state' will be removed in future, use the 'relay_state' property instead !",
-        )
-        return self._relay_state
-
-    def set_relay_state(self, state: bool, callback=None):
-        """Switch relay."""
-        # TODO: Can be removed when HA component is changed to use property
-        _LOGGER.warning(
-            "Function 'set_relay_state' will be removed in future, use the 'relay_state' property instead !",
-        )
-        self._request_switch(state, callback)
-
-    def get_power_usage(self):
-        """
-        Returns power usage during the last second in Watts
-        Based on last received power usage information
-        """
-        # TODO: Can be removed when HA component is changed to use property
-        _LOGGER.warning(
-            "Function 'get_power_usage' will be removed in future, use the 'current_power_usage' property instead !",
-        )
-        if self._pulses_1s is not None:
-            return self.pulses_to_kWs(self._pulses_1s) * 1000
-        return None
-
-    def get_power_usage_8_sec(self):
-        """
-        Returns power usage during the last 8 second in Watts
-        Based on last received power usage information
-        """
-        # TODO: Can be removed when HA component is changed to use property
-        _LOGGER.warning(
-            "Function 'get_power_usage_8_sec' will be removed in future, use the 'current_power_usage_8_sec' property instead !",
-        )
-        if self._pulses_8s is not None:
-            return self.pulses_to_kWs(self._pulses_8s, 8) * 1000
-        return None
-
-    def get_power_consumption_current_hour(self):
-        """
-        Returns the power usage during this running hour in kWh
-        Based on last received power usage information
-        """
-        # TODO: Can be removed when HA component is changed to use property
-        _LOGGER.warning(
-            "Function 'get_power_consumption_current_hour' will be removed in future, use the 'power_consumption_current_hour' property instead !",
-        )
-        if self._pulses_consumed_1h is not None:
-            return self.pulses_to_kWs(self._pulses_consumed_1h, 3600)
-        return None
-
-    def get_power_production_current_hour(self):
-        """
-        Returns the power production during this running hour in kWh
-        Based on last received power usage information
-        """
-        # TODO: Can be removed when HA component is changed to use property
-        _LOGGER.warning(
-            "Function 'get_power_production_current_hour' will be removed in future, use the 'power_production_current_hour' property instead !",
-        )
-        if self._pulses_produced_1h is not None:
-            return self.pulses_to_kWs(self._pulses_produced_1h, 3600)
-        return None
-
-    def get_power_consumption_prev_hour(self):
-        """Returns power consumption during the previous hour in kWh"""
-        # TODO: Can be removed when HA component is changed to use property
-        _LOGGER.warning(
-            "Function 'get_power_consumption_prev_hour' will be removed in future, use the 'power_consumption_previous_hour' property instead !",
-        )
-        return self._power_consumption_prev_hour
-
-    def get_power_consumption_today(self):
-        """Total power consumption during today in kWh"""
-        # TODO: Can be removed when HA component is changed to use property
-        _LOGGER.warning(
-            "Function 'get_power_consumption_today' will be removed in future, use the 'power_consumption_today' property instead !",
-        )
-        return self._power_consumption_today
-
-    def get_power_consumption_yesterday(self):
-        """Total power consumption of yesterday in kWh"""
-        # TODO: Can be removed when HA component is changed to use property
-        _LOGGER.warning(
-            "Function 'get_power_consumption_yesterday' will be removed in future, use the 'power_consumption_yesterday' property instead !",
-        )
-        return self._power_consumption_yesterday
-
     def _node_ack_response(self, message):
         """Process switch response message"""
         if message.ack_id == RELAY_SWITCHED_ON:
@@ -571,3 +479,87 @@ class PlugwiseCircle(PlugwiseNode):
                     str(self._clock_offset),
                 )
                 self.set_clock()
+
+    ## TODO: All functions below can be removed when HA component is changed to use the property values ##
+    def get_relay_state(self) -> bool:
+        """Return last known relay state."""
+        _LOGGER.warning(
+            "Function 'get_relay_state' will be removed in future, use the 'relay_state' property instead !",
+        )
+        return self._relay_state
+
+    def set_relay_state(self, state: bool, callback=None):
+        """Switch relay."""
+        _LOGGER.warning(
+            "Function 'set_relay_state' will be removed in future, use the 'relay_state' property instead !",
+        )
+        self._request_switch(state, callback)
+
+    def get_power_usage(self):
+        """
+        Returns power usage during the last second in Watts
+        Based on last received power usage information
+        """
+        _LOGGER.warning(
+            "Function 'get_power_usage' will be removed in future, use the 'current_power_usage' property instead !",
+        )
+        if self._pulses_1s is not None:
+            return self.pulses_to_kWs(self._pulses_1s) * 1000
+        return None
+
+    def get_power_usage_8_sec(self):
+        """
+        Returns power usage during the last 8 second in Watts
+        Based on last received power usage information
+        """
+        _LOGGER.warning(
+            "Function 'get_power_usage_8_sec' will be removed in future, use the 'current_power_usage_8_sec' property instead !",
+        )
+        if self._pulses_8s is not None:
+            return self.pulses_to_kWs(self._pulses_8s, 8) * 1000
+        return None
+
+    def get_power_consumption_current_hour(self):
+        """
+        Returns the power usage during this running hour in kWh
+        Based on last received power usage information
+        """
+        _LOGGER.warning(
+            "Function 'get_power_consumption_current_hour' will be removed in future, use the 'power_consumption_current_hour' property instead !",
+        )
+        if self._pulses_consumed_1h is not None:
+            return self.pulses_to_kWs(self._pulses_consumed_1h, 3600)
+        return None
+
+    def get_power_production_current_hour(self):
+        """
+        Returns the power production during this running hour in kWh
+        Based on last received power usage information
+        """
+        _LOGGER.warning(
+            "Function 'get_power_production_current_hour' will be removed in future, use the 'power_production_current_hour' property instead !",
+        )
+        if self._pulses_produced_1h is not None:
+            return self.pulses_to_kWs(self._pulses_produced_1h, 3600)
+        return None
+
+    def get_power_consumption_prev_hour(self):
+        """Returns power consumption during the previous hour in kWh"""
+        _LOGGER.warning(
+            "Function 'get_power_consumption_prev_hour' will be removed in future, use the 'power_consumption_previous_hour' property instead !",
+        )
+        return self._power_consumption_prev_hour
+
+    def get_power_consumption_today(self):
+        """Total power consumption during today in kWh"""
+        _LOGGER.warning(
+            "Function 'get_power_consumption_today' will be removed in future, use the 'power_consumption_today' property instead !",
+        )
+        return self._power_consumption_today
+
+    def get_power_consumption_yesterday(self):
+        """Total power consumption of yesterday in kWh"""
+        _LOGGER.warning(
+            "Function 'get_power_consumption_yesterday' will be removed in future, use the 'power_consumption_yesterday' property instead !",
+        )
+        return self._power_consumption_yesterday

--- a/plugwise/nodes/circle_plus.py
+++ b/plugwise/nodes/circle_plus.py
@@ -37,7 +37,7 @@ class PlugwiseCirclePlus(PlugwiseCircle):
             _LOGGER.waning(
                 "Unsupported message type '%s' received from circle with mac %s",
                 str(message.__class__.__name__),
-                self.get_mac(),
+                self.mac,
             )
 
     def scan_for_nodes(self, callback=None):
@@ -112,7 +112,7 @@ class PlugwiseCirclePlus(PlugwiseCircle):
             self._realtime_clock_offset = realtime_clock_offset.seconds
         _LOGGER.debug(
             "Realtime clock of node %s has drifted %s sec",
-            self.get_mac(),
+            self.mac,
             str(self._clock_offset),
         )
 
@@ -133,7 +133,7 @@ class PlugwiseCirclePlus(PlugwiseCircle):
             ):
                 _LOGGER.info(
                     "Reset realtime clock of node %s because time has drifted %s sec",
-                    self.get_mac(),
+                    self.mac,
                     str(self._clock_offset),
                 )
                 self.set_real_time_clock()

--- a/plugwise/nodes/circle_plus.py
+++ b/plugwise/nodes/circle_plus.py
@@ -2,7 +2,7 @@
 from datetime import datetime
 import logging
 
-from ..constants import MAX_TIME_DRIFT, UTF8_DECODE
+from ..constants import MAX_TIME_DRIFT, PRIORITY_LOW, UTF8_DECODE
 from ..messages.requests import (
     CirclePlusRealTimeClockGetRequest,
     CirclePlusRealTimeClockSetRequest,
@@ -92,6 +92,8 @@ class PlugwiseCirclePlus(PlugwiseCircle):
         self.message_sender(
             CirclePlusRealTimeClockGetRequest(self._mac),
             callback,
+            0,
+            PRIORITY_LOW,
         )
 
     def _response_realtime_clock(self, message):

--- a/plugwise/nodes/scan.py
+++ b/plugwise/nodes/scan.py
@@ -2,19 +2,17 @@
 import logging
 
 from ..constants import (
-    HA_BINARY_SENSOR,
-    HA_SENSOR,
+    FEATURE_AVAILABLE,
+    FEATURE_MOTION,
+    FEATURE_PING,
+    FEATURE_RSSI_IN,
+    FEATURE_RSSI_OUT,
     SCAN_CONFIGURE_ACCEPTED,
     SCAN_DAYLIGHT_MODE,
     SCAN_MOTION_RESET_TIMER,
     SCAN_SENSITIVITY_HIGH,
     SCAN_SENSITIVITY_MEDIUM,
     SCAN_SENSITIVITY_OFF,
-    SENSOR_AVAILABLE,
-    SENSOR_MOTION,
-    SENSOR_PING,
-    SENSOR_RSSI_IN,
-    SENSOR_RSSI_OUT,
 )
 from ..messages.requests import ScanConfigureRequest, ScanLightCalibrateRequest
 from ..messages.responses import NodeAckResponse, NodeSwitchGroupResponse
@@ -28,13 +26,11 @@ class PlugwiseScan(NodeSED):
 
     def __init__(self, mac, address, message_sender):
         super().__init__(mac, address, message_sender)
-        self._categories = (HA_SENSOR, HA_BINARY_SENSOR)
-        self._sensors = (
-            SENSOR_AVAILABLE["id"],
-            SENSOR_PING["id"],
-            SENSOR_MOTION["id"],
-            SENSOR_RSSI_IN["id"],
-            SENSOR_RSSI_OUT["id"],
+        self._features = (
+            FEATURE_MOTION["id"],
+            FEATURE_PING["id"],
+            FEATURE_RSSI_IN["id"],
+            FEATURE_RSSI_OUT["id"],
         )
         self._motion_state = False
         self._motion_reset_timer = None
@@ -89,12 +85,12 @@ class PlugwiseScan(NodeSED):
             # turn off => clear motion
             if self._motion_state:
                 self._motion_state = False
-                self.do_callback(SENSOR_MOTION["id"])
+                self.do_callback(FEATURE_MOTION["id"])
         elif message.power_state.value == 1:
             # turn on => motion
             if not self._motion_state:
                 self._motion_state = True
-                self.do_callback(SENSOR_MOTION["id"])
+                self.do_callback(FEATURE_MOTION["id"])
         else:
             _LOGGER.warning(
                 "Unknown power_state (%s) received from %s",

--- a/plugwise/nodes/scan.py
+++ b/plugwise/nodes/scan.py
@@ -44,8 +44,17 @@ class PlugwiseScan(NodeSED):
         self._new_daylight_mode = None
         self._new_sensitivity = None
 
+    @property
+    def motion(self) -> bool:
+        """Return the last known motion state"""
+        return self._motion_state
+
     def get_motion(self) -> bool:
         """Return motion state"""
+        # TODO: Can be removed when HA component is changed to use property
+        _LOGGER.warning(
+            "Function 'get_motion' will be removed in future, use the 'motion' property instead !",
+        )
         return self._motion_state
 
     def message_for_scan(self, message):

--- a/plugwise/nodes/scan.py
+++ b/plugwise/nodes/scan.py
@@ -57,7 +57,7 @@ class PlugwiseScan(NodeSED):
                 "Switch group %s to state %s received from %s",
                 str(message.group.value),
                 str(message.power_state.value),
-                self.get_mac(),
+                self.mac,
             )
             self._process_switch_group(message)
         elif isinstance(message, NodeAckResponse):
@@ -66,7 +66,7 @@ class PlugwiseScan(NodeSED):
             _LOGGER.info(
                 "Unsupported message %s received from %s",
                 message.__class__.__name__,
-                self.get_mac(),
+                self.mac,
             )
 
     def _process_ack_message(self, message):
@@ -79,7 +79,7 @@ class PlugwiseScan(NodeSED):
             _LOGGER.info(
                 "Unsupported ack message %s received for %s",
                 str(message.ack_id),
-                self.get_mac(),
+                self.mac,
             )
 
     def _process_switch_group(self, message):
@@ -98,7 +98,7 @@ class PlugwiseScan(NodeSED):
             _LOGGER.warning(
                 "Unknown power_state (%s) received from %s",
                 str(message.power_state.value),
-                self.get_mac(),
+                self.mac,
             )
 
     def CalibrateLight(self, callback=None):

--- a/plugwise/nodes/scan.py
+++ b/plugwise/nodes/scan.py
@@ -49,14 +49,6 @@ class PlugwiseScan(NodeSED):
         """Return the last known motion state"""
         return self._motion_state
 
-    def get_motion(self) -> bool:
-        """Return motion state"""
-        # TODO: Can be removed when HA component is changed to use property
-        _LOGGER.warning(
-            "Function 'get_motion' will be removed in future, use the 'motion' property instead !",
-        )
-        return self._motion_state
-
     def message_for_scan(self, message):
         """
         Process received message
@@ -144,3 +136,12 @@ class PlugwiseScan(NodeSED):
         # TODO:
 
         # self._queue_request(NodeSwitchGroupRequest(self._mac), callback)
+
+    ## TODO: All functions below can be removed when HA component is changed to use the property values ##
+    def get_motion(self) -> bool:
+        """Return motion state"""
+        # TODO: Can be removed when HA component is changed to use property
+        _LOGGER.warning(
+            "Function 'get_motion' will be removed in future, use the 'motion' property instead !",
+        )
+        return self._motion_state

--- a/plugwise/nodes/scan.py
+++ b/plugwise/nodes/scan.py
@@ -28,7 +28,7 @@ class PlugwiseScan(NodeSED):
 
     def __init__(self, mac, address, message_sender):
         super().__init__(mac, address, message_sender)
-        self.categories = (HA_SENSOR, HA_BINARY_SENSOR)
+        self._categories = (HA_SENSOR, HA_BINARY_SENSOR)
         self._sensors = (
             SENSOR_AVAILABLE["id"],
             SENSOR_PING["id"],

--- a/plugwise/nodes/sed.py
+++ b/plugwise/nodes/sed.py
@@ -75,7 +75,7 @@ class NodeSED(PlugwiseNode):
         _LOGGER.debug(
             "Awake message type '%s' received from %s",
             str(message.awake_type.value),
-            self.get_mac(),
+            self.mac,
         )
         if (
             message.awake_type.value == SED_AWAKE_MAINTENANCE
@@ -88,18 +88,18 @@ class NodeSED(PlugwiseNode):
                 _LOGGER.info(
                     "Send queued %s message to SED node %s",
                     request_message.__class__.__name__,
-                    self.get_mac(),
+                    self.mac,
                 )
                 self.message_sender(request_message, callback, -1)
             self._SED_requests = {}
         else:
             if message.awake_type.value == SED_AWAKE_STATE:
-                _LOGGER.debug("Node %s awake for state change", self.get_mac())
+                _LOGGER.debug("Node %s awake for state change", self.mac)
             else:
                 _LOGGER.info(
                     "Unknown awake message type (%s) received for node %s",
                     str(message.awake_type.value),
-                    self.get_mac(),
+                    self.mac,
                 )
 
     def _queue_request(self, request_message, callback=None):
@@ -131,7 +131,7 @@ class NodeSED(PlugwiseNode):
         else:
             _LOGGER.debug(
                 "Drop ping request for SED %s because no callback is registered",
-                self.get_mac(),
+                self.mac,
             )
 
     def _wake_up_interval_accepted(self):
@@ -160,5 +160,5 @@ class NodeSED(PlugwiseNode):
         _LOGGER.info(
             "Queue %s message to be send at next awake of SED node %s",
             message.__class__.__name__,
-            self.get_mac(),
+            self.mac,
         )

--- a/plugwise/nodes/sed.py
+++ b/plugwise/nodes/sed.py
@@ -7,6 +7,9 @@
 import logging
 
 from ..constants import (
+    FEATURE_PING,
+    FEATURE_RSSI_IN,
+    FEATURE_RSSI_OUT,
     SED_AWAKE_BUTTON,
     SED_AWAKE_FIRST,
     SED_AWAKE_MAINTENANCE,
@@ -17,9 +20,6 @@ from ..constants import (
     SED_MAINTENANCE_INTERVAL,
     SED_SLEEP_FOR,
     SED_STAY_ACTIVE,
-    FEATURE_PING,
-    FEATURE_RSSI_IN,
-    FEATURE_RSSI_OUT,
     SLEEP_SET,
 )
 from ..messages.requests import NodeInfoRequest, NodePingRequest, NodeSleepConfigRequest

--- a/plugwise/nodes/sed.py
+++ b/plugwise/nodes/sed.py
@@ -38,10 +38,7 @@ class NodeSED(PlugwiseNode):
         self.maintenance_interval = SED_MAINTENANCE_INTERVAL
         self._new_maintenance_interval = None
         self._wake_up_interval = None
-
-    def is_sed(self) -> bool:
-        """Return if True if node SED (battery powered)"""
-        return True
+        self._battery_powered = True
 
     def message_for_sed(self, message):
         """

--- a/plugwise/nodes/sed.py
+++ b/plugwise/nodes/sed.py
@@ -119,7 +119,7 @@ class NodeSED(PlugwiseNode):
             callback,
         )
 
-    def ping(self, callback=None, sensor=True):
+    def do_ping(self, callback=None, sensor=True):
         """Ping node"""
         if (
             sensor

--- a/plugwise/nodes/sed.py
+++ b/plugwise/nodes/sed.py
@@ -10,6 +10,7 @@ from ..constants import (
     FEATURE_PING,
     FEATURE_RSSI_IN,
     FEATURE_RSSI_OUT,
+    PRIORITY_HIGH,
     SED_AWAKE_BUTTON,
     SED_AWAKE_FIRST,
     SED_AWAKE_MAINTENANCE,
@@ -90,7 +91,7 @@ class NodeSED(PlugwiseNode):
                     request_message.__class__.__name__,
                     self.mac,
                 )
-                self.message_sender(request_message, callback, -1)
+                self.message_sender(request_message, callback, -1, PRIORITY_HIGH)
             self._SED_requests = {}
         else:
             if message.awake_type.value == SED_AWAKE_STATE:

--- a/plugwise/nodes/sed.py
+++ b/plugwise/nodes/sed.py
@@ -109,7 +109,7 @@ class NodeSED(PlugwiseNode):
             callback,
         )
 
-    def request_info(self, callback=None):
+    def _request_info(self, callback=None):
         """Request info from node"""
         self._queue_request(
             NodeInfoRequest(self._mac),

--- a/plugwise/nodes/sed.py
+++ b/plugwise/nodes/sed.py
@@ -116,7 +116,7 @@ class NodeSED(PlugwiseNode):
             callback,
         )
 
-    def do_ping(self, callback=None, sensor=True):
+    def _request_ping(self, callback=None, sensor=True):
         """Ping node"""
         if (
             sensor

--- a/plugwise/nodes/sed.py
+++ b/plugwise/nodes/sed.py
@@ -17,9 +17,9 @@ from ..constants import (
     SED_MAINTENANCE_INTERVAL,
     SED_SLEEP_FOR,
     SED_STAY_ACTIVE,
-    SENSOR_PING,
-    SENSOR_RSSI_IN,
-    SENSOR_RSSI_OUT,
+    FEATURE_PING,
+    FEATURE_RSSI_IN,
+    FEATURE_RSSI_OUT,
     SLEEP_SET,
 )
 from ..messages.requests import NodeInfoRequest, NodePingRequest, NodeSleepConfigRequest
@@ -120,9 +120,9 @@ class NodeSED(PlugwiseNode):
         """Ping node"""
         if (
             sensor
-            or self._callbacks.get(SENSOR_PING["id"])
-            or self._callbacks.get(SENSOR_RSSI_IN["id"])
-            or self._callbacks.get(SENSOR_RSSI_OUT["id"])
+            or self._callbacks.get(FEATURE_PING["id"])
+            or self._callbacks.get(FEATURE_RSSI_IN["id"])
+            or self._callbacks.get(FEATURE_RSSI_OUT["id"])
         ):
             self._queue_request(
                 NodePingRequest(self._mac),

--- a/plugwise/nodes/sense.py
+++ b/plugwise/nodes/sense.py
@@ -37,14 +37,14 @@ class PlugwiseSense(NodeSED):
         self._humidity = None
 
     @property
-    def temperature(self) -> int:
-        """Return the current temperature."""
-        return self._temperature
-
-    @property
     def humidity(self) -> int:
         """Return the current humidity."""
         return self._humidity
+
+    @property
+    def temperature(self) -> int:
+        """Return the current temperature."""
+        return self._temperature
 
     def message_for_sense(self, message):
         """

--- a/plugwise/nodes/sense.py
+++ b/plugwise/nodes/sense.py
@@ -36,7 +36,8 @@ class PlugwiseSense(NodeSED):
         self._temperature = None
         self._humidity = None
 
-    def get_temperature(self) -> int:
+    @property
+    def temperature(self) -> int:
         """Return the current temperature."""
         return self._temperature
 
@@ -85,3 +86,11 @@ class PlugwiseSense(NodeSED):
                     str(self._humidity),
                 )
                 self.do_callback(SENSOR_HUMIDITY["id"])
+
+    ## TODO: All functions below can be removed when HA component is changed to use the property values ##
+    def get_temperature(self) -> int:
+        """Return the current temperature."""
+        _LOGGER.warning(
+            "Function 'get_temperature' will be removed in future, use the 'temperature' property instead !",
+        )
+        return self._temperature

--- a/plugwise/nodes/sense.py
+++ b/plugwise/nodes/sense.py
@@ -41,7 +41,8 @@ class PlugwiseSense(NodeSED):
         """Return the current temperature."""
         return self._temperature
 
-    def get_humidity(self) -> int:
+    @property
+    def humidity(self) -> int:
         """Return the current humidity."""
         return self._humidity
 
@@ -94,3 +95,10 @@ class PlugwiseSense(NodeSED):
             "Function 'get_temperature' will be removed in future, use the 'temperature' property instead !",
         )
         return self._temperature
+
+    def get_humidity(self) -> int:
+        """Return the current humidity."""
+        _LOGGER.warning(
+            "Function 'get_humidity' will be removed in future, use the 'humidity' property instead !",
+        )
+        return self._humidity

--- a/plugwise/nodes/sense.py
+++ b/plugwise/nodes/sense.py
@@ -2,17 +2,15 @@
 import logging
 
 from ..constants import (
-    HA_BINARY_SENSOR,
-    HA_SENSOR,
+    FEATURE_HUMIDITY,
+    FEATURE_PING,
+    FEATURE_RSSI_IN,
+    FEATURE_RSSI_OUT,
+    FEATURE_TEMPERATURE,
     SENSE_HUMIDITY_MULTIPLIER,
     SENSE_HUMIDITY_OFFSET,
     SENSE_TEMPERATURE_MULTIPLIER,
     SENSE_TEMPERATURE_OFFSET,
-    SENSOR_AVAILABLE,
-    SENSOR_HUMIDITY,
-    SENSOR_RSSI_IN,
-    SENSOR_RSSI_OUT,
-    SENSOR_TEMPERATURE,
 )
 from ..messages.responses import SenseReportResponse
 from ..nodes.sed import NodeSED
@@ -25,13 +23,12 @@ class PlugwiseSense(NodeSED):
 
     def __init__(self, mac, address, message_sender):
         super().__init__(mac, address, message_sender)
-        self._categories = (HA_SENSOR, HA_BINARY_SENSOR)
-        self._sensors = (
-            SENSOR_AVAILABLE["id"],
-            SENSOR_TEMPERATURE["id"],
-            SENSOR_HUMIDITY["id"],
-            SENSOR_RSSI_IN["id"],
-            SENSOR_RSSI_OUT["id"],
+        self._features = (
+            FEATURE_HUMIDITY["id"],
+            FEATURE_PING["id"],
+            FEATURE_RSSI_IN["id"],
+            FEATURE_RSSI_OUT["id"],
+            FEATURE_TEMPERATURE["id"],
         )
         self._temperature = None
         self._humidity = None
@@ -73,7 +70,7 @@ class PlugwiseSense(NodeSED):
                     self.mac,
                     str(self._temperature),
                 )
-                self.do_callback(SENSOR_TEMPERATURE["id"])
+                self.do_callback(FEATURE_TEMPERATURE["id"])
         if message.humidity.value != 65535:
             new_humidity = int(
                 SENSE_HUMIDITY_MULTIPLIER * (message.humidity.value / 65536)
@@ -86,7 +83,7 @@ class PlugwiseSense(NodeSED):
                     self.mac,
                     str(self._humidity),
                 )
-                self.do_callback(SENSOR_HUMIDITY["id"])
+                self.do_callback(FEATURE_HUMIDITY["id"])
 
     ## TODO: All functions below can be removed when HA component is changed to use the property values ##
     def get_temperature(self) -> int:

--- a/plugwise/nodes/sense.py
+++ b/plugwise/nodes/sense.py
@@ -25,7 +25,7 @@ class PlugwiseSense(NodeSED):
 
     def __init__(self, mac, address, message_sender):
         super().__init__(mac, address, message_sender)
-        self.categories = (HA_SENSOR, HA_BINARY_SENSOR)
+        self._categories = (HA_SENSOR, HA_BINARY_SENSOR)
         self._sensors = (
             SENSOR_AVAILABLE["id"],
             SENSOR_TEMPERATURE["id"],

--- a/plugwise/nodes/sense.py
+++ b/plugwise/nodes/sense.py
@@ -54,7 +54,7 @@ class PlugwiseSense(NodeSED):
             _LOGGER.info(
                 "Unsupported message %s received from %s",
                 message.__class__.__name__,
-                self.get_mac(),
+                self.mac,
             )
 
     def _process_sense_report(self, message):
@@ -68,7 +68,7 @@ class PlugwiseSense(NodeSED):
                 self._temperature = new_temperature
                 _LOGGER.debug(
                     "Sense report received from %s with new temperature level of %s",
-                    self.get_mac(),
+                    self.mac,
                     str(self._temperature),
                 )
                 self.do_callback(SENSOR_TEMPERATURE["id"])
@@ -81,7 +81,7 @@ class PlugwiseSense(NodeSED):
                 self._humidity = new_humidity
                 _LOGGER.debug(
                     "Sense report received from %s with new humidity level of %s",
-                    self.get_mac(),
+                    self.mac,
                     str(self._humidity),
                 )
                 self.do_callback(SENSOR_HUMIDITY["id"])

--- a/plugwise/nodes/switch.py
+++ b/plugwise/nodes/switch.py
@@ -26,8 +26,9 @@ class PlugwiseSwitch(NodeSED):
         )
         self._switch_state = False
 
-    def get_switch_state(self):
-        """Return state of switch"""
+    @property
+    def switch(self) -> bool:
+        """Return the last known switch state"""
         return self._switch_state
 
     def message_for_switch(self, message):
@@ -61,3 +62,11 @@ class PlugwiseSwitch(NodeSED):
                 str(message.power_state),
                 self.mac,
             )
+
+    ## TODO: All functions below can be removed when HA component is changed to use the property values ##
+    def get_switch_state(self):
+        """Return state of switch"""
+        _LOGGER.warning(
+            "Function 'get_switch_state' will be removed in future, use the 'switch' property instead !",
+        )
+        return self._switch_state

--- a/plugwise/nodes/switch.py
+++ b/plugwise/nodes/switch.py
@@ -1,7 +1,12 @@
 """Plugwise switch node object."""
 import logging
 
-from ..constants import HA_BINARY_SENSOR, HA_SENSOR, SENSOR_SWITCH
+from ..constants import (
+    FEATURE_PING,
+    FEATURE_RSSI_IN,
+    FEATURE_RSSI_OUT,
+    FEATURE_SWITCH,
+)
 from ..messages.responses import NodeSwitchGroupResponse
 from ..nodes.sed import NodeSED
 
@@ -13,7 +18,12 @@ class PlugwiseSwitch(NodeSED):
 
     def __init__(self, mac, address, message_sender):
         super().__init__(mac, address, message_sender)
-        self._categories = (HA_SENSOR, HA_BINARY_SENSOR)
+        self._features = (
+            FEATURE_PING["id"],
+            FEATURE_RSSI_IN["id"],
+            FEATURE_RSSI_OUT["id"],
+            FEATURE_SWITCH["id"],
+        )
         self._switch_state = False
 
     def get_switch_state(self):
@@ -39,12 +49,12 @@ class PlugwiseSwitch(NodeSED):
             # turn off => clear motion
             if self._switch_state:
                 self._switch_state = False
-                self.do_callback(SENSOR_SWITCH["id"])
+                self.do_callback(FEATURE_SWITCH["id"])
         elif message.power_state == 1:
             # turn on => motion
             if not self._switch_state:
                 self._switch_state = True
-                self.do_callback(SENSOR_SWITCH["id"])
+                self.do_callback(FEATURE_SWITCH["id"])
         else:
             _LOGGER.debug(
                 "Unknown power_state (%s) received from %s",

--- a/plugwise/nodes/switch.py
+++ b/plugwise/nodes/switch.py
@@ -28,7 +28,7 @@ class PlugwiseSwitch(NodeSED):
             _LOGGER.debug(
                 "Switch group request %s received from %s for group id %s",
                 str(message.power_state),
-                self.get_mac(),
+                self.mac,
                 str(message.group),
             )
             self._process_switch_group(message)
@@ -49,5 +49,5 @@ class PlugwiseSwitch(NodeSED):
             _LOGGER.debug(
                 "Unknown power_state (%s) received from %s",
                 str(message.power_state),
-                self.get_mac(),
+                self.mac,
             )

--- a/plugwise/nodes/switch.py
+++ b/plugwise/nodes/switch.py
@@ -1,12 +1,7 @@
 """Plugwise switch node object."""
 import logging
 
-from ..constants import (
-    FEATURE_PING,
-    FEATURE_RSSI_IN,
-    FEATURE_RSSI_OUT,
-    FEATURE_SWITCH,
-)
+from ..constants import FEATURE_PING, FEATURE_RSSI_IN, FEATURE_RSSI_OUT, FEATURE_SWITCH
 from ..messages.responses import NodeSwitchGroupResponse
 from ..nodes.sed import NodeSED
 

--- a/plugwise/nodes/switch.py
+++ b/plugwise/nodes/switch.py
@@ -13,7 +13,7 @@ class PlugwiseSwitch(NodeSED):
 
     def __init__(self, mac, address, message_sender):
         super().__init__(mac, address, message_sender)
-        self.categories = (HA_SENSOR, HA_BINARY_SENSOR)
+        self._categories = (HA_SENSOR, HA_BINARY_SENSOR)
         self._switch_state = False
 
     def get_switch_state(self):

--- a/plugwise/smile.py
+++ b/plugwise/smile.py
@@ -87,6 +87,8 @@ class Smile:
             self.websession = websession
 
         self._auth = aiohttp.BasicAuth(username, password=password)
+        # Work-around for Stretchv2-aiohttp-deflate-error, can be removed for aiohttp v3.7
+        self._headers = {"Accept-Encoding": "gzip"}
 
         self._timeout = timeout
         self._endpoint = f"http://{host}:{str(port)}"
@@ -230,7 +232,10 @@ class Smile:
         try:
             with async_timeout.timeout(self._timeout):
                 if method == "get":
-                    resp = await self.websession.get(url, auth=self._auth)
+                    # Work-around, see above, can be removed for aiohttp v3.7:
+                    resp = await self.websession.get(
+                        url, auth=self._auth, headers=self._headers
+                    )
                 if method == "put":
                     resp = await self.websession.put(
                         url, data=data, headers=headers, auth=self._auth

--- a/plugwise/smile.py
+++ b/plugwise/smile.py
@@ -87,8 +87,6 @@ class Smile:
             self.websession = websession
 
         self._auth = aiohttp.BasicAuth(username, password=password)
-        # Work-around for Stretchv2-aiohttp-deflate-error, can be removed for aiohttp v3.7
-        self._headers = {"Accept-Encoding": "gzip"}
 
         self._timeout = timeout
         self._endpoint = f"http://{host}:{str(port)}"
@@ -226,25 +224,21 @@ class Smile:
         resp = None
         url = f"{self._endpoint}{command}"
 
-        if headers is None:
-            headers = {"Content-type": "text/xml"}
-
         try:
             with async_timeout.timeout(self._timeout):
                 if method == "get":
-                    # Work-around, see above, can be removed for aiohttp v3.7:
+                    # Work-around for Stretchv2, should not hurt the other smiles
+                    headers = {"Accept-Encoding": "gzip"}
                     resp = await self.websession.get(
-                        url, auth=self._auth, headers=self._headers
+                        url, auth=self._auth, headers=headers
                     )
                 if method == "put":
+                    headers = {"Content-type": "text/xml"}
                     resp = await self.websession.put(
                         url, data=data, headers=headers, auth=self._auth
                     )
                 if method == "delete":
                     resp = await self.websession.delete(url, auth=self._auth)
-            if resp.status == 401:
-                raise InvalidAuthentication
-
         except asyncio.TimeoutError:
             if retry < 1:
                 _LOGGER.error("Timed out sending command to Plugwise: %s", command)
@@ -257,6 +251,9 @@ class Smile:
         # Cornercase for stretch not responding with 202
         if method == "put" and resp.status == 200:
             return
+
+        if resp.status == 401:
+            raise InvalidAuthentication
 
         result = await resp.text()
         if not result or "<error>" in result:

--- a/plugwise/stick.py
+++ b/plugwise/stick.py
@@ -614,7 +614,7 @@ class stick:
                             # Check availability state of SED's
                             self._check_availability_of_seds(mac)
 
-                        if self._plugwise_nodes[mac].measure_power():
+                        if self._plugwise_nodes[mac].measures_power:
                             # Request current power usage
                             self._plugwise_nodes[mac].update_power_usage()
                             # Sync internal clock of power measure nodes once a day

--- a/plugwise/stick.py
+++ b/plugwise/stick.py
@@ -356,7 +356,7 @@ class stick:
     def node_state_updates(self, mac, state: bool):
         """Update availability state of a node"""
         if mac in self._plugwise_nodes:
-            if not self._plugwise_nodes[mac].is_sed():
+            if not self._plugwise_nodes[mac].battery_powered:
                 self._plugwise_nodes[mac].available = state
 
     def node_join(self, mac: str, callback=None) -> bool:
@@ -609,8 +609,9 @@ class stick:
                     if self._plugwise_nodes[mac]:
                         # Do ping request for all nodes if listener is registered for sensor
                         self._plugwise_nodes[mac].do_ping(None, True)
-                        # Check availability state of SED's
-                        if self._plugwise_nodes[mac].is_sed():
+
+                        if self._plugwise_nodes[mac].battery_powered:
+                            # Check availability state of SED's
                             self._check_availability_of_seds(mac)
 
                         if self._plugwise_nodes[mac].measure_power():

--- a/plugwise/stick.py
+++ b/plugwise/stick.py
@@ -686,7 +686,7 @@ class stick:
             self._auto_update_timer = 0
             self._run_update_thread = False
         else:
-            # Timer based on a minium of 5 seconds + 1 second for each node supporting power measurement
+            # Timer based on a minimum of 5 seconds + 1 second for each node supporting power measurement
             if not self._auto_update_manually:
                 count_nodes = 0
                 for mac in self.discovered_nodes:

--- a/plugwise/stick.py
+++ b/plugwise/stick.py
@@ -608,12 +608,13 @@ class stick:
                 for mac in self._plugwise_nodes:
                     if self._plugwise_nodes[mac]:
                         # Do ping request for all nodes if listener is registered for sensor
-                        self._plugwise_nodes[mac].ping(None, True)
+                        self._plugwise_nodes[mac].do_ping(None, True)
                         # Check availability state of SED's
                         if self._plugwise_nodes[mac].is_sed():
                             self._check_availability_of_seds(mac)
-                        # Request current power usage for all nodes supporting power measurement
+
                         if self._plugwise_nodes[mac].measure_power():
+                            # Request current power usage
                             self._plugwise_nodes[mac].update_power_usage()
                             # Sync internal clock of power measure nodes once a day
                             if datetime.now().day != day_of_month:

--- a/plugwise/stick.py
+++ b/plugwise/stick.py
@@ -750,36 +750,33 @@ class stick:
             self.do_callback(CB_NEW_NODE, node_discovered)
             self.auto_update()
 
-    def discover_node(self, mac: str, callback=None, force_discover=False) -> bool:
+    def discover_node(self, mac: str, callback=None, force_discover=False):
         """Helper to try to discovery the node (type) based on mac."""
-        if validate_mac(mac):
-            if not self._plugwise_nodes.get(mac):
-                if mac not in self._nodes_not_discovered:
-                    self._nodes_not_discovered[mac] = (
-                        None,
-                        None,
-                    )
-                    self.msg_controller.send(
-                        NodeInfoRequest(bytes(mac, UTF8_DECODE)),
-                        callback,
-                    )
-                else:
-                    (firstrequest, lastrequest) = self._nodes_not_discovered[mac]
-                    if not (firstrequest and lastrequest):
-                        self.msg_controller.send(
-                            NodeInfoRequest(bytes(mac, UTF8_DECODE)),
-                            callback,
-                            0,
-                            PRIORITY_LOW,
-                        )
-                    elif force_discover:
-                        self.msg_controller.send(
-                            NodeInfoRequest(bytes(mac, UTF8_DECODE)),
-                            callback,
-                        )
-                return True
-            return False
-        return False
+        if not validate_mac(mac) or self._plugwise_nodes.get(mac):
+            return
+        if mac not in self._nodes_not_discovered:
+            self._nodes_not_discovered[mac] = (
+                None,
+                None,
+            )
+            self.msg_controller.send(
+                NodeInfoRequest(bytes(mac, UTF8_DECODE)),
+                callback,
+            )
+        else:
+            (firstrequest, lastrequest) = self._nodes_not_discovered[mac]
+            if not (firstrequest and lastrequest):
+                self.msg_controller.send(
+                    NodeInfoRequest(bytes(mac, UTF8_DECODE)),
+                    callback,
+                    0,
+                    PRIORITY_LOW,
+                )
+            elif force_discover:
+                self.msg_controller.send(
+                    NodeInfoRequest(bytes(mac, UTF8_DECODE)),
+                    callback,
+                )
 
     ## TODO: All functions below can be removed when HA component is changed to use the property values ##
     def get_mac_stick(self) -> str:

--- a/plugwise/stick.py
+++ b/plugwise/stick.py
@@ -107,6 +107,15 @@ class stick:
         """Return total number of nodes registered to Circle+ including Circle+ itself"""
         return self._joined_nodes + 1
 
+    @property
+    def discovered_nodes(self) -> list:
+        """Return a list of mac addresses of all discovered and supported plugwise nodes."""
+        return list(
+            dict(
+                filter(lambda item: item[1] is not None, self._plugwise_nodes.items())
+            ).keys()
+        )
+
     def auto_initialize(self, callback=None):
         """Automatic initialization of USB-stick and discovery of all registered nodes."""
 
@@ -363,6 +372,10 @@ class stick:
 
     def nodes(self) -> list:
         """Return list of mac addresses of discovered and supported plugwise nodes."""
+        # TODO: Can be removed when HA component is changed to use property
+        _LOGGER.warning(
+            "Function 'nodes' will be removed in future, use the 'discovered_nodes' property instead !",
+        )
         return list(
             dict(
                 filter(lambda item: item[1] is not None, self._plugwise_nodes.items())

--- a/plugwise/stick.py
+++ b/plugwise/stick.py
@@ -76,7 +76,7 @@ class stick:
         self.scan_callback = None
         self.network_id = None
         self._plugwise_nodes = {}
-        self._nodes_registered = 0
+        self._joined_nodes = 0
         self._nodes_to_discover = {}
         self._nodes_not_discovered = {}
         self._nodes_off_line = 0
@@ -101,6 +101,11 @@ class stick:
         if self._mac_stick:
             return self._mac_stick.decode(UTF8_DECODE)
         return None
+
+    @property
+    def joined_nodes(self) -> int:
+        """Return total number of nodes registered to Circle+ including Circle+ itself"""
+        return self._joined_nodes + 1
 
     def auto_initialize(self, callback=None):
         """Automatic initialization of USB-stick and discovery of all registered nodes."""
@@ -238,7 +243,7 @@ class stick:
         _LOGGER.debug("Scan plugwise network finished")
         self._nodes_discovered = 0
         self._nodes_to_discover = nodes_to_discover
-        self._nodes_registered = len(nodes_to_discover)
+        self._joined_nodes = len(nodes_to_discover)
 
         # setup timeout for node discovery
         discover_timeout = (
@@ -350,7 +355,11 @@ class stick:
 
     def registered_nodes(self) -> int:
         """Return total number of nodes registered to Circle+ including Circle+ itself"""
-        return self._nodes_registered + 1
+        # TODO: Can be removed when HA component is changed to use property
+        _LOGGER.warning(
+            "Function 'registered_nodes' will be removed in future, use the 'joined_nodes' property instead !",
+        )
+        return self._joined_nodes + 1
 
     def nodes(self) -> list:
         """Return list of mac addresses of discovered and supported plugwise nodes."""

--- a/plugwise/stick.py
+++ b/plugwise/stick.py
@@ -642,7 +642,7 @@ class stick:
 
                         if self._plugwise_nodes[mac].measures_power:
                             # Request current power usage
-                            self._plugwise_nodes[mac].update_power_usage()
+                            self._plugwise_nodes[mac]._request_power_update()
                             # Sync internal clock of power measure nodes once a day
                             if datetime.now().day != day_of_month:
                                 day_of_month = datetime.now().day

--- a/plugwise/stick.py
+++ b/plugwise/stick.py
@@ -415,6 +415,8 @@ class stick:
         """Remove node from list of controllable nodes."""
         if mac in self._plugwise_nodes:
             del self._plugwise_nodes[mac]
+        else:
+            _LOGGER.warning("Node %s does not exists, unable to remove node.", mac)
 
     def message_processor(self, message: NodeResponse):
         """Received message from Plugwise network."""

--- a/plugwise/stick.py
+++ b/plugwise/stick.py
@@ -96,6 +96,20 @@ class stick:
             self.auto_initialize(callback)
 
     @property
+    def discovered_nodes(self) -> list:
+        """Return a list of mac addresses of all discovered and supported plugwise nodes."""
+        return list(
+            dict(
+                filter(lambda item: item[1] is not None, self._plugwise_nodes.items())
+            ).keys()
+        )
+
+    @property
+    def joined_nodes(self) -> int:
+        """Return total number of nodes registered to Circle+ including Circle+ itself."""
+        return self._joined_nodes + 1
+
+    @property
     def mac(self) -> str:
         """Return the MAC address of the USB-Stick."""
         if self._mac_stick:
@@ -111,20 +125,6 @@ class stick:
     def network_id(self) -> int:
         """Return the id of the Plugwise network."""
         return self._network_id
-
-    @property
-    def joined_nodes(self) -> int:
-        """Return total number of nodes registered to Circle+ including Circle+ itself."""
-        return self._joined_nodes + 1
-
-    @property
-    def discovered_nodes(self) -> list:
-        """Return a list of mac addresses of all discovered and supported plugwise nodes."""
-        return list(
-            dict(
-                filter(lambda item: item[1] is not None, self._plugwise_nodes.items())
-            ).keys()
-        )
 
     @property
     def port(self) -> str:

--- a/plugwise/stick.py
+++ b/plugwise/stick.py
@@ -309,16 +309,6 @@ class stick:
             if self.scan_callback:
                 self.scan_callback()
 
-    def get_mac_stick(self) -> str:
-        """Return mac address of USB-Stick"""
-        # TODO: Can be removed when HA component is changed to use property
-        _LOGGER.warning(
-            "Function 'get_mac_stick' will be removed in future, use the 'mac' property instead !",
-        )
-        if self._mac_stick:
-            return self._mac_stick.decode(UTF8_DECODE)
-        return None
-
     def _append_node(self, mac, address, node_type):
         """Add node to list of controllable nodes"""
         _LOGGER.debug(
@@ -361,26 +351,6 @@ class stick:
         self._messages_for_undiscovered_nodes = []
         for msg in msg_to_process:
             self.message_processor(msg)
-
-    def registered_nodes(self) -> int:
-        """Return total number of nodes registered to Circle+ including Circle+ itself"""
-        # TODO: Can be removed when HA component is changed to use property
-        _LOGGER.warning(
-            "Function 'registered_nodes' will be removed in future, use the 'joined_nodes' property instead !",
-        )
-        return self._joined_nodes + 1
-
-    def nodes(self) -> list:
-        """Return list of mac addresses of discovered and supported plugwise nodes."""
-        # TODO: Can be removed when HA component is changed to use property
-        _LOGGER.warning(
-            "Function 'nodes' will be removed in future, use the 'discovered_nodes' property instead !",
-        )
-        return list(
-            dict(
-                filter(lambda item: item[1] is not None, self._plugwise_nodes.items())
-            ).keys()
-        )
 
     def node(self, mac: str) -> PlugwiseNode:
         """Return a specific node object"""
@@ -769,3 +739,31 @@ class stick:
                 return True
             return False
         return False
+
+    ## TODO: All functions below can be removed when HA component is changed to use the property values ##
+    def get_mac_stick(self) -> str:
+        """Return mac address of USB-Stick"""
+        _LOGGER.warning(
+            "Function 'get_mac_stick' will be removed in future, use the 'mac' property instead !",
+        )
+        if self._mac_stick:
+            return self._mac_stick.decode(UTF8_DECODE)
+        return None
+
+    def registered_nodes(self) -> int:
+        """Return total number of nodes registered to Circle+ including Circle+ itself"""
+        _LOGGER.warning(
+            "Function 'registered_nodes' will be removed in future, use the 'joined_nodes' property instead !",
+        )
+        return self._joined_nodes + 1
+
+    def nodes(self) -> list:
+        """Return list of mac addresses of discovered and supported plugwise nodes."""
+        _LOGGER.warning(
+            "Function 'nodes' will be removed in future, use the 'discovered_nodes' property instead !",
+        )
+        return list(
+            dict(
+                filter(lambda item: item[1] is not None, self._plugwise_nodes.items())
+            ).keys()
+        )

--- a/plugwise/stick.py
+++ b/plugwise/stick.py
@@ -67,7 +67,7 @@ class stick:
     """Plugwise connection stick."""
 
     def __init__(self, port, callback=None):
-        self.port = port
+        self._port = port
         self._mac_stick = None
         self._network_online = False
         self.circle_plus_mac = None
@@ -125,6 +125,18 @@ class stick:
                 filter(lambda item: item[1] is not None, self._plugwise_nodes.items())
             ).keys()
         )
+
+    @property
+    def port(self) -> str:
+        """Return currently configured port to USB-Stick."""
+        return self._port
+
+    @port.setter
+    def port(self, port: str):
+        """Set port to USB-Stick."""
+        if self.msg_controller:
+            self.disconnect()
+        self._port = port
 
     def auto_initialize(self, callback=None):
         """Automatic initialization of USB-stick and discovery of all registered nodes."""
@@ -206,6 +218,7 @@ class stick:
         self._run_update_thread = False
         self._auto_update_timer = 0
         self.msg_controller.disconnect_from_stick()
+        self.msg_controller = None
 
     def subscribe_stick_callback(self, callback, callback_type):
         """Subscribe callback to execute."""

--- a/plugwise/stick.py
+++ b/plugwise/stick.py
@@ -95,6 +95,13 @@ class stick:
         if callback:
             self.auto_initialize(callback)
 
+    @property
+    def mac(self) -> str:
+        """Return the MAC address of theUSB-Stick"""
+        if self._mac_stick:
+            return self._mac_stick.decode(UTF8_DECODE)
+        return None
+
     def auto_initialize(self, callback=None):
         """Automatic initialization of USB-stick and discovery of all registered nodes."""
 
@@ -290,6 +297,10 @@ class stick:
 
     def get_mac_stick(self) -> str:
         """Return mac address of USB-Stick"""
+        # TODO: Can be removed when HA component is changed to use property
+        _LOGGER.warning(
+            "Function 'get_mac_stick' will be removed in future, use the 'mac' property instead !",
+        )
         if self._mac_stick:
             return self._mac_stick.decode(UTF8_DECODE)
         return None

--- a/plugwise/stick.py
+++ b/plugwise/stick.py
@@ -103,15 +103,6 @@ class stick:
         return self._device_nodes
 
     @property
-    def discovered_nodes(self) -> list:
-        """Return a list of mac addresses of all discovered and supported plugwise nodes."""
-        return list(
-            dict(
-                filter(lambda item: item[1] is not None, self._device_nodes.items())
-            ).keys()
-        )
-
-    @property
     def joined_nodes(self) -> int:
         """Return total number of nodes registered to Circle+ including Circle+ itself."""
         return self._joined_nodes + 1
@@ -692,7 +683,7 @@ class stick:
             # Timer based on a minimum of 5 seconds + 1 second for each node supporting power measurement
             if not self._auto_update_manually:
                 count_nodes = 0
-                for mac in self.discovered_nodes:
+                for mac in self._device_nodes:
                     if self._device_nodes[mac].measures_power:
                         count_nodes += 1
                 self._auto_update_timer = 5 + (count_nodes * 1)
@@ -799,7 +790,7 @@ class stick:
     def nodes(self) -> list:
         """Return list of mac addresses of discovered and supported plugwise nodes."""
         _LOGGER.warning(
-            "Function 'nodes' will be removed in future, use the 'discovered_nodes' property instead !",
+            "Function 'nodes' will be removed in future, use the 'devices' (dict) property instead !",
         )
         return list(
             dict(

--- a/plugwise/stick.py
+++ b/plugwise/stick.py
@@ -69,7 +69,7 @@ class stick:
     def __init__(self, port, callback=None):
         self.port = port
         self._mac_stick = None
-        self.network_online = False
+        self._network_online = False
         self.circle_plus_mac = None
         self._circle_plus_discovered = False
         self._circle_plus_retries = 0
@@ -103,6 +103,11 @@ class stick:
         return None
 
     @property
+    def network_state(self) -> bool:
+        """Return the state of the plugwise network"""
+        return self._network_online
+
+    @property
     def joined_nodes(self) -> int:
         """Return total number of nodes registered to Circle+ including Circle+ itself"""
         return self._joined_nodes + 1
@@ -120,7 +125,7 @@ class stick:
         """Automatic initialization of USB-stick and discovery of all registered nodes."""
 
         def init_finished():
-            if not self.network_online:
+            if not self._network_online:
                 _LOGGER.Error("plugwise Zigbee network down")
             else:
                 self.scan(callback)
@@ -170,7 +175,7 @@ class stick:
             time.sleep(0.1)
         if not self._stick_initialized:
             raise StickInitError
-        if not self.network_online:
+        if not self._network_online:
             raise NetworkDown
 
     def initialize_circle_plus(self, callback=None, timeout=MESSAGE_TIME_OUT):
@@ -412,9 +417,9 @@ class stick:
         """Process StickInitResponse message."""
         self._mac_stick = stick_init_response.mac
         if stick_init_response.network_is_online.value == 1:
-            self.network_online = True
+            self._network_online = True
         else:
-            self.network_online = False
+            self._network_online = False
         # Replace first 2 characters by 00 for mac of circle+ node
         self.circle_plus_mac = "00" + stick_init_response.circle_plus_mac.value[
             2:

--- a/plugwise/stick.py
+++ b/plugwise/stick.py
@@ -74,7 +74,7 @@ class stick:
         self._circle_plus_discovered = False
         self._circle_plus_retries = 0
         self.scan_callback = None
-        self.network_id = None
+        self._network_id = None
         self._plugwise_nodes = {}
         self._joined_nodes = 0
         self._nodes_to_discover = {}
@@ -106,6 +106,11 @@ class stick:
     def network_state(self) -> bool:
         """Return the state of the plugwise network"""
         return self._network_online
+
+    @property
+    def network_id(self) -> int:
+        """Return the id of the Plugwise network."""
+        return self._network_id
 
     @property
     def joined_nodes(self) -> int:
@@ -424,7 +429,7 @@ class stick:
         self.circle_plus_mac = "00" + stick_init_response.circle_plus_mac.value[
             2:
         ].decode(UTF8_DECODE)
-        self.network_id = stick_init_response.network_id.value
+        self._network_id = stick_init_response.network_id.value
         self._stick_initialized = True
         if not self._run_watchdog:
             self._run_watchdog = True

--- a/plugwise/stick.py
+++ b/plugwise/stick.py
@@ -23,6 +23,7 @@ from .constants import (
     NODE_TYPE_SENSE,
     NODE_TYPE_STEALTH,
     NODE_TYPE_SWITCH,
+    PRIORITY_LOW,
     STATE_ACTIONS,
     UTF8_DECODE,
     WATCHDOG_DEAMON,
@@ -656,6 +657,7 @@ class stick:
                             NodePingRequest(bytes(mac, UTF8_DECODE)),
                             None,
                             -1,
+                            PRIORITY_LOW,
                         )
                     _discover_counter = 0
                 else:
@@ -679,6 +681,7 @@ class stick:
         """Configure auto update polling daemon for power usage and availability state."""
         if timer:
             self._auto_update_timer = timer
+            self._auto_update_manually = True
         elif timer == 0:
             self._auto_update_timer = 0
             self._run_update_thread = False
@@ -764,6 +767,8 @@ class stick:
                         self.msg_controller.send(
                             NodeInfoRequest(bytes(mac, UTF8_DECODE)),
                             callback,
+                            0,
+                            PRIORITY_LOW,
                         )
                     elif force_discover:
                         self.msg_controller.send(

--- a/plugwise/stick.py
+++ b/plugwise/stick.py
@@ -607,12 +607,12 @@ class stick:
             while self._run_update_thread:
                 for mac in self._plugwise_nodes:
                     if self._plugwise_nodes[mac]:
-                        # Do ping request for all nodes if listener is registered for sensor
-                        self._plugwise_nodes[mac].do_ping(None, True)
-
                         if self._plugwise_nodes[mac].battery_powered:
                             # Check availability state of SED's
                             self._check_availability_of_seds(mac)
+                        else:
+                            # Do ping request for all non SED's
+                            self._plugwise_nodes[mac]._request_ping(None, True)
 
                         if self._plugwise_nodes[mac].measures_power:
                             # Request current power usage

--- a/plugwise/stick.py
+++ b/plugwise/stick.py
@@ -97,14 +97,14 @@ class stick:
 
     @property
     def mac(self) -> str:
-        """Return the MAC address of theUSB-Stick"""
+        """Return the MAC address of the USB-Stick."""
         if self._mac_stick:
             return self._mac_stick.decode(UTF8_DECODE)
         return None
 
     @property
     def network_state(self) -> bool:
-        """Return the state of the plugwise network"""
+        """Return the state of the Plugwise network."""
         return self._network_online
 
     @property
@@ -114,7 +114,7 @@ class stick:
 
     @property
     def joined_nodes(self) -> int:
-        """Return total number of nodes registered to Circle+ including Circle+ itself"""
+        """Return total number of nodes registered to Circle+ including Circle+ itself."""
         return self._joined_nodes + 1
 
     @property

--- a/plugwise/util.py
+++ b/plugwise/util.py
@@ -241,22 +241,12 @@ class DateTime(CompositeType):
 
     def deserialize(self, val):
         CompositeType.deserialize(self, val)
-        minutes = self.minutes.value
-        if minutes == 0:
-            self.value = datetime.datetime(PLUGWISE_EPOCH, 1, 1, 0, 0)
-        elif minutes == 65535:
+        if self.minutes.value == 65535:
             self.value = None
         else:
-            hours = minutes // 60
-            days = hours // 24
-            hours -= days * 24
-            minutes -= (days * 24 * 60) + (hours * 60)
-            try:
-                self.value = datetime.datetime(
-                    self.year.value, self.month.value, days + 1, hours, minutes
-                )
-            except datetime.datetime.ValueError:
-                self.value = None
+            self.value = datetime.datetime(
+                year=self.year.value, month=self.month.value, day=1
+            ) + datetime.timedelta(minutes=self.minutes.value)
 
 
 class Time(CompositeType):


### PR DESCRIPTION
This PR is based on #53, so that one needs to be merged first.

- Improvement: Debounce relay state
- Improvement: Prioritize request so requests like switching a relay get send out before power measurement requests.
- Improvement: Dynamically change the refresh interval based on the actual discovered nodes with power measurement capabilities
- Added: New property attributes for USB-stick.
  The old methods are still available but will give a deprecate warning
  - Stick
    - `devices` (dict) - All discovered and supported plugwise devices with the MAC address as their key
    - `joined_nodes` (integer) - Total number of registered nodes at Plugwise Circle+
    - `mac` (string) - The MAC address of the USB-Stick
    - `network_state` (boolean) - The state (on-line/off-line) of the Plugwise network.
    - `network_id` (integer) - The ID of the Plugwise network.
    - `port` (string) - The port connection string
  - All plugwise devices
    - `available` (boolean) - The current network availability state of the device
    - `battery_powered` (boolean) - Indicates if device is battery powered
    - `features` (tuple) - List of supported attribute IDs
    - `firmware_version` (string) - Firmware version device is running
    - `hardware_model` (string) - Hardware model name
    - `hardware_version` (string) - Hardware version of device
    - `last_update` (datetime) - Date/time stamp of last received update from device
    - `mac` (string) - MAC address of device
    - `measures_power` (boolean) - Indicates if device supports power measurement
    - `name` (string) - Name of device based om hardware model and MAC address
    - `ping` (integer) - Network roundtrip time in milliseconds
    - `rssi_in` (DBm) - Inbound RSSI level
    - `rssi_out` (DBm) - Outbound RSSI level based on the received inbound RSSI level of the neighbor node
  - Scan devices
    - `motion` (boolean) - Current detection state of motion.
  - Sense devices
    - `humidity`  (integer) - Last reported humidity value.
    - `temperature` (integer) - Last reported temperature value.
  - Circle/Circle+/Stealth devices
    - `current_power_usage` (float) - Current power usage (Watts) during the last second
    - `current_power_usage_8_sec` (float) - Current power usage (Watts) during the last 8 seconds
    - `power_consumption_current_hour` (float) - Total power consumption (kWh) this running hour
    - `power_consumption_previous_hour` (float) - Total power consumption (kWh) during the previous hour
    - `power_consumption_today` (float) - Total power consumption (kWh) of today
    - `power_consumption_yesterday` (float) - Total power consumption (kWh) during yesterday
    - `power_production_current_hour` (float) - Total power production (kWh) this hour
    - `relay_state` (boolean) - State of the output power relay. Setting this property will operate the relay
  - Switch devices
    - `switch`  (boolean) - Last reported state of switch