### PR TITLE
Fully support legacy P1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## 0.xy.z - Smile: fully support P1 legacy (with firmware v2.1.13 specifically)
+## 0.13.0 - Smile: fully support P1 legacy (specifically with firmware v2.1.13)
 
 ## 0.12.0 - Energy support and bugfixes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 # Changelog
 
+## 0.xy.z - Smile: fully support P1 legacy (with firware v2.1.13 specifically)
+
 ## 0.12.0 - Energy support and bugfixes
 
 - Stick: Add new properties `energy_consumption_today` counter and `energy_consumption_today_last_reset` timestamp. These properties can be used to properly measure the used energy. Very useful for the 'Energy' capabilities introduced in Home Assistant 2021.8

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## 0.xy.z - Smile: fully support P1 legacy (with firware v2.1.13 specifically)
+## 0.xy.z - Smile: fully support P1 legacy (with firmware v2.1.13 specifically)
 
 ## 0.12.0 - Energy support and bugfixes
 

--- a/plugwise/__init__.py
+++ b/plugwise/__init__.py
@@ -1,6 +1,6 @@
 """Plugwise module."""
 
-__version__ = "0.13.0a4"
+__version__ = "0.13.0a5"
 
 from plugwise.smile import Smile
 from plugwise.stick import Stick

--- a/plugwise/__init__.py
+++ b/plugwise/__init__.py
@@ -1,6 +1,6 @@
 """Plugwise module."""
 
-__version__ = "0.13.0a5"
+__version__ = "0.13.0a6"
 
 from plugwise.smile import Smile
 from plugwise.stick import Stick

--- a/plugwise/__init__.py
+++ b/plugwise/__init__.py
@@ -1,6 +1,6 @@
 """Plugwise module."""
 
-__version__ = "0.13.0a6"
+__version__ = "0.13.0a7"
 
 from plugwise.smile import Smile
 from plugwise.stick import Stick

--- a/plugwise/__init__.py
+++ b/plugwise/__init__.py
@@ -1,6 +1,6 @@
 """Plugwise module."""
 
-__version__ = "0.13.0a3"
+__version__ = "0.13.0a4"
 
 from plugwise.smile import Smile
 from plugwise.stick import Stick

--- a/plugwise/__init__.py
+++ b/plugwise/__init__.py
@@ -1,6 +1,6 @@
 """Plugwise module."""
 
-__version__ = "0.13.0a2"
+__version__ = "0.13.0a3"
 
 from plugwise.smile import Smile
 from plugwise.stick import Stick

--- a/plugwise/__init__.py
+++ b/plugwise/__init__.py
@@ -1,6 +1,6 @@
 """Plugwise module."""
 
-__version__ = "0.13.0a1"
+__version__ = "0.13.0a2"
 
 from plugwise.smile import Smile
 from plugwise.stick import Stick

--- a/plugwise/__init__.py
+++ b/plugwise/__init__.py
@@ -1,6 +1,6 @@
 """Plugwise module."""
 
-__version__ = "0.13.0a7"
+__version__ = "0.13.0"
 
 from plugwise.smile import Smile
 from plugwise.stick import Stick

--- a/plugwise/__init__.py
+++ b/plugwise/__init__.py
@@ -1,6 +1,6 @@
 """Plugwise module."""
 
-__version__ = "0.12.0"
+__version__ = "0.13.0a1"
 
 from plugwise.smile import Smile
 from plugwise.stick import Stick

--- a/plugwise/helper.py
+++ b/plugwise/helper.py
@@ -201,18 +201,17 @@ def power_data_local_format(attrs, key_string, val):
 
 def power_data_energy_diff(measurement, net_string, f_val, direct_data):
     """Calculate differential energy."""
-    if "electricity" in measurement:
-        diff = 1
-        if "produced" in measurement:
-            diff = -1
-        if net_string not in direct_data:
-            direct_data[net_string] = 0
+    diff = 1
+    if "produced" in measurement:
+        diff = -1
+    if net_string not in direct_data:
+        direct_data[net_string] = 0
 
