### PR TITLE
Python 3.9 default and small left-over linting

### DIFF
--- a/.github/workflows/merge.yml
+++ b/.github/workflows/merge.yml
@@ -4,7 +4,7 @@
 name: Latest release
 
 env:
-  CACHE_VERSION: 3
+  CACHE_VERSION: 4
   DEFAULT_PYTHON: 3.9
 
 # Only run on merges

--- a/.github/workflows/verify.yml
+++ b/.github/workflows/verify.yml
@@ -7,7 +7,7 @@ env:
   CACHE_VERSION: 4
   DEFAULT_PYTHON: "3.9"
   PRE_COMMIT_HOME: ~/.cache/pre-commit
-  PYTHON_VERSIONS: [3.9, "3.10"]
+  PYTHON_VERSIONS: '[3.9, "3.10"]'
 
 on:
   schedule:

--- a/.github/workflows/verify.yml
+++ b/.github/workflows/verify.yml
@@ -7,7 +7,6 @@ env:
   CACHE_VERSION: 4
   DEFAULT_PYTHON: "3.9"
   PRE_COMMIT_HOME: ~/.cache/pre-commit
-  PYTHON_VERSIONS: '3.9, "3.10"'
 
 on:
   schedule:
@@ -168,7 +167,7 @@ jobs:
     needs: commitcheck
     strategy:
       matrix:
-        python-version: [${{ env.PYTHON_VERSIONS }}]
+        python-version: [3.9, "3.10"]
     steps:
       - name: Check out committed code
         uses: actions/checkout@v2
@@ -207,7 +206,7 @@ jobs:
     needs: prepare-test-cache
     strategy:
       matrix:
-        python-version: [${{ env.PYTHON_VERSIONS }}]
+        python-version: [3.9, "3.10"]
 
     steps:
       - name: Check out committed code

--- a/.github/workflows/verify.yml
+++ b/.github/workflows/verify.yml
@@ -168,7 +168,7 @@ jobs:
     needs: commitcheck
     strategy:
       matrix:
-        python-version: ${{ PYTHON_VERSIONS }}
+        python-version: ${{ env.PYTHON_VERSIONS }}
     steps:
       - name: Check out committed code
         uses: actions/checkout@v2
@@ -207,7 +207,7 @@ jobs:
     needs: prepare-test-cache
     strategy:
       matrix:
-        python-version: ${{ PYTHON_VERSIONS }}
+        python-version: ${{ env.PYTHON_VERSIONS }}
 
     steps:
       - name: Check out committed code

--- a/.github/workflows/verify.yml
+++ b/.github/workflows/verify.yml
@@ -4,13 +4,14 @@
 name: Latest commit
 
 env:
-  CACHE_VERSION: 3
+  CACHE_VERSION: 4
   DEFAULT_PYTHON: "3.9"
   PRE_COMMIT_HOME: ~/.cache/pre-commit
+  PYTHON_VERSIONS: [3.9, "3.10"]
 
 on:
   schedule:
-    - cron: "0 0 * * 0" # weekly
+    - cron: "2 4 * * 0" # weekly
   workflow_dispatch:
   push:
 # pull_request:
@@ -167,7 +168,7 @@ jobs:
     needs: commitcheck
     strategy:
       matrix:
-        python-version: [3.8, 3.9, "3.10"]
+        python-version: ${{ PYTHON_VERSIONS }}
     steps:
       - name: Check out committed code
         uses: actions/checkout@v2
@@ -206,7 +207,7 @@ jobs:
     needs: prepare-test-cache
     strategy:
       matrix:
-        python-version: [3.8, 3.9, "3.10"]
+        python-version: ${{ PYTHON_VERSIONS }}
 
     steps:
       - name: Check out committed code

--- a/.github/workflows/verify.yml
+++ b/.github/workflows/verify.yml
@@ -7,7 +7,7 @@ env:
   CACHE_VERSION: 4
   DEFAULT_PYTHON: "3.9"
   PRE_COMMIT_HOME: ~/.cache/pre-commit
-  PYTHON_VERSIONS: '[3.9, "3.10"]'
+  PYTHON_VERSIONS: '3.9, "3.10"'
 
 on:
   schedule:
