### PR TITLE
Revert "Unprotect vars to fix pylint error"

### DIFF
--- a/.github/workflows/verify.yml
+++ b/.github/workflows/verify.yml
@@ -4,7 +4,7 @@
 name: Latest commit
 
 env:
-  CACHE_VERSION: 8
+  CACHE_VERSION: 9
   DEFAULT_PYTHON: 3.9
   PRE_COMMIT_HOME: ~/.cache/pre-commit
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 # Changelog
 
+## v0.15.3 - Skipping, not released
+
 ## v0.15.2 - Smile: Implement possible fix for HA Core issue #59711
 
 ## v0.15.1 - Smile: Dependency update (aiohttp 3.8.0) and aligning other HA Core dependencies

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,5 @@
 # Changelog
 
-## v0.15.3 - Smile: fix pylint warning
-
 ## v0.15.2 - Smile: Implement possible fix for HA Core issue #59711
 
 ## v0.15.1 - Smile: Dependency update (aiohttp 3.8.0) and aligning other HA Core dependencies

--- a/plugwise/__init__.py
+++ b/plugwise/__init__.py
@@ -1,6 +1,6 @@
 """Plugwise module."""
 
-__version__ = "0.15.3"
+__version__ = "0.15.2"
 
 from plugwise.smile import Smile
 from plugwise.stick import Stick

--- a/plugwise/helper.py
+++ b/plugwise/helper.py
@@ -459,10 +459,10 @@ class SmileHelper:
 
         if appl.pwclass == "heater_central":
             # Remove heater_central when no active device present
-            if not self.active_device_present:
+            if not self._active_device_present:
                 return None
 
-            self.heater_id = appliance.attrib["id"]
+            self._heater_id = appliance.attrib["id"]
             appl.name = "Auxiliary"
             locator1 = ".//logs/point_log[type='flame_state']/boiler_state"
             locator2 = ".//services/boiler_state"
@@ -538,7 +538,7 @@ class SmileHelper:
         )
         fl_state = self._appliances.find(".//logs/point_log[type='flame_state']")
         bl_state = self._appliances.find(".//services/boiler_state")