-        if isinstance(f_val, int):
-            direct_data[net_string] += f_val * diff
-        else:
-            direct_data[net_string] += float(f_val * diff)
-            direct_data[net_string] = float(f"{round(direct_data[net_string], 3):.3f}")
+    if isinstance(f_val, int):
+        direct_data[net_string] += f_val * diff
+    else:
+        direct_data[net_string] += float(f_val * diff)
+        direct_data[net_string] = float(f"{round(direct_data[net_string], 3):.3f}")
 
     return direct_data
 
@@ -926,7 +925,7 @@ class SmileHelper:
     def _power_data_peak_value(self, loc):
         """Helper-function for _power_data_from_location()."""
         loc.found = True
-        loc.net_string = None
+        loc.net_string = "dummy"
 
         # Only once try to find P1 Legacy values
         if loc.logs.find(loc.locator) is None and self.smile_type == "power":
@@ -951,7 +950,7 @@ class SmileHelper:
         loc.key_string = f"{loc.measurement}_{peak}_{log_found}"
         if "gas" in loc.measurement:
             loc.key_string = f"{loc.measurement}_{log_found}"
-        # Don't create net_elec_interval sensor!
+        # Don't create net_elec_interval sensor
         if "electricity" in loc.measurement and "interval" not in log_found:
             loc.net_string = f"net_electricity_{log_found}"
         val = loc.logs.find(loc.locator).text
@@ -1006,6 +1005,7 @@ class SmileHelper:
                         direct_data[loc.key_string] = [loc.f_val, loc.log_date]
 
         if direct_data != {}:
+            direct_data.pop("dummy")
             return direct_data
 
     def _preset(self, loc_id):

--- a/plugwise/helper.py
+++ b/plugwise/helper.py
@@ -392,7 +392,7 @@ class SmileHelper:
                 "members": loc.members,
             }
 
-            # Smile P1 has one valid location, filter any left-overs
+            # Smile P1 has one valid location, skip any left-overs
             if self.smile_type == "power":
                 return
 
@@ -522,11 +522,13 @@ class SmileHelper:
             # Inject home_location as device id for legacy so
             # appl_data can use the location id as device id.
             self._appl_data[self._home_location] = {
-                "name": "P1",
-                "model": "Smile P1",
-                "types": {"power", "home"},
                 "class": "gateway",
+                "fw": None,
                 "location": self._home_location,
+                "model": "Smile P1",
+                "name": "P1",
+                "types": {"power", "home"},
+                "vendor": "Plugwise B.V.",
             }
             self.gateway_id = self._home_location
 

--- a/plugwise/helper.py
+++ b/plugwise/helper.py
@@ -742,6 +742,7 @@ class SmileHelper:
         Determined from APPLIANCES, for legacy from DOMAIN_OBJECTS.
         """
         data = {}
+        # P1 legacy has no APPLIANCES, also not present in DOMAIN_OBJECTS
         if self._smile_legacy and self.smile_type == "power":
             return data
 
@@ -861,6 +862,7 @@ class SmileHelper:
         Collect switching- or pump-group info.
         """
         switch_groups = {}
+        # P1 and Anna don't have switch groups
         if self.smile_type == "power" or self.smile_name == "Anna":
             return switch_groups
 
@@ -926,7 +928,7 @@ class SmileHelper:
 
         # Only once try to find P1 Legacy values
         if loc.logs.find(loc.locator) is None and self.smile_type == "power":
-            # Skip peak if not split (P1 Legacy)
+            # Skip peak if not split (P1 Legacy), this also results in one (peak_)point sensor for all P1's.
             if loc.peak_select == "nl_offpeak":
                 loc.found = False
                 return loc
@@ -965,6 +967,7 @@ class SmileHelper:
         search = self._domain_objects
         t_string = "tariff"
         if self.smile_type == "power":
+            # P1: use data from LOCATIONS
             search = self._locations
             if self._smile_legacy:
                 t_string = "tariff_indicator"

--- a/plugwise/helper.py
+++ b/plugwise/helper.py
@@ -956,9 +956,10 @@ class SmileHelper:
 
         search = self._domain_objects
         t_string = "tariff"
-        if self._smile_legacy and self.smile_type == "power":
+        if self.smile_type == "power":
             search = self._locations
-            t_string = "tariff_indicator"
+            if self._smile_legacy:
+                t_string = "tariff_indicator"
 
         loc.logs = search.find(f'.//location[@id="{loc_id}"]/logs')
 