@@ -168,7 +168,7 @@ jobs:
     needs: commitcheck
     strategy:
       matrix:
-        python-version: ${{ env.PYTHON_VERSIONS }}
+        python-version: [${{ env.PYTHON_VERSIONS }}]
     steps:
       - name: Check out committed code
         uses: actions/checkout@v2
@@ -207,7 +207,7 @@ jobs:
     needs: prepare-test-cache
     strategy:
       matrix:
-        python-version: ${{ env.PYTHON_VERSIONS }}
+        python-version: [${{ env.PYTHON_VERSIONS }}]
 
     steps:
       - name: Check out committed code

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,3 +1,6 @@
+default_language_version:
+  # force all unspecified python hooks to run python3
+  python: python3.9
 repos:
   # Run manually in CI skipping the branch checks
   - repo: https://github.com/PyCQA/pylint
@@ -8,11 +11,10 @@ repos:
         entry: pylint
         language: system
         types: [python]
-        args:
-          [
-            "-rn",  # Only display messages
-            "-sn",  # Don't display the score
-          ]
+        args: [
+          "-rn",  # Only display messages
+          "-sn",  # Don't display the score
+        ]
   - repo: https://github.com/PyCQA/isort
     rev: 5.10.1
     hooks:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -26,12 +26,12 @@ repos:
         args:
           - --branch=main
   - repo: https://github.com/asottile/pyupgrade
-    rev: v2.30.1
+    rev: v2.31.0
     hooks:
       - id: pyupgrade
         args: [--py37-plus]
   - repo: https://github.com/psf/black
-    rev: 21.12b0
+    rev: 22.1.0
     hooks:
       - id: black
         args:
@@ -56,7 +56,7 @@ repos:
           - pydocstyle==5.1.1
         files: ^(plugwise|tests)/.+\.py$
   - repo: https://github.com/PyCQA/bandit
-    rev: 1.7.1
+    rev: 1.7.2
     hooks:
       - id: bandit
         args:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -8,7 +8,7 @@ repos:
     hooks:
       - id: pylint
         name: pylint
-        entry: pylint
+        entry: scripts/run-in-env.sh pylint
         language: system
         types: [python]
         args: [

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,8 @@
 # Changelog
 
-# v0.16.2 - Generic:
+# v0.16.2 - Generic and Stretch
   - As per Core deprecation of python 3.8, removed CI/CD testing and bumped pypi to 3.9 and production
+  - Add support for Stretch with fw 2.7.18
 
 # v0.16.1 - Smile - various updates:
   - BREAKING: Change active device detection, detect both OpenTherm (replace Auxiliary) and OnOff (new) heating and cooling devices.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+# v0.16.2 - Generic:
+  - As per Core deprecation of python 3.8, removed CI/CD testing and bumped pypi to 3.9 and production
+
 # v0.16.1 - Smile - various updates:
   - BREAKING: Change active device detection, detect both OpenTherm (replace Auxiliary) and OnOff (new) heating and cooling devices.
   - Stretch: base detection on the always present Stick

--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2019 @laetificat, 2019-2020 @CoMPaTech & @bouwew
+Copyright (c) 2019 @laetificat, 2019-2020 @CoMPaTech & @bouwew, 2020-current @CoMPaTech, @bouwew & @brefra
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/plugwise/__init__.py
+++ b/plugwise/__init__.py
@@ -1,6 +1,6 @@
 """Plugwise module."""
 
-__version__ = "0.16.2a0"
+__version__ = "0.16.2a1"
 
 from plugwise.smile import Smile
 from plugwise.stick import Stick

--- a/plugwise/__init__.py
+++ b/plugwise/__init__.py
@@ -1,6 +1,6 @@
 """Plugwise module."""
 
-__version__ = "0.16.1"
+__version__ = "0.16.2a0"
 
 from plugwise.smile import Smile
 from plugwise.stick import Stick

--- a/plugwise/__init__.py
+++ b/plugwise/__init__.py
@@ -1,6 +1,6 @@
 """Plugwise module."""
 
-__version__ = "0.16.2a1"
+__version__ = "0.16.2"
 
 from plugwise.smile import Smile
 from plugwise.stick import Stick

--- a/plugwise/nodes/circle_plus.py
+++ b/plugwise/nodes/circle_plus.py
@@ -57,10 +57,8 @@ class PlugwiseCirclePlus(PlugwiseCircle):
                 "Linked plugwise node with mac %s found",
                 message.node_mac.value.decode(UTF8_DECODE),
             )