-        self.active_device_present = (
+        self._active_device_present = (
             self._cp_state is not None or fl_state is not None or bl_state is not None
         )
 
@@ -585,7 +585,7 @@ class SmileHelper:
 
         # For legacy Anna gateway and heater_central is the same device
         if self._smile_legacy and self.smile_type == "thermostat":
-            self.gateway_id = self.heater_id
+            self.gateway_id = self._heater_id
 
     def _match_locations(self):
         """Helper-function for _scan_thermostats().
@@ -727,7 +727,7 @@ class SmileHelper:
 
         for appliance in appliances:
             measurements = DEVICE_MEASUREMENTS.items()
-            if self.active_device_present:
+            if self._active_device_present:
                 measurements = {
                     **DEVICE_MEASUREMENTS,
                     **HEATER_CENTRAL_MEASUREMENTS,
@@ -1141,7 +1141,7 @@ class SmileHelper:
             for item in BINARY_SENSORS:
                 if item[ATTR_ID] == key:
                     data.pop(item[ATTR_ID])
-                    if self.active_device_present:
+                    if self._active_device_present:
                         item[ATTR_STATE] = value
                         bs_list.append(item)
             for item in SENSORS:

--- a/plugwise/smile.py
+++ b/plugwise/smile.py
@@ -54,9 +54,9 @@ class SmileData(SmileHelper):
         if d_id == self.gateway_id:
             if self.single_master_thermostat() is not None:
                 bs_list.append(PW_NOTIFICATION)
-            if not self.active_device_present and "heating_state" in data:
+            if not self._active_device_present and "heating_state" in data:
                 s_list.append(DEVICE_STATE)
-        if d_id == self.heater_id and self.single_master_thermostat() is False:
+        if d_id == self._heater_id and self.single_master_thermostat() is False:
             s_list.append(DEVICE_STATE)
 
     def _all_device_data(self):
@@ -88,9 +88,9 @@ class SmileData(SmileHelper):
         self.gw_devices = dict(zip(dev_id_list, dev_and_data_list))
 
         self.gw_data["gateway_id"] = self.gateway_id
-        self.gw_data["heater_id"] = self.heater_id
+        self.gw_data["heater_id"] = self._heater_id
         self.gw_data["smile_name"] = self.smile_name
-        self.gw_data["active_device"] = self.active_device_present
+        self.gw_data["active_device"] = self._active_device_present
         self.gw_data["single_master_thermostat"] = self.single_master_thermostat()
 
     def get_all_devices(self):
@@ -161,7 +161,7 @@ class SmileData(SmileHelper):
         if self.smile_name == "Adam":
             if details["class"] == "gateway":
                 if (
-                    not self.active_device_present
+                    not self._active_device_present
                     and self._heating_valves() is not None
                 ):
                     device_data["heating_state"] = True
@@ -279,9 +279,11 @@ class Smile(SmileComm, SmileData):
             websession,
         )
 
+        self._active_device_present = None
         self._appliances = None
         self._appl_data = {}
         self._domain_objects = None
+        self._heater_id = None
         self._home_location = None
         self._locations = None
         self._modules = None
@@ -290,11 +292,9 @@ class Smile(SmileComm, SmileData):
         self._stretch_v3 = False
         self._thermo_locs = None
 
-        self.active_device_present = None
         self.gateway_id = None
         self.gw_data = {}
         self.gw_devices = {}
-        self.heater_id = None
         self.notifications = {}
         self.smile_hostname = None
         self.smile_name = None

--- a/tests/test_smile.py
+++ b/tests/test_smile.py
@@ -594,7 +594,7 @@ class TestPlugwise:  # pylint: disable=attribute-defined-outside-init
         assert not smile.notifications
 
         await self.device_test(smile, testdata)
-        assert smile.active_device_present
+        assert smile._active_device_present
 
         await self.tinker_thermostat(
             smile,
@@ -658,7 +658,7 @@ class TestPlugwise:  # pylint: disable=attribute-defined-outside-init
         assert not smile.notifications
 
         await self.device_test(smile, testdata)
-        assert smile.active_device_present
+        assert smile._active_device_present
 
         await self.tinker_thermostat(
             smile,
@@ -808,7 +808,7 @@ class TestPlugwise:  # pylint: disable=attribute-defined-outside-init
         assert not smile.notifications
 
         await self.device_test(smile, testdata)
-        assert smile.active_device_present
+        assert smile._active_device_present
 
         await self.tinker_thermostat(
             smile,
@@ -906,7 +906,7 @@ class TestPlugwise:  # pylint: disable=attribute-defined-outside-init
         assert not smile.notifications
 
         await self.device_test(smile, testdata)
-        assert not smile.active_device_present
+        assert not smile._active_device_present
 
         await self.tinker_thermostat(
             smile, "c34c6864216446528e95d88985e714cc", good_schemas=["Test", "Normal"]
@@ -965,7 +965,7 @@ class TestPlugwise:  # pylint: disable=attribute-defined-outside-init
         assert not smile.notifications
 
         await self.device_test(smile, testdata)
-        assert not smile.active_device_present
+        assert not smile._active_device_present
 
         await self.tinker_thermostat(
             smile, "c34c6864216446528e95d88985e714cc", good_schemas=["Test", "Normal"]
@@ -1038,7 +1038,7 @@ class TestPlugwise:  # pylint: disable=attribute-defined-outside-init
         assert not smile.notifications
 
         await self.device_test(smile, testdata)
-        assert smile.active_device_present
+        assert smile._active_device_present
 
         await self.tinker_thermostat(
             smile, "009490cc2f674ce6b576863fbb64f867", good_schemas=["Weekschema"]
@@ -1096,7 +1096,7 @@ class TestPlugwise:  # pylint: disable=attribute-defined-outside-init
         assert not smile.single_master_thermostat()
 
         await self.device_test(smile, testdata)
-        assert smile.active_device_present
+        assert smile._active_device_present
 
         switch_change = await self.tinker_switch(
             smile,
@@ -1263,7 +1263,7 @@ class TestPlugwise:  # pylint: disable=attribute-defined-outside-init
         await smile.delete_notification()
 
         await self.device_test(smile, testdata)
-        assert not smile.active_device_present
+        assert not smile._active_device_present
 
         await self.tinker_thermostat(
             smile, "c50f167537524366a5af7aa3942feb1e", good_schemas=["GF7  Woonkamer"]
@@ -1376,7 +1376,7 @@ class TestPlugwise:  # pylint: disable=attribute-defined-outside-init
         assert "af82e4ccf9c548528166d38e560662a4" in smile.notifications
 
         await self.device_test(smile, testdata)
-        assert not smile.active_device_present
+        assert not smile._active_device_present
 
         await self.tinker_thermostat(
             smile, "c50f167537524366a5af7aa3942feb1e", good_schemas=["GF7  Woonkamer"]
@@ -1597,7 +1597,7 @@ class TestPlugwise:  # pylint: disable=attribute-defined-outside-init
         assert not smile.notifications
 
         await self.device_test(smile, testdata)
-        assert smile.active_device_present
+        assert smile._active_device_present
 
         await smile.close_connection()
         await self.disconnect(server, client)
@@ -1650,7 +1650,7 @@ class TestPlugwise:  # pylint: disable=attribute-defined-outside-init
         assert not smile.notifications
 
         await self.device_test(smile, testdata)
-        assert smile.active_device_present
+        assert smile._active_device_present
 
         await smile.close_connection()
         await self.disconnect(server, client)


### PR DESCRIPTION
I found a better solution, let's revert this PR.

Other/better solution, see https://github.com/plugwise/plugwise-beta/commit/6014b5116fc81eb371b682b512f465a77d7cd123