--- a/plugwise/helper.py
+++ b/plugwise/helper.py
@@ -211,7 +211,8 @@ def power_data_energy_diff(measurement, net_string, f_val, direct_data):
         if isinstance(f_val, int):
             direct_data[net_string] += f_val * diff
         else:
-            direct_data[net_string] += float(f_val * diff)
+        direct_data[net_string] += float(f_val * diff)
+        direct_data[net_string] = float(f"{round(direct_data[net_string], 3):.3f}")
 
     return direct_data
 

--- a/plugwise/helper.py
+++ b/plugwise/helper.py
@@ -950,9 +950,10 @@ class SmileHelper:
         loc.key_string = f"{loc.measurement}_{peak}_{log_found}"
         if "gas" in loc.measurement:
             loc.key_string = f"{loc.measurement}_{log_found}"
-        if "interval" not in log_found:
+        # Don't create net_elec_interval sensor!
+        if "electricity" in log_found and "interval" not in log_found: 
             loc.net_string = (
-                f"net_electricity_{log_found}"  # Don't create net_elec_interval sensor!
+                f"net_electricity_{log_found}" 
             )
         val = loc.logs.find(loc.locator).text
         log_date = parse(loc.logs.find(loc.locator).get("log_date"))

--- a/plugwise/helper.py
+++ b/plugwise/helper.py
@@ -201,17 +201,18 @@ def power_data_local_format(attrs, key_string, val):
 
 def power_data_energy_diff(measurement, net_string, f_val, direct_data):
     """Calculate differential energy."""
-    diff = 1
-    if "produced" in measurement:
-        diff = -1
-    if net_string not in direct_data:
-        direct_data[net_string] = 0
+    if "electricity" in measurement and "interval" not in net_string:
+        diff = 1
+        if "produced" in measurement:
+            diff = -1
+        if net_string not in direct_data:
+            direct_data[net_string] = 0
 
-    if isinstance(f_val, int):
-        direct_data[net_string] += f_val * diff
-    else:
-        direct_data[net_string] += float(f_val * diff)
-        direct_data[net_string] = float(f"{round(direct_data[net_string], 3):.3f}")
+        if isinstance(f_val, int):
+            direct_data[net_string] += f_val * diff
+        else:
+            direct_data[net_string] += float(f_val * diff)
+            direct_data[net_string] = float(f"{round(direct_data[net_string], 3):.3f}")
 
     return direct_data
 
@@ -925,7 +926,6 @@ class SmileHelper:
     def _power_data_peak_value(self, loc):
         """Helper-function for _power_data_from_location()."""
         loc.found = True
-        loc.net_string = "dummy"
 
         # Only once try to find P1 Legacy values
         if loc.logs.find(loc.locator) is None and self.smile_type == "power":
@@ -950,9 +950,7 @@ class SmileHelper:
         loc.key_string = f"{loc.measurement}_{peak}_{log_found}"
         if "gas" in loc.measurement:
             loc.key_string = f"{loc.measurement}_{log_found}"
-        # Don't create net_elec_interval sensor
-        if "electricity" in loc.measurement and "interval" not in log_found:
-            loc.net_string = f"net_electricity_{log_found}"
+        loc.net_string = f"net_electricity_{log_found}"
         val = loc.logs.find(loc.locator).text
         log_date = parse(loc.logs.find(loc.locator).get("log_date"))
         loc.log_date = log_date.astimezone(tz.gettz("UTC")).replace(tzinfo=None)
@@ -1005,7 +1003,6 @@ class SmileHelper:
                         direct_data[loc.key_string] = [loc.f_val, loc.log_date]
 
         if direct_data != {}:
-            direct_data.pop("dummy")
             return direct_data
 
     def _preset(self, loc_id):

--- a/plugwise/helper.py
+++ b/plugwise/helper.py
@@ -856,6 +856,9 @@ class SmileHelper:
         Collect switching- or pump-group info.
         """
         switch_groups = {}
+        if self.smile_type == "power" and self.smile_name == "Anna":
+            return switch_groups
+
         search = self._domain_objects
 
         appliances = search.findall("./appliance")

--- a/plugwise/helper.py
+++ b/plugwise/helper.py
@@ -740,6 +740,9 @@ class SmileHelper:
         Determined from APPLIANCES, for legacy from DOMAIN_OBJECTS.
         """
         data = {}