-            if (
-                message.node_mac.value.decode(UTF8_DECODE)
-                not in self._plugwise_nodes.keys()
-            ):
+            #  TODO: 20220206 is there 'mac' in the dict? Otherwise it can be rewritten to just if message... in
+            if not self._plugwise_nodes.get(message.node_mac.value.decode(UTF8_DECODE)):
                 self._plugwise_nodes[
                     message.node_mac.value.decode(UTF8_DECODE)
                 ] = message.node_address.value

--- a/plugwise/stick.py
+++ b/plugwise/stick.py
@@ -316,7 +316,9 @@ class Stick:
         """Timeout for initial scan."""
         if not self.msg_controller.discovery_finished:
             for mac in self._nodes_to_discover:
-                if mac not in self._device_nodes.keys():
+                #  TODO: 20220206 is there 'mac' in the dict? Otherwise it can be rewritten as below (twice as fast above .get)
+                #        if mac not in self._device_nodes:
+                if not self._device_nodes.get(mac):
                     _LOGGER.info(
                         "Failed to discover node type for registered MAC '%s'. This is expected for battery powered nodes, they will be discovered at their first awake",
                         str(mac),

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,5 @@
 [tool.black]
-target-version = ["py37", "py38"]
+target-version = ["py39", "py310"]
 exclude = 'generated'
 
 [tool.isort]

--- a/scripts/python-venv.sh
+++ b/scripts/python-venv.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 set -eu
 
-pyversions=(3.10 3.9 3.8)
+pyversions=(3.10 3.9)
 my_path=$(git rev-parse --show-toplevel)
 my_venv=${my_path}/venv
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -6,11 +6,11 @@ description  = Plugwise Smile, Stretch and USB module for Python 3.
 long_description = file: README.md
 keywords     = home, automation, plugwise
 classifier =
-    Development Status :: 4 - Beta
+    Development Status :: 5 - Production/Stable
     Intended Audience :: Developers
     License :: OSI Approved :: MIT License
     Operating System :: OS Independent
-    Programming Language :: Python :: 3.8
+    Programming Language :: Python :: 3.9
     Topic :: Home Automation
 
 [flake8]
@@ -30,7 +30,7 @@ ignore =
     W504
 
 [mypy]
-python_version = 3.8
+python_version = 3.9
 show_error_codes = true
 ignore_errors = true
 follow_imports = silent

--- a/setup.py
+++ b/setup.py
@@ -19,8 +19,8 @@ def get_version(rel_path):
 
 
 def readme():
-    with open("README.md") as f:
-        return f.read()
+    with open("README.md", encoding="utf-8") as readme_file:
+        return readme_file.read()
 
 
 setup(

--- a/tests/test_smile.py
+++ b/tests/test_smile.py
@@ -1,7 +1,7 @@
 """Test Plugwise Home Assistant module and generate test JSON fixtures."""
 import asyncio
-import json
 import importlib
+import json
 
 # Fixture writing
 import logging
@@ -46,7 +46,7 @@ class TestPlugwise:  # pylint: disable=attribute-defined-outside-init
         if not os.path.exists(os.path.dirname(datafile)):  # pragma: no cover
             os.mkdir(os.path.dirname(datafile))
 
-        with open(datafile, "w") as fixture_file:
+        with open(datafile, "w", encoding="utf-8") as fixture_file:
             fixture_file.write(
                 json.dumps(
                     data,
@@ -121,9 +121,8 @@ class TestPlugwise:  # pylint: disable=attribute-defined-outside-init
             os.path.dirname(__file__),
             f"../userdata/{self.smile_setup}/core.appliances.xml",
         )
-        filedata = open(userdata)
-        data = filedata.read()
-        filedata.close()
+        with open(userdata, encoding="utf-8") as filedata:
+            data = filedata.read()
         return aiohttp.web.Response(text=data)
 
     async def smile_domain_objects(self, request):
@@ -132,9 +131,8 @@ class TestPlugwise:  # pylint: disable=attribute-defined-outside-init
             os.path.dirname(__file__),
             f"../userdata/{self.smile_setup}/core.domain_objects.xml",
         )
-        filedata = open(userdata)
-        data = filedata.read()
-        filedata.close()
+        with open(userdata, encoding="utf-8") as filedata:
+            data = filedata.read()
         return aiohttp.web.Response(text=data)
 
     async def smile_locations(self, request):
@@ -143,9 +141,8 @@ class TestPlugwise:  # pylint: disable=attribute-defined-outside-init
             os.path.dirname(__file__),
             f"../userdata/{self.smile_setup}/core.locations.xml",
         )
-        filedata = open(userdata)
-        data = filedata.read()
-        filedata.close()
+        with open(userdata, encoding="utf-8") as filedata:
+            data = filedata.read()
         return aiohttp.web.Response(text=data)
 
     async def smile_modules(self, request):
@@ -154,9 +151,8 @@ class TestPlugwise:  # pylint: disable=attribute-defined-outside-init
             os.path.dirname(__file__),
             f"../userdata/{self.smile_setup}/core.modules.xml",
         )