+        if self._smile_legacy and self.smile_type == "power":
+            return data
+
         search = self._appliances
         if self._smile_legacy and self.smile_type != "stretch":
             search = self._domain_objects

--- a/plugwise/helper.py
+++ b/plugwise/helper.py
@@ -392,6 +392,10 @@ class SmileHelper:
                 "members": loc.members,
             }
 
+            # Smile P1 has one valid location, filter any left-overs
+            if self.smile_type == "power":
+                return
+
         return
 
     def _get_module_data(self, appliance, locator, mod_type):
@@ -953,6 +957,7 @@ class SmileHelper:
         search = self._domain_objects
         t_string = "tariff"
         if self._smile_legacy and self.smile_type == "power":
+            search = self._locations
             t_string = "tariff_indicator"
 
         loc.logs = search.find(f'.//location[@id="{loc_id}"]/logs')

--- a/plugwise/helper.py
+++ b/plugwise/helper.py
@@ -951,10 +951,8 @@ class SmileHelper:
         if "gas" in loc.measurement:
             loc.key_string = f"{loc.measurement}_{log_found}"
         # Don't create net_elec_interval sensor!
-        if "electricity" in log_found and "interval" not in log_found: 
-            loc.net_string = (
-                f"net_electricity_{log_found}" 
-            )
+        if "electricity" in log_found and "interval" not in log_found:
+            loc.net_string = f"net_electricity_{log_found}"
         val = loc.logs.find(loc.locator).text
         log_date = parse(loc.logs.find(loc.locator).get("log_date"))
         loc.log_date = log_date.astimezone(tz.gettz("UTC")).replace(tzinfo=None)