-        filedata = open(userdata)
-        data = filedata.read()
-        filedata.close()
+        with open(userdata, encoding="utf-8") as filedata:
+            data = filedata.read()
         return aiohttp.web.Response(text=data)
 
     async def smile_status(self, request):
@@ -166,47 +162,54 @@ class TestPlugwise:  # pylint: disable=attribute-defined-outside-init
                 os.path.dirname(__file__),
                 f"../userdata/{self.smile_setup}/system_status_xml.xml",
             )
-            filedata = open(userdata)
-            data = filedata.read()
-            filedata.close()
+            with open(userdata, encoding="utf-8") as filedata:
+                data = filedata.read()
             return aiohttp.web.Response(text=data)
         except OSError:
             raise aiohttp.web.HTTPNotFound
 
-    async def smile_set_temp_or_preset(self, request):
+    @classmethod
+    async def smile_set_temp_or_preset(cls, request):
         """Render generic API calling endpoint."""
         text = "<xml />"
         raise aiohttp.web.HTTPAccepted(text=text)
 
-    async def smile_set_schedule(self, request):
+    @classmethod
+    async def smile_set_schedule(cls, request):
         """Render generic API calling endpoint."""
         text = "<xml />"
         raise aiohttp.web.HTTPAccepted(text=text)
 
-    async def smile_set_relay(self, request):
+    @classmethod
+    async def smile_set_relay(cls, request):
         """Render generic API calling endpoint."""
         text = "<xml />"
         raise aiohttp.web.HTTPAccepted(text=text)
 
-    async def smile_set_relay_stretch(self, request):
+    @classmethod
+    async def smile_set_relay_stretch(cls, request):
         """Render generic API calling endpoint."""
         text = "<xml />"
         raise aiohttp.web.HTTPOk(text=text)
 
-    async def smile_del_notification(self, request):
+    @classmethod
+    async def smile_del_notification(cls, request):
         """Render generic API calling endpoint."""
         text = "<xml />"
         raise aiohttp.web.HTTPAccepted(text=text)
 
-    async def smile_timeout(self, request):
+    @classmethod
+    async def smile_timeout(cls, request):
         """Render timeout endpoint."""
         raise asyncio.TimeoutError
 
-    async def smile_broken(self, request):
+    @classmethod
+    async def smile_broken(cls, request):
         """Render server error endpoint."""
         raise aiohttp.web.HTTPInternalServerError(text="Internal Server Error")
 
-    async def smile_fail_auth(self, request):
+    @classmethod
+    async def smile_fail_auth(cls, request):
         """Render authentication error endpoint."""
         raise aiohttp.web.HTTPUnauthorized()
 
@@ -254,7 +257,7 @@ class TestPlugwise:  # pylint: disable=attribute-defined-outside-init
             resp = await websession.get(url)
             assumed_status = self.connect_status(broken, timeout, fail_auth)
             assert resp.status == assumed_status
-        except Exception:  # pylint disable=broad-except
+        except Exception:  # pylint: disable=broad-except
             assert True
 
         if not broken and not timeout and not fail_auth:
@@ -271,7 +274,7 @@ class TestPlugwise:  # pylint: disable=attribute-defined-outside-init
                 websession=None,
             )
             assert False
-        except Exception:  # pylint disable=broad-except
+        except Exception:  # pylint: disable=broad-except
             assert True
 
         smile = pw_smile.Smile(
@@ -341,8 +344,9 @@ class TestPlugwise:  # pylint: disable=attribute-defined-outside-init
         return await self.connect(stretch=stretch)
 
     # Generic disconnect
+    @classmethod
     @pytest.mark.asyncio
-    async def disconnect(self, server, client):
+    async def disconnect(cls, server, client):
         """Disconnect from webserver."""
         await client.session.close()
         await server.close()
@@ -389,7 +393,7 @@ class TestPlugwise:  # pylint: disable=attribute-defined-outside-init
         self._write_json("all_data", data)
         self._write_json("notifications", extra["notifications"])
 
-        location_list = smile._thermo_locs
+        location_list = smile._thermo_locs  # pylint: disable=protected-access
 
         _LOGGER.info("Gateway id = %s", extra["gateway_id"])
         _LOGGER.info("Hostname = %s", smile.smile_hostname)
@@ -640,7 +644,7 @@ class TestPlugwise:  # pylint: disable=attribute-defined-outside-init
 
         await self.device_test(smile, testdata)
         _LOGGER.info(" # Assert master thermostat")
-        assert smile._sm_thermostat
+        assert smile._sm_thermostat  # pylint: disable=protected-access
         assert self.active_device_present
         assert not self.notifications
 
@@ -741,7 +745,7 @@ class TestPlugwise:  # pylint: disable=attribute-defined-outside-init
 
         await self.device_test(smile, testdata)
         _LOGGER.info(" # Assert master thermostat")
-        assert smile._sm_thermostat
+        assert smile._sm_thermostat  # pylint: disable=protected-access
         assert self.active_device_present
         assert not self.notifications
 
@@ -812,7 +816,8 @@ class TestPlugwise:  # pylint: disable=attribute-defined-outside-init
 
         await self.device_test(smile, testdata)
         _LOGGER.info(" # Assert no master thermostat")
-        assert smile._sm_thermostat is None  # it's not a thermostat :)
+        # it's not a thermostat :)
+        assert smile._sm_thermostat is None  # pylint: disable=protected-access
         assert not self.notifications
 
         await smile.close_connection()
@@ -849,7 +854,8 @@ class TestPlugwise:  # pylint: disable=attribute-defined-outside-init
 
         await self.device_test(smile, testdata)
         _LOGGER.info(" # Assert no master thermostat")
-        assert smile._sm_thermostat is None  # it's not a thermostat :)
+        # it's not a thermostat :)
+        assert smile._sm_thermostat is None  # pylint: disable=protected-access
         assert not self.notifications
 
         await smile.close_connection()
@@ -931,7 +937,7 @@ class TestPlugwise:  # pylint: disable=attribute-defined-outside-init
 
         await self.device_test(smile, testdata)
         _LOGGER.info(" # Assert master thermostat")
-        assert smile._sm_thermostat
+        assert smile._sm_thermostat  # pylint: disable=protected-access
         assert self.active_device_present
         assert not self.notifications
 
@@ -976,7 +982,7 @@ class TestPlugwise:  # pylint: disable=attribute-defined-outside-init
 
         await self.device_test(smile, testdata)
         _LOGGER.info(" # Assert master thermostat")
-        assert smile._sm_thermostat
+        assert smile._sm_thermostat  # pylint: disable=protected-access
 
         await self.tinker_thermostat(
             smile,
@@ -1027,7 +1033,7 @@ class TestPlugwise:  # pylint: disable=attribute-defined-outside-init
 
         await self.device_test(smile, testdata)
         _LOGGER.info(" # Assert master thermostat")
-        assert smile._sm_thermostat
+        assert smile._sm_thermostat  # pylint: disable=protected-access
         assert self.active_device_present
         assert not self.notifications
 
@@ -1076,7 +1082,7 @@ class TestPlugwise:  # pylint: disable=attribute-defined-outside-init
 
         await self.device_test(smile, testdata)
         _LOGGER.info(" # Assert master thermostat")
-        assert smile._sm_thermostat
+        assert smile._sm_thermostat  # pylint: disable=protected-access
         assert self.active_device_present
         assert not self.notifications
 
@@ -1163,7 +1169,7 @@ class TestPlugwise:  # pylint: disable=attribute-defined-outside-init
 
         await self.device_test(smile, testdata)
         _LOGGER.info(" # Assert master thermostat")
-        assert smile._sm_thermostat
+        assert smile._sm_thermostat  # pylint: disable=protected-access
         assert self.active_device_present
         assert not self.notifications
 
@@ -1223,7 +1229,7 @@ class TestPlugwise:  # pylint: disable=attribute-defined-outside-init
 
         await self.device_test(smile, testdata)
         _LOGGER.info(" # Assert master thermostat")
-        assert smile._sm_thermostat
+        assert smile._sm_thermostat  # pylint: disable=protected-access
         assert self.active_device_present
         assert not self.notifications
 
@@ -1422,7 +1428,7 @@ class TestPlugwise:  # pylint: disable=attribute-defined-outside-init
 
         await self.device_test(smile, testdata)
         _LOGGER.info(" # Assert master thermostat")
-        assert not smile._sm_thermostat
+        assert not smile._sm_thermostat  # pylint: disable=protected-access
         assert self.active_device_present
 
         switch_change = await self.tinker_switch(
@@ -1572,7 +1578,7 @@ class TestPlugwise:  # pylint: disable=attribute-defined-outside-init
 
         await self.device_test(smile, testdata)
         _LOGGER.info(" # Assert master thermostat")
-        assert not smile._sm_thermostat
+        assert not smile._sm_thermostat  # pylint: disable=protected-access
         assert self.active_device_present
 
         assert "af82e4ccf9c548528166d38e560662a4" in self.notifications
@@ -1977,7 +1983,7 @@ class TestPlugwise:  # pylint: disable=attribute-defined-outside-init
 
         await self.device_test(smile, testdata)
         _LOGGER.info(" # Assert master thermostat")
-        assert not smile._sm_thermostat
+        assert not smile._sm_thermostat  # pylint: disable=protected-access
         assert self.active_device_present
 
         assert "af82e4ccf9c548528166d38e560662a4" in self.notifications
@@ -2075,7 +2081,8 @@ class TestPlugwise:  # pylint: disable=attribute-defined-outside-init
         assert not smile._smile_legacy  # pylint: disable=protected-access
 
         await self.device_test(smile, testdata)
-        assert smile._sm_thermostat is None  # it's not a thermostat :)
+        # it's not a thermostat :)
+        assert smile._sm_thermostat is None  # pylint: disable=protected-access
         assert not self.cooling_present
         assert not self.notifications
 
@@ -2111,7 +2118,8 @@ class TestPlugwise:  # pylint: disable=attribute-defined-outside-init
 
         await self.device_test(smile, testdata)
         _LOGGER.info(" # Assert nomaster thermostat")
-        assert smile._sm_thermostat is None  # it's not a thermostat :)
+        # it's not a thermostat :)
+        assert smile._sm_thermostat is None  # pylint: disable=protected-access
         assert not self.notifications
 
         await smile.close_connection()
@@ -2164,7 +2172,8 @@ class TestPlugwise:  # pylint: disable=attribute-defined-outside-init
 
         await self.device_test(smile, testdata)
         _LOGGER.info(" # Assert no master thermostat")
-        assert smile._sm_thermostat is None  # it's not a thermostat :)
+        # it's not a thermostat :)
+        assert smile._sm_thermostat is None  # pylint: disable=protected-access
         assert not self.notifications
 
         await smile.close_connection()
@@ -2217,7 +2226,7 @@ class TestPlugwise:  # pylint: disable=attribute-defined-outside-init
         # Preset cooling_active to True, will turn to False due to the lowered outdoor temp
         await self.device_test(smile, testdata, True)
         _LOGGER.info(" # Assert master thermostat")
-        assert smile._sm_thermostat
+        assert smile._sm_thermostat  # pylint: disable=protected-access
         assert self.active_device_present
         assert self.cooling_present
         assert not self.notifications
@@ -2271,7 +2280,7 @@ class TestPlugwise:  # pylint: disable=attribute-defined-outside-init
 
         await self.device_test(smile, testdata)
         _LOGGER.info(" # Assert master thermostat")
-        assert smile._sm_thermostat
+        assert smile._sm_thermostat  # pylint: disable=protected-access
         assert self.active_device_present
         assert self.cooling_present
         assert not self.notifications
@@ -2303,7 +2312,7 @@ class TestPlugwise:  # pylint: disable=attribute-defined-outside-init
 
         await self.device_test(smile, testdata, True)
         _LOGGER.info(" # Assert master thermostat")
-        assert smile._sm_thermostat
+        assert smile._sm_thermostat  # pylint: disable=protected-access
 
         assert "3d28a20e17cb47dca210a132463721d5" in self.notifications
 
@@ -2495,7 +2504,8 @@ class TestPlugwise:  # pylint: disable=attribute-defined-outside-init
 
         await self.device_test(smile, testdata)
         _LOGGER.info(" # Assert no master thermostat")
-        assert smile._sm_thermostat is None  # it's not a thermostat :)
+        # it's not a thermostat :)
+        assert smile._sm_thermostat is None  # pylint: disable=protected-access
 
         await smile.close_connection()
         await self.disconnect(server, client)
@@ -2771,7 +2781,8 @@ class TestPlugwise:  # pylint: disable=attribute-defined-outside-init
 
         await self.device_test(smile, testdata)
         _LOGGER.info(" # Assert no master thermostat")
-        assert smile._sm_thermostat is None  # it's not a thermostat :)
+        # it's not a thermostat :)
+        assert smile._sm_thermostat is None  # pylint: disable=protected-access
 
         switch_change = await self.tinker_switch(
             smile, "2587a7fcdd7e482dab03fda256076b4b"
@@ -2819,7 +2830,8 @@ class TestPlugwise:  # pylint: disable=attribute-defined-outside-init
 
         await self.device_test(smile, testdata)
         _LOGGER.info(" # Assert no master thermostat")
-        assert smile._sm_thermostat is None  # it's not a thermostat :)
+        # it's not a thermostat :)
+        assert smile._sm_thermostat is None  # pylint: disable=protected-access
 
         switch_change = await self.tinker_switch(
             smile, "8b8d14b242e24cd789743c828b9a2ea9"
@@ -2874,7 +2886,8 @@ class TestPlugwise:  # pylint: disable=attribute-defined-outside-init
 
         await self.device_test(smile, testdata)
         _LOGGER.info(" # Assert no master thermostat")
-        assert smile._sm_thermostat is None  # it's not a thermostat :)
+        # it's not a thermostat :)
+        assert smile._sm_thermostat is None  # pylint: disable=protected-access
         assert not self.notifications
 
         await smile.close_connection()
@@ -2918,9 +2931,14 @@ class TestPlugwise:  # pylint: disable=attribute-defined-outside-init
     async def test_connect_timeout(self, timeout_test):
         """Wrap connect to raise timeout during get."""
 
+        # pylint: disable=unused-variable
         try:
             self.smile_setup = "p1v4"
-            server, smile, client = await self.connect_wrapper()
+            (
+                server,
+                smile,
+                client,
+            ) = await self.connect_wrapper()
             assert False  # pragma: no cover
         except pw_exceptions.DeviceTimeoutError:
             assert True


### PR DESCRIPTION
Default to python 3.9, deprecating 3.8
Fixing final lint issues (i.e. `pre-commit run -v -a`) within USB and mostly in test
Small version bump
Pre-commit autoupdate dependencies