--- a/plugwise/helper.py
+++ b/plugwise/helper.py
@@ -856,7 +856,7 @@ class SmileHelper:
         Collect switching- or pump-group info.
         """
         switch_groups = {}
-        if self.smile_type == "power" and self.smile_name == "Anna":
+        if self.smile_type == "power" or self.smile_name == "Anna":
             return switch_groups
 
         search = self._domain_objects

--- a/plugwise/helper.py
+++ b/plugwise/helper.py
@@ -211,8 +211,8 @@ def power_data_energy_diff(measurement, net_string, f_val, direct_data):
         if isinstance(f_val, int):
             direct_data[net_string] += f_val * diff
         else:
-        direct_data[net_string] += float(f_val * diff)
-        direct_data[net_string] = float(f"{round(direct_data[net_string], 3):.3f}")
+            direct_data[net_string] += float(f_val * diff)
+            direct_data[net_string] = float(f"{round(direct_data[net_string], 3):.3f}")
 
     return direct_data
 

--- a/plugwise/helper.py
+++ b/plugwise/helper.py
@@ -925,6 +925,7 @@ class SmileHelper:
     def _power_data_peak_value(self, loc):
         """Helper-function for _power_data_from_location()."""
         loc.found = True
+        loc.net_string = None
 
         # Only once try to find P1 Legacy values
         if loc.logs.find(loc.locator) is None and self.smile_type == "power":
@@ -949,7 +950,10 @@ class SmileHelper:
         loc.key_string = f"{loc.measurement}_{peak}_{log_found}"
         if "gas" in loc.measurement:
             loc.key_string = f"{loc.measurement}_{log_found}"
-        loc.net_string = f"net_electricity_{log_found}"
+        if "interval" not in log_found:
+            loc.net_string = (
+                f"net_electricity_{log_found}"  # Don't create net_elec_interval sensor!
+            )
         val = loc.logs.find(loc.locator).text
         log_date = parse(loc.logs.find(loc.locator).get("log_date"))
         loc.log_date = log_date.astimezone(tz.gettz("UTC")).replace(tzinfo=None)

--- a/plugwise/helper.py
+++ b/plugwise/helper.py
@@ -951,7 +951,7 @@ class SmileHelper:
         if "gas" in loc.measurement:
             loc.key_string = f"{loc.measurement}_{log_found}"
         # Don't create net_elec_interval sensor!
-        if "electricity" in log_found and "interval" not in log_found:
+        if "electricity" in loc.measurement and "interval" not in log_found:
             loc.net_string = f"net_electricity_{log_found}"
         val = loc.logs.find(loc.locator).text
         log_date = parse(loc.logs.find(loc.locator).get("log_date"))

--- a/plugwise/smile.py
+++ b/plugwise/smile.py
@@ -399,7 +399,7 @@ class Smile(SmileHelper):
         # Generic
         if details["class"] == "gateway" or dev_id == self.gateway_id:
             # Anna: outdoor_temperature only present in domain_objects
-            if self.smile_name == "Anna" and "outdoor_temperature" not in device_data:
+            if self.smile_type == "thermostat" and "outdoor_temperature" not in device_data:
                 outdoor_temperature = self._object_value(
                     "location", self._home_location, "outdoor_temperature"
                 )

--- a/plugwise/smile.py
+++ b/plugwise/smile.py
@@ -204,20 +204,23 @@ class Smile(SmileHelper):
 
     async def _full_update_device(self):
         """Perform a first fetch of all XML data, needed for initialization."""
-        await self._update_domain_objects()
         self._locations = await self._request(LOCATIONS)
+        self._modules = await self._request(MODULES)
 
         # P1 legacy has no appliances
         if not (self.smile_type == "power" and self._smile_legacy):
             self._appliances = await self._request(APPLIANCES)
 
-        # No need to import modules for P1, no userfull info
+        # No need to import domain_objects and modules for P1, no userfull info
         if self.smile_type != "power":
-            self._modules = await self._request(MODULES)
+            await self._update_domain_objects()
 
     async def update_gw_devices(self):
         """Perform an incremental update for updating the various device states."""
-        await self._update_domain_objects()
+        if self.smile_type != "power":
+            await self._update_domain_objects()
+        else:
+            self._locations = await self._request(LOCATIONS)
 
         # P1 legacy has no appliances
         if not (self.smile_type == "power" and self._smile_legacy):

--- a/plugwise/smile.py
+++ b/plugwise/smile.py
@@ -399,7 +399,10 @@ class Smile(SmileHelper):
         # Generic
         if details["class"] == "gateway" or dev_id == self.gateway_id:
             # Anna: outdoor_temperature only present in domain_objects
-            if self.smile_type == "thermostat" and "outdoor_temperature" not in device_data:
+            if (
+                self.smile_type == "thermostat"
+                and "outdoor_temperature" not in device_data
+            ):
                 outdoor_temperature = self._object_value(
                     "location", self._home_location, "outdoor_temperature"
                 )

--- a/plugwise/smile.py
+++ b/plugwise/smile.py
@@ -211,7 +211,7 @@ class Smile(SmileHelper):
         if not (self.smile_type == "power" and self._smile_legacy):
             self._appliances = await self._request(APPLIANCES)
 
-        # No need to import domain_objects and modules for P1, no userfull info
+        # No need to import domain_objects and modules for P1, no useful info
         if self.smile_type != "power":
             await self._update_domain_objects()
 

--- a/plugwise/smile.py
+++ b/plugwise/smile.py
@@ -398,7 +398,7 @@ class Smile(SmileHelper):
         # Generic
         if details["class"] == "gateway" or dev_id == self.gateway_id:
             # Anna: outdoor_temperature only present in domain_objects
-            if "outdoor_temperature" not in device_data:
+            if self.smile_name == "Anna" and "outdoor_temperature" not in device_data:
                 outdoor_temperature = self._object_value(
                     "location", self._home_location, "outdoor_temperature"
                 )

--- a/plugwise/smile.py
+++ b/plugwise/smile.py
@@ -345,9 +345,10 @@ class Smile(SmileHelper):
             device_data.pop("intended_boiler_state", None)
 
         # Anna specific
-        illuminance = self._object_value("appliance", dev_id, "illuminance")
-        if illuminance is not None:
-            device_data["illuminance"] = illuminance
+        if self.smile_name == "Anna":
+            illuminance = self._object_value("appliance", dev_id, "illuminance")
+            if illuminance is not None:
+                device_data["illuminance"] = illuminance
 
         return device_data
 

--- a/tests/test_smile.py
+++ b/tests/test_smile.py
@@ -759,7 +759,7 @@ class TestPlugwise:  # pylint: disable=attribute-defined-outside-init
                         "id": "electricity_produced_off_peak_cumulative",
                         "state": 482.598,
                     },
-                    {"id": "net_electricity_cumulative", "state": 1019.151},
+                    {"id": "net_electricity_cumulative", "state": 1019.161},
                 ]
             }
         }

--- a/tests/test_smile.py
+++ b/tests/test_smile.py
@@ -796,7 +796,7 @@ class TestPlugwise:  # pylint: disable=attribute-defined-outside-init
                     {"id": "electricity_consumed_peak_point", "state": 456.0},
                     {"id": "net_electricity_point", "state": 456.0},
                     {"id": "gas_consumed_cumulative", "state": 584.431},
-                    {"id": "electricity_produced_peak_cumulative", "state": 0.0},
+                    {"id": "electricity_produced_peak_cumulative", "state": 1296.136},
                 ]
             }
         }

--- a/tests/test_smile.py
+++ b/tests/test_smile.py
@@ -751,9 +751,9 @@ class TestPlugwise:  # pylint: disable=attribute-defined-outside-init
             # Gateway / P1 itself
             "938696c4bcdb4b8a9a595cb38ed43913": {
                 "sensors": [
-                    {"id": "electricity_consumed_peak_point", "state": 458.0},
-                    {"id": "net_electricity_point", "state": 458.0},
-                    {"id": "gas_consumed_cumulative", "state": 584.433},
+                    {"id": "electricity_consumed_peak_point", "state": 456.0},
+                    {"id": "net_electricity_point", "state": 456.0},
+                    {"id": "gas_consumed_cumulative", "state": 584.431},
                     {"id": "electricity_produced_peak_cumulative", "state": 1296.136},
                     {
                         "id": "electricity_produced_off_peak_cumulative",
@@ -793,9 +793,9 @@ class TestPlugwise:  # pylint: disable=attribute-defined-outside-init
             # Gateway / P1 itself
             "199aa40f126840f392983d171374ab0b": {
                 "sensors": [
-                    {"id": "electricity_consumed_peak_point", "state": 368.0},
-                    {"id": "net_electricity_point", "state": 368.0},
-                    {"id": "gas_consumed_cumulative", "state": 2637.993},
+                    {"id": "electricity_consumed_peak_point", "state": 456.0},
+                    {"id": "net_electricity_point", "state": 456.0},
+                    {"id": "gas_consumed_cumulative", "state": 584.431},
                     {"id": "electricity_produced_peak_cumulative", "state": 0.0},
                 ]
             }

--- a/tests/test_smile.py
+++ b/tests/test_smile.py
@@ -759,6 +759,7 @@ class TestPlugwise:  # pylint: disable=attribute-defined-outside-init
                         "id": "electricity_produced_off_peak_cumulative",
                         "state": 482.598,
                     },
+                    {"id": "net_electricity_cumulative", "state": 1019.151},
                 ]
             }
         }

--- a/tests/test_smile.py
+++ b/tests/test_smile.py
@@ -1513,7 +1513,7 @@ class TestPlugwise:  # pylint: disable=attribute-defined-outside-init
             # Gateway / P1 itself
             "ba4de7613517478da82dd9b6abea36af": {
                 "sensors": [
-                    {"id": "electricity_consumed_peak_point", "state": 650.0},
+                    {"id": "electricity_consumed_peak_point", "state": 636.0},
                     {"id": "electricity_produced_peak_cumulative", "state": 0.0},
                     {
                         "id": "electricity_consumed_off_peak_cumulative",
@@ -1554,13 +1554,13 @@ class TestPlugwise:  # pylint: disable=attribute-defined-outside-init
             # Gateway / P1 itself
             "ba4de7613517478da82dd9b6abea36af": {
                 "sensors": [
-                    {"id": "electricity_consumed_peak_point", "state": 644.0},
+                    {"id": "electricity_consumed_peak_point", "state": 636.0},
                     {"id": "electricity_produced_peak_cumulative", "state": 20.0},
                     {
                         "id": "electricity_consumed_off_peak_cumulative",
                         "state": 10263.159,
                     },
-                    {"id": "net_electricity_point", "state": 244},
+                    {"id": "net_electricity_point", "state": 636},
                 ]
             }
         }
@@ -1596,8 +1596,8 @@ class TestPlugwise:  # pylint: disable=attribute-defined-outside-init
                     {"id": "electricity_consumed_peak_point", "state": 0.0},
                     {"id": "electricity_produced_peak_cumulative", "state": 396.559},
                     {"id": "electricity_consumed_off_peak_cumulative", "state": 551.09},
-                    {"id": "electricity_produced_peak_point", "state": 2761},
-                    {"id": "net_electricity_point", "state": -2761},
+                    {"id": "electricity_produced_peak_point", "state": 2816},
+                    {"id": "net_electricity_point", "state": -2816},
                     {"id": "gas_consumed_cumulative", "state": 584.85},
                 ]
             }
@@ -1855,7 +1855,7 @@ class TestPlugwise:  # pylint: disable=attribute-defined-outside-init
             # Gateway / P1 itself
             "ba4de7613517478da82dd9b6abea36af": {
                 "sensors": [
-                    {"id": "electricity_consumed_peak_point", "state": 571},
+                    {"id": "electricity_consumed_peak_point", "state": 548},
                     {"id": "electricity_produced_peak_cumulative", "state": 0.0},
                 ]
             }

--- a/tests/test_smile.py
+++ b/tests/test_smile.py
@@ -1523,6 +1523,7 @@ class TestPlugwise:  # pylint: disable=attribute-defined-outside-init
                         "id": "electricity_consumed_peak_interval",
                         "state": [179, dt.datetime(2020, 3, 12, 19, 45)],
                     },
+                    {"id": "net_electricity_cumulative", "state": 17965.326},
                 ]
             }
         }

--- a/userdata/p1v3solarfake/core.locations.xml
+++ b/userdata/p1v3solarfake/core.locations.xml
@@ -62,7 +62,7 @@
 				<interval>PT15M</interval>
 				<period start_date="2020-03-12T20:45:00+01:00" end_date="2020-03-12T20:45:00+01:00" interval="PT15M">
 					<measurement log_date="2020-03-12T20:45:00+01:00" tariff="nl_peak">0.00</measurement>
-					<measurement log_date="2020-03-12T20:45:00+01:00" tariff="nl_offpeak">0.00</measurement>
+					<measurement log_date="2020-03-12T20:45:00+01:00" tariff="nl_offpeak">20.00</measurement>
 				</period>
 				<electricity_interval_meter id='b3e07d45b7354d189cd0d5d41a4f80d7'/>
 			</interval_log>

--- a/userdata/p1v3solarfake/core.locations.xml
+++ b/userdata/p1v3solarfake/core.locations.xml
@@ -28,8 +28,8 @@
 				<unit>Wh</unit>
 				<last_consecutive_log_date>2020-03-12T21:00:00+01:00</last_consecutive_log_date>
 				<period start_date="2020-03-12T21:00:00+01:00" end_date="2020-03-12T21:00:00+01:00">
-					<measurement log_date="2020-03-12T21:00:00+01:00" tariff="nl_peak">0.00</measurement>
-					<measurement log_date="2020-03-12T21:00:00+01:00" tariff="nl_offpeak">0.00</measurement>
+					<measurement log_date="2020-03-12T21:00:00+01:00" tariff="nl_peak">20000.00</measurement>
+					<measurement log_date="2020-03-12T21:00:00+01:00" tariff="nl_offpeak">3000.00</measurement>
 				</period>
 				<electricity_cumulative_meter id='1fa5f5772e464e5cbcb595101adaf8e5'/>
 			</cumulative_log>


### PR DESCRIPTION
This change is specifically meant for the P1 with firmware 2.1.13, see also https://github.com/plugwise/plugwise-beta/issues/187
All other changes are "bijvangst":
- Read P1 data from LOCATIONS instead of from DOMAIN_OBJECTS - data in LOCATIONS is up-to-date for P1 legacy
- Change reading of data in `_full_update_device()` and `update_gw_devices()` due to this change
- Don't create `net_electricity_interval` sensor 
- At test-cases for `net_electricity_peak_point` sensor, add net-sensor value formatting to fix a rounding-error when adding