### PR TITLE
Fix zigbee mac addresses in testdata

### DIFF
--- a/plugwise/__init__.py
+++ b/plugwise/__init__.py
@@ -1,6 +1,6 @@
 """Plugwise module."""
 
-__version__ = "0.16.6a0"
+__version__ = "0.16.6a1"
 
 from plugwise.smile import Smile
 from plugwise.stick import Stick

--- a/tests/test_smile.py
+++ b/tests/test_smile.py
@@ -51,6 +51,7 @@ class TestPlugwise:  # pylint: disable=attribute-defined-outside-init
             fixture_file.write(
                 json.dumps(
                     data,
+                    indent=2,
                     default=lambda x: list(x) if isinstance(x, set) else x,
                 )
             )
@@ -1202,7 +1203,7 @@ class TestPlugwise:  # pylint: disable=attribute-defined-outside-init
             "b128b4bbbd1f47e9bf4d756e8fb5ee94": {
                 "hw": "AME Smile 2.0 board",
                 "mac_address": "012345670001",
-                "zigbee_mac_address": "012345670101",
+                "zigbee_mac_address": "ABCD012345670101",
                 "sensors": {
                     "outdoor_temperature": 11.9,
                 },
@@ -1505,7 +1506,7 @@ class TestPlugwise:  # pylint: disable=attribute-defined-outside-init
                 "binary_sensors": {"plugwise_notification": True},
                 "sensors": {"outdoor_temperature": 7.69},
                 "mac_address": "012345670001",
-                "zigbee_mac_address": "012345670101",
+                "zigbee_mac_address": "ABCD012345670101",
             },
             # Modem
             "675416a629f343c495449970e2ca37b5": {
@@ -1745,7 +1746,7 @@ class TestPlugwise:  # pylint: disable=attribute-defined-outside-init
                     "electricity_produced_interval": 0.0,
                 },
                 "switches": {"relay": True, "lock": True},
-                "zigbee_mac_address": "012345670A14",
+                "zigbee_mac_address": "ABCD012345670A14",
             },
             "4a810418d5394b3f82727340b91ba740": {
                 "class": "router",
@@ -2268,7 +2269,7 @@ class TestPlugwise:  # pylint: disable=attribute-defined-outside-init
                 "model": "Stretch",
                 "name": "Stretch",
                 "vendor": "Plugwise B.V.",
-                "zigbee_mac_address": "012345670101",
+                "zigbee_mac_address": "ABCD012345670101",
             },
             "5871317346d045bc9f6b987ef25ee638": {
                 "class": "water_heater_vessel",
@@ -2413,7 +2414,7 @@ class TestPlugwise:  # pylint: disable=attribute-defined-outside-init
                 "name": "Stretch",
                 "vendor": "Plugwise B.V.",
                 "mac_address": "01:23:45:67:89:AB",
-                "zigbee_mac_address": "012345670101",
+                "zigbee_mac_address": "ABCD012345670101",
             },
             "09c8ce93d7064fa6a233c0e4c2449bfe": {
                 "class": "lamp",
@@ -2428,7 +2429,7 @@ class TestPlugwise:  # pylint: disable=attribute-defined-outside-init
                     "electricity_produced": 0.0,
                 },
                 "switches": {"relay": False, "lock": False},
-                "zigbee_mac_address": "012345670A01",
+                "zigbee_mac_address": "ABCD012345670A01",
             },
             "33a1c784a9ff4c2d8766a0212714be09": {
                 "class": "lighting",

--- a/userdata/README.md
+++ b/userdata/README.md
@@ -64,10 +64,11 @@ See 'pre-commit.sh' for details
 
 We used to obfuscate them as they weren't used within our module nor HomeAssistant.
 With 0.16.4 this was changed as such we recommend leaving them in, if you do wish to obfuscate
+Note: Zigbee mac addresses are 64bit (not 48bit like Ethernet mac addresses)
 
 Prefix: 
 
-  - `01234567`
+  - `ABCD01234567`
 
 Postfix:
 

--- a/userdata/adam_heatpump/domain_objects.xml
+++ b/userdata/adam_heatpump/domain_objects.xml
@@ -146,7 +146,7 @@
 		</services>
 		<protocols>
 			<zig_bee_node id='138298657dbd44ca9b8393b6a3cd86a8'>
-				<mac_address>012345670A01</mac_address>
+				<mac_address>ABCD012345670A01</mac_address>
 				<type>router</type>
 				<reachable>true</reachable>
 				<power_source>mains</power_source>
@@ -386,7 +386,7 @@
 		</services>
 		<protocols>
 			<zig_bee_node id='9a0d6157588a43c9ae492a362cb71168'>
-				<mac_address>012345670A02</mac_address>
+				<mac_address>ABCD012345670A02</mac_address>
 				<type>end_device</type>
 				<reachable>true</reachable>
 				<power_source>battery</power_source>
@@ -729,7 +729,7 @@
 		</services>
 		<protocols>
 			<zig_bee_node id='33e54459fdd54c22b3b99ae70a94d1c5'>
-				<mac_address>012345670A03</mac_address>
+				<mac_address>ABCD012345670A03</mac_address>
 				<type>router</type>
 				<reachable>true</reachable>
 				<power_source>mains</power_source>
@@ -931,7 +931,7 @@
 		</services>
 		<protocols>
 			<zig_bee_node id='4ac495040ae2462d832b15d00b245c0b'>
-				<mac_address>012345670A04</mac_address>
+				<mac_address>ABCD012345670A04</mac_address>
 				<type>router</type>
 				<reachable>true</reachable>
 				<power_source>mains</power_source>
@@ -1266,7 +1266,7 @@
 		</services>
 		<protocols>
 			<zig_bee_node id='8dbb5981239a41d1b7c39c6a85276c61'>
-				<mac_address>012345670A05</mac_address>
+				<mac_address>ABCD012345670A05</mac_address>
 				<type>router</type>
 				<reachable>true</reachable>
 				<power_source>mains</power_source>
@@ -1347,7 +1347,7 @@
 		</services>
 		<protocols>
 			<zig_bee_node id='a64db02a2fa243e0a9c00126ad1b1f7e'>
-				<mac_address>012345670A06</mac_address>
+				<mac_address>ABCD012345670A06</mac_address>
 				<type>router</type>
 				<reachable>true</reachable>
 				<power_source>mains</power_source>
@@ -1378,7 +1378,7 @@
 		</services>
 		<protocols>
 			<zig_bee_node id='972269fa494440d393dbdb8e5b0643b7'>
-				<mac_address>012345670A07</mac_address>
+				<mac_address>ABCD012345670A07</mac_address>
 				<type>router</type>
 				<reachable>true</reachable>
 				<power_source>mains</power_source>
@@ -2347,7 +2347,7 @@
 		</services>
 		<protocols>
 			<zig_bee_node id='ede18329ad24437d8d37222733789c7c'>
-				<mac_address>012345670A08</mac_address>
+				<mac_address>ABCD012345670A08</mac_address>
 				<type>router</type>
 				<reachable>true</reachable>
 				<power_source>mains</power_source>
@@ -3355,7 +3355,7 @@
 		</services>
 		<protocols>
 			<zig_bee_node id='b1d09b4fa20c4f1a98278709b3363eea'>
-				<mac_address>012345670A09</mac_address>
+				<mac_address>ABCD012345670A09</mac_address>
 				<type>router</type>
 				<reachable>true</reachable>
 				<power_source>mains</power_source>
@@ -3386,7 +3386,7 @@
 		</services>
 		<protocols>
 			<zig_bee_node id='5cf439ab62eb48c3977ca41ac1d986ee'>
-				<mac_address>012345670A10</mac_address>
+				<mac_address>ABCD012345670A10</mac_address>
 				<type>router</type>
 				<reachable>true</reachable>
 				<power_source>mains</power_source>
@@ -3567,7 +3567,7 @@
 		</services>
 		<protocols>
 			<zig_bee_node id='91af9b4eb6b247909afab2b09cca821a'>
-				<mac_address>012345670A11</mac_address>
+				<mac_address>ABCD012345670A11</mac_address>
 				<type>router</type>
 				<reachable>true</reachable>
 				<power_source>mains</power_source>
@@ -3598,7 +3598,7 @@
 		</services>
 		<protocols>
 			<zig_bee_node id='59277b278b4c48a3889cd70378299ebb'>
-				<mac_address>012345670A12</mac_address>
+				<mac_address>ABCD012345670A12</mac_address>
 				<type>router</type>
 				<reachable>true</reachable>
 				<power_source>mains</power_source>
@@ -3629,7 +3629,7 @@
 		</services>
 		<protocols>
 			<zig_bee_node id='08ceb19506ee4546998f62381e867a8e'>
-				<mac_address>012345670A13</mac_address>
+				<mac_address>ABCD012345670A13</mac_address>
 				<type>router</type>
 				<reachable>true</reachable>
 				<power_source>mains</power_source>
@@ -3660,7 +3660,7 @@
 		</services>
 		<protocols>
 			<zig_bee_node id='954e187dd4924e6a92a109f41d844712'>
-				<mac_address>012345670A14</mac_address>
+				<mac_address>ABCD012345670A14</mac_address>
 				<type>router</type>
 				<reachable>true</reachable>
 				<power_source>mains</power_source>
@@ -3691,7 +3691,7 @@
 		</services>
 		<protocols>
 			<zig_bee_node id='e116d86377504e69bc8efb73988f11f8'>
-				<mac_address>012345670A15</mac_address>
+				<mac_address>ABCD012345670A15</mac_address>
 				<type>router</type>
 				<reachable>true</reachable>
 				<power_source>mains</power_source>
@@ -3805,7 +3805,7 @@
 		</services>
 		<protocols>
 			<zig_bee_node id='8f06059e0cdc44038e9201fd8bfbea97'>
-				<mac_address>012345670A16</mac_address>
+				<mac_address>ABCD012345670A16</mac_address>
 				<type>router</type>
 				<reachable>true</reachable>
 				<power_source>mains</power_source>
@@ -3881,7 +3881,7 @@
 		</services>
 		<protocols>
 			<zig_bee_node id='96ce5e59e0474853bda4ee2794ed0da0'>
-				<mac_address>012345670A17</mac_address>
+				<mac_address>ABCD012345670A17</mac_address>
 				<type>end_device</type>
 				<reachable>true</reachable>
 				<power_source>battery</power_source>
@@ -3912,7 +3912,7 @@
 		</services>
 		<protocols>
 			<zig_bee_node id='29f51d5cde66420facb975744d59f09c'>
-				<mac_address>012345670A18</mac_address>
+				<mac_address>ABCD012345670A18</mac_address>
 				<type>router</type>
 				<reachable>true</reachable>
 				<power_source>mains</power_source>
@@ -3932,7 +3932,7 @@
 		<services/>
 		<protocols>
 			<zig_bee_coordinator id='d55765aedfdf47baa1e3cc6d2b2d6000'>
-				<mac_address>012345670101</mac_address>
+				<mac_address>ABCD012345670101</mac_address>
 				<permit_joining>false</permit_joining>
 				<neighbors><zig_bee_node id='4ac495040ae2462d832b15d00b245c0b'/><zig_bee_node id='8dbb5981239a41d1b7c39c6a85276c61'/><zig_bee_node id='91af9b4eb6b247909afab2b09cca821a'/><zig_bee_node id='972269fa494440d393dbdb8e5b0643b7'/><zig_bee_node id='c2f3ab78380a4ff3a1fbdd7638a67099'/><zig_bee_node id='ede18329ad24437d8d37222733789c7c'/></neighbors>
 				<zig_bee_nodes><zig_bee_node id='08ceb19506ee4546998f62381e867a8e'/><zig_bee_node id='0a85fd64b82246fbaac0a5c6e77ae958'/><zig_bee_node id='138298657dbd44ca9b8393b6a3cd86a8'/><zig_bee_node id='29f51d5cde66420facb975744d59f09c'/><zig_bee_node id='33e54459fdd54c22b3b99ae70a94d1c5'/><zig_bee_node id='4ac495040ae2462d832b15d00b245c0b'/><zig_bee_node id='59277b278b4c48a3889cd70378299ebb'/><zig_bee_node id='5cf439ab62eb48c3977ca41ac1d986ee'/><zig_bee_node id='8dbb5981239a41d1b7c39c6a85276c61'/><zig_bee_node id='8f06059e0cdc44038e9201fd8bfbea97'/><zig_bee_node id='91af9b4eb6b247909afab2b09cca821a'/><zig_bee_node id='954e187dd4924e6a92a109f41d844712'/><zig_bee_node id='96ce5e59e0474853bda4ee2794ed0da0'/><zig_bee_node id='972269fa494440d393dbdb8e5b0643b7'/><zig_bee_node id='9a0d6157588a43c9ae492a362cb71168'/><zig_bee_node id='a64db02a2fa243e0a9c00126ad1b1f7e'/><zig_bee_node id='b1d09b4fa20c4f1a98278709b3363eea'/><zig_bee_node id='c2f3ab78380a4ff3a1fbdd7638a67099'/><zig_bee_node id='e116d86377504e69bc8efb73988f11f8'/><zig_bee_node id='ede18329ad24437d8d37222733789c7c'/></zig_bee_nodes>
@@ -4108,7 +4108,7 @@
 		</services>
 		<protocols>
 			<zig_bee_node id='0a85fd64b82246fbaac0a5c6e77ae958'>
-				<mac_address>012345670A19</mac_address>
+				<mac_address>ABCD012345670A19</mac_address>
 				<type>router</type>
 				<reachable>false</reachable>
 				<power_source>mains</power_source>
@@ -4139,7 +4139,7 @@
 		</services>
 		<protocols>
 			<zig_bee_node id='c2f3ab78380a4ff3a1fbdd7638a67099'>
-				<mac_address>012345670A20</mac_address>
+				<mac_address>ABCD012345670A20</mac_address>
 				<type>router</type>
 				<reachable>true</reachable>
 				<power_source>mains</power_source>

--- a/userdata/adam_heatpump/modules.xml
+++ b/userdata/adam_heatpump/modules.xml
@@ -22,7 +22,7 @@
 		</services>
 		<protocols>
 			<zig_bee_node id='8dbb5981239a41d1b7c39c6a85276c61'>
-				<mac_address>012345670A05</mac_address>
+				<mac_address>ABCD012345670A05</mac_address>
 				<type>router</type>
 				<reachable>true</reachable>
 				<power_source>mains</power_source>
@@ -85,7 +85,7 @@
 		</services>
 		<protocols>
 			<zig_bee_node id='a64db02a2fa243e0a9c00126ad1b1f7e'>
-				<mac_address>012345670A06</mac_address>
+				<mac_address>ABCD012345670A06</mac_address>
 				<type>router</type>
 				<reachable>true</reachable>
 				<power_source>mains</power_source>
@@ -116,7 +116,7 @@
 		</services>
 		<protocols>
 			<zig_bee_node id='972269fa494440d393dbdb8e5b0643b7'>
-				<mac_address>012345670A07</mac_address>
+				<mac_address>ABCD012345670A07</mac_address>
 				<type>router</type>
 				<reachable>true</reachable>
 				<power_source>mains</power_source>
@@ -147,7 +147,7 @@
 		</services>
 		<protocols>
 			<zig_bee_node id='33e54459fdd54c22b3b99ae70a94d1c5'>
-				<mac_address>012345670A03</mac_address>
+				<mac_address>ABCD012345670A03</mac_address>
 				<type>router</type>
 				<reachable>true</reachable>
 				<power_source>mains</power_source>
@@ -167,7 +167,7 @@
 		<services/>
 		<protocols>
 			<zig_bee_coordinator id='d55765aedfdf47baa1e3cc6d2b2d6000'>
-				<mac_address>012345670101</mac_address>
+				<mac_address>ABCD012345670101</mac_address>
 				<permit_joining>false</permit_joining>
 				<neighbors><zig_bee_node id='4ac495040ae2462d832b15d00b245c0b'/><zig_bee_node id='8dbb5981239a41d1b7c39c6a85276c61'/><zig_bee_node id='91af9b4eb6b247909afab2b09cca821a'/><zig_bee_node id='972269fa494440d393dbdb8e5b0643b7'/><zig_bee_node id='c2f3ab78380a4ff3a1fbdd7638a67099'/><zig_bee_node id='ede18329ad24437d8d37222733789c7c'/></neighbors>
 				<zig_bee_nodes><zig_bee_node id='08ceb19506ee4546998f62381e867a8e'/><zig_bee_node id='0a85fd64b82246fbaac0a5c6e77ae958'/><zig_bee_node id='138298657dbd44ca9b8393b6a3cd86a8'/><zig_bee_node id='29f51d5cde66420facb975744d59f09c'/><zig_bee_node id='33e54459fdd54c22b3b99ae70a94d1c5'/><zig_bee_node id='4ac495040ae2462d832b15d00b245c0b'/><zig_bee_node id='59277b278b4c48a3889cd70378299ebb'/><zig_bee_node id='5cf439ab62eb48c3977ca41ac1d986ee'/><zig_bee_node id='8dbb5981239a41d1b7c39c6a85276c61'/><zig_bee_node id='8f06059e0cdc44038e9201fd8bfbea97'/><zig_bee_node id='91af9b4eb6b247909afab2b09cca821a'/><zig_bee_node id='954e187dd4924e6a92a109f41d844712'/><zig_bee_node id='96ce5e59e0474853bda4ee2794ed0da0'/><zig_bee_node id='972269fa494440d393dbdb8e5b0643b7'/><zig_bee_node id='9a0d6157588a43c9ae492a362cb71168'/><zig_bee_node id='a64db02a2fa243e0a9c00126ad1b1f7e'/><zig_bee_node id='b1d09b4fa20c4f1a98278709b3363eea'/><zig_bee_node id='c2f3ab78380a4ff3a1fbdd7638a67099'/><zig_bee_node id='e116d86377504e69bc8efb73988f11f8'/><zig_bee_node id='ede18329ad24437d8d37222733789c7c'/></zig_bee_nodes>
@@ -196,7 +196,7 @@
 		</services>
 		<protocols>
 			<zig_bee_node id='e116d86377504e69bc8efb73988f11f8'>
-				<mac_address>012345670A15</mac_address>
+				<mac_address>ABCD012345670A15</mac_address>
 				<type>router</type>
 				<reachable>true</reachable>
 				<power_source>mains</power_source>
@@ -227,7 +227,7 @@
 		</services>
 		<protocols>
 			<zig_bee_node id='59277b278b4c48a3889cd70378299ebb'>
-				<mac_address>012345670A12</mac_address>
+				<mac_address>ABCD012345670A12</mac_address>
 				<type>router</type>
 				<reachable>true</reachable>
 				<power_source>mains</power_source>
@@ -258,7 +258,7 @@
 		</services>
 		<protocols>
 			<zig_bee_node id='08ceb19506ee4546998f62381e867a8e'>
-				<mac_address>012345670A13</mac_address>
+				<mac_address>ABCD012345670A13</mac_address>
 				<type>router</type>
 				<reachable>true</reachable>
 				<power_source>mains</power_source>
@@ -292,7 +292,7 @@
 		</services>
 		<protocols>
 			<zig_bee_node id='9a0d6157588a43c9ae492a362cb71168'>
-				<mac_address>012345670A02</mac_address>
+				<mac_address>ABCD012345670A02</mac_address>
 				<type>end_device</type>
 				<reachable>true</reachable>
 				<power_source>battery</power_source>
@@ -386,7 +386,7 @@
 		</services>
 		<protocols>
 			<zig_bee_node id='138298657dbd44ca9b8393b6a3cd86a8'>
-				<mac_address>012345670A01</mac_address>
+				<mac_address>ABCD012345670A01</mac_address>
 				<type>router</type>
 				<reachable>true</reachable>
 				<power_source>mains</power_source>
@@ -571,7 +571,7 @@
 		</services>
 		<protocols>
 			<zig_bee_node id='954e187dd4924e6a92a109f41d844712'>
-				<mac_address>012345670A14</mac_address>
+				<mac_address>ABCD012345670A14</mac_address>
 				<type>router</type>
 				<reachable>true</reachable>
 				<power_source>mains</power_source>
@@ -602,7 +602,7 @@
 		</services>
 		<protocols>
 			<zig_bee_node id='91af9b4eb6b247909afab2b09cca821a'>
-				<mac_address>012345670A11</mac_address>
+				<mac_address>ABCD012345670A11</mac_address>
 				<type>router</type>
 				<reachable>true</reachable>
 				<power_source>mains</power_source>
@@ -633,7 +633,7 @@
 		</services>
 		<protocols>
 			<zig_bee_node id='8f06059e0cdc44038e9201fd8bfbea97'>
-				<mac_address>012345670A16</mac_address>
+				<mac_address>ABCD012345670A16</mac_address>
 				<type>router</type>
 				<reachable>true</reachable>
 				<power_source>mains</power_source>
@@ -664,7 +664,7 @@
 		</services>
 		<protocols>
 			<zig_bee_node id='5cf439ab62eb48c3977ca41ac1d986ee'>
-				<mac_address>012345670A10</mac_address>
+				<mac_address>ABCD012345670A10</mac_address>
 				<type>router</type>
 				<reachable>true</reachable>
 				<power_source>mains</power_source>
@@ -695,7 +695,7 @@
 		</services>
 		<protocols>
 			<zig_bee_node id='b1d09b4fa20c4f1a98278709b3363eea'>
-				<mac_address>012345670A09</mac_address>
+				<mac_address>ABCD012345670A09</mac_address>
 				<type>router</type>
 				<reachable>true</reachable>
 				<power_source>mains</power_source>
@@ -723,7 +723,7 @@
 		</services>
 		<protocols>
 			<zig_bee_node id='0a85fd64b82246fbaac0a5c6e77ae958'>
-				<mac_address>012345670A19</mac_address>
+				<mac_address>ABCD012345670A19</mac_address>
 				<type>router</type>
 				<reachable>false</reachable>
 				<power_source>mains</power_source>
@@ -754,7 +754,7 @@
 		</services>
 		<protocols>
 			<zig_bee_node id='4ac495040ae2462d832b15d00b245c0b'>
-				<mac_address>012345670A04</mac_address>
+				<mac_address>ABCD012345670A04</mac_address>
 				<type>router</type>
 				<reachable>true</reachable>
 				<power_source>mains</power_source>
@@ -785,7 +785,7 @@
 		</services>
 		<protocols>
 			<zig_bee_node id='ede18329ad24437d8d37222733789c7c'>
-				<mac_address>012345670A08</mac_address>
+				<mac_address>ABCD012345670A08</mac_address>
 				<type>router</type>
 				<reachable>true</reachable>
 				<power_source>mains</power_source>
@@ -819,7 +819,7 @@
 		</services>
 		<protocols>
 			<zig_bee_node id='96ce5e59e0474853bda4ee2794ed0da0'>
-				<mac_address>012345670A17</mac_address>
+				<mac_address>ABCD012345670A17</mac_address>
 				<type>end_device</type>
 				<reachable>true</reachable>
 				<power_source>battery</power_source>
@@ -850,7 +850,7 @@
 		</services>
 		<protocols>
 			<zig_bee_node id='29f51d5cde66420facb975744d59f09c'>
-				<mac_address>012345670A18</mac_address>
+				<mac_address>ABCD012345670A18</mac_address>
 				<type>router</type>
 				<reachable>true</reachable>
 				<power_source>mains</power_source>
@@ -881,7 +881,7 @@
 		</services>
 		<protocols>
 			<zig_bee_node id='c2f3ab78380a4ff3a1fbdd7638a67099'>
-				<mac_address>012345670A20</mac_address>
+				<mac_address>ABCD012345670A20</mac_address>
 				<type>router</type>
 				<reachable>true</reachable>
 				<power_source>mains</power_source>

--- a/userdata/adam_jip/core.domain_objects.xml
+++ b/userdata/adam_jip/core.domain_objects.xml
@@ -43,7 +43,7 @@
 		</services>
 		<protocols>
 			<zig_bee_node id='119b7672919748a0a47d6b1b3e4b6927'>
-				<mac_address>012345670A01</mac_address>
+				<mac_address>ABCD012345670A01</mac_address>
 				<type>end_device</type>
 				<reachable>true</reachable>
 				<power_source>battery</power_source>
@@ -183,7 +183,7 @@
 		</services>
 		<protocols>
 			<zig_bee_node id='9094202b9b77458ba6f540a71cfd465e'>
-				<mac_address>012345670A02</mac_address>
+				<mac_address>ABCD012345670A02</mac_address>
 				<type>end_device</type>
 				<reachable>true</reachable>
 				<power_source>battery</power_source>
@@ -203,7 +203,7 @@
 		<services/>
 		<protocols>
 			<zig_bee_coordinator id='b5f160ae0b4540c68860ee3782913ef7'>
-				<mac_address>012345670101</mac_address>
+				<mac_address>ABCD012345670101</mac_address>
 				<permit_joining>false</permit_joining>
 				<neighbors><zig_bee_node id='5feeb0ee0f904debb3129224ef4f551a'/><zig_bee_node id='c717b08831f34a2c950d6eaae4b4fa1a'/></neighbors>
 				<zig_bee_nodes><zig_bee_node id='119b7672919748a0a47d6b1b3e4b6927'/><zig_bee_node id='5efd1c1f4ad4495b8586abe20dc8d4c6'/><zig_bee_node id='5feeb0ee0f904debb3129224ef4f551a'/><zig_bee_node id='60268db6ba6e49f3a4b160185354daab'/><zig_bee_node id='9094202b9b77458ba6f540a71cfd465e'/><zig_bee_node id='b5ee8c0a3c1b457c9aadcedb8f5fc1dc'/><zig_bee_node id='b8275a11206745d19a66fb111e994d4d'/><zig_bee_node id='c717b08831f34a2c950d6eaae4b4fa1a'/><zig_bee_node id='e4db4ce80deb4219928279602b7fc482'/></zig_bee_nodes>
@@ -235,7 +235,7 @@
 		</services>
 		<protocols>
 			<zig_bee_node id='e4db4ce80deb4219928279602b7fc482'>
-				<mac_address>012345670A03</mac_address>
+				<mac_address>ABCD012345670A03</mac_address>
 				<type>end_device</type>
 				<reachable>true</reachable>
 				<power_source>battery</power_source>
@@ -483,7 +483,7 @@
 		</services>
 		<protocols>
 			<zig_bee_node id='b5ee8c0a3c1b457c9aadcedb8f5fc1dc'>
-				<mac_address>012345670A04</mac_address>
+				<mac_address>ABCD012345670A04</mac_address>
 				<type>router</type>
 				<reachable>true</reachable>
 				<power_source>mains</power_source>
@@ -650,7 +650,7 @@
 		</services>
 		<protocols>
 			<zig_bee_node id='5efd1c1f4ad4495b8586abe20dc8d4c6'>
-				<mac_address>012345670A05</mac_address>
+				<mac_address>ABCD012345670A05</mac_address>
 				<type>router</type>
 				<reachable>true</reachable>
 				<power_source>mains</power_source>
@@ -680,7 +680,7 @@
 		</services>
 		<protocols>
 			<zig_bee_node id='5feeb0ee0f904debb3129224ef4f551a'>
-				<mac_address>012345670A06</mac_address>
+				<mac_address>ABCD012345670A06</mac_address>
 				<type>router</type>
 				<reachable>true</reachable>
 				<power_source>mains</power_source>
@@ -857,7 +857,7 @@
 		</services>
 		<protocols>
 			<zig_bee_node id='60268db6ba6e49f3a4b160185354daab'>
-				<mac_address>012345670A07</mac_address>
+				<mac_address>ABCD012345670A07</mac_address>
 				<type>router</type>
 				<reachable>true</reachable>
 				<power_source>mains</power_source>
@@ -1327,7 +1327,7 @@
 		</services>
 		<protocols>
 			<zig_bee_node id='b8275a11206745d19a66fb111e994d4d'>
-				<mac_address>012345670A08</mac_address>
+				<mac_address>ABCD012345670A08</mac_address>
 				<type>end_device</type>
 				<reachable>true</reachable>
 				<power_source>battery</power_source>
@@ -2395,7 +2395,7 @@
 		</services>
 		<protocols>
 			<zig_bee_node id='c717b08831f34a2c950d6eaae4b4fa1a'>
-				<mac_address>012345670A09</mac_address>
+				<mac_address>ABCD012345670A09</mac_address>
 				<type>router</type>
 				<reachable>true</reachable>
 				<power_source>mains</power_source>

--- a/userdata/adam_jip/core.modules.xml
+++ b/userdata/adam_jip/core.modules.xml
@@ -177,7 +177,7 @@
 		</services>
 		<protocols>
 			<zig_bee_node id='5feeb0ee0f904debb3129224ef4f551a'>
-				<mac_address>012345670A06</mac_address>
+				<mac_address>ABCD012345670A06</mac_address>
 				<type>router</type>
 				<reachable>true</reachable>
 				<power_source>mains</power_source>
@@ -217,7 +217,7 @@
 		</services>
 		<protocols>
 			<zig_bee_node id='60268db6ba6e49f3a4b160185354daab'>
-				<mac_address>012345670A07</mac_address>
+				<mac_address>ABCD012345670A07</mac_address>
 				<type>router</type>
 				<reachable>true</reachable>
 				<power_source>mains</power_source>
@@ -314,7 +314,7 @@
 		</services>
 		<protocols>
 			<zig_bee_node id='119b7672919748a0a47d6b1b3e4b6927'>
-				<mac_address>012345670A01</mac_address>
+				<mac_address>ABCD012345670A01</mac_address>
 				<type>end_device</type>
 				<reachable>true</reachable>
 				<power_source>battery</power_source>
@@ -354,7 +354,7 @@
 		</services>
 		<protocols>
 			<zig_bee_node id='b5ee8c0a3c1b457c9aadcedb8f5fc1dc'>
-				<mac_address>012345670A04</mac_address>
+				<mac_address>ABCD012345670A04</mac_address>
 				<type>router</type>
 				<reachable>true</reachable>
 				<power_source>mains</power_source>
@@ -390,7 +390,7 @@
 		</services>
 		<protocols>
 			<zig_bee_node id='9094202b9b77458ba6f540a71cfd465e'>
-				<mac_address>012345670A02</mac_address>
+				<mac_address>ABCD012345670A02</mac_address>
 				<type>end_device</type>
 				<reachable>true</reachable>
 				<power_source>battery</power_source>
@@ -410,7 +410,7 @@
 		<services/>
 		<protocols>
 			<zig_bee_coordinator id='b5f160ae0b4540c68860ee3782913ef7'>
-				<mac_address>012345670101</mac_address>
+				<mac_address>ABCD012345670101</mac_address>
 				<permit_joining>false</permit_joining>
 				<neighbors><zig_bee_node id='5feeb0ee0f904debb3129224ef4f551a'/><zig_bee_node id='c717b08831f34a2c950d6eaae4b4fa1a'/></neighbors>
 				<zig_bee_nodes><zig_bee_node id='119b7672919748a0a47d6b1b3e4b6927'/><zig_bee_node id='5efd1c1f4ad4495b8586abe20dc8d4c6'/><zig_bee_node id='5feeb0ee0f904debb3129224ef4f551a'/><zig_bee_node id='60268db6ba6e49f3a4b160185354daab'/><zig_bee_node id='9094202b9b77458ba6f540a71cfd465e'/><zig_bee_node id='b5ee8c0a3c1b457c9aadcedb8f5fc1dc'/><zig_bee_node id='b8275a11206745d19a66fb111e994d4d'/><zig_bee_node id='c717b08831f34a2c950d6eaae4b4fa1a'/><zig_bee_node id='e4db4ce80deb4219928279602b7fc482'/></zig_bee_nodes>
@@ -448,7 +448,7 @@
 		</services>
 		<protocols>
 			<zig_bee_node id='5efd1c1f4ad4495b8586abe20dc8d4c6'>
-				<mac_address>012345670A05</mac_address>
+				<mac_address>ABCD012345670A05</mac_address>
 				<type>router</type>
 				<reachable>true</reachable>
 				<power_source>mains</power_source>
@@ -484,7 +484,7 @@
 		</services>
 		<protocols>
 			<zig_bee_node id='e4db4ce80deb4219928279602b7fc482'>
-				<mac_address>012345670A03</mac_address>
+				<mac_address>ABCD012345670A03</mac_address>
 				<type>end_device</type>
 				<reachable>true</reachable>
 				<power_source>battery</power_source>
@@ -548,7 +548,7 @@
 		</services>
 		<protocols>
 			<zig_bee_node id='c717b08831f34a2c950d6eaae4b4fa1a'>
-				<mac_address>012345670A09</mac_address>
+				<mac_address>ABCD012345670A09</mac_address>
 				<type>router</type>
 				<reachable>true</reachable>
 				<power_source>mains</power_source>
@@ -587,7 +587,7 @@
 		</services>
 		<protocols>
 			<zig_bee_node id='b8275a11206745d19a66fb111e994d4d'>
-				<mac_address>012345670A08</mac_address>
+				<mac_address>ABCD012345670A08</mac_address>
 				<type>end_device</type>
 				<reachable>true</reachable>
 				<power_source>battery</power_source>

--- a/userdata/adam_multiple_devices_per_zone/core.domain_objects.xml
+++ b/userdata/adam_multiple_devices_per_zone/core.domain_objects.xml
@@ -34,7 +34,7 @@
 		</services>
 		<protocols>
 			<zig_bee_node id='04ed662277f045b288312eb607b2c234'>
-				<mac_address>012345670A01</mac_address>
+				<mac_address>ABCD012345670A01</mac_address>
 				<type>router</type>
 				<reachable>true</reachable>
 				<power_source>mains</power_source>
@@ -377,7 +377,7 @@
 		</services>
 		<protocols>
 			<zig_bee_node id='0af3463d7dec46408244e48c7df0914d'>
-				<mac_address>012345670A02</mac_address>
+				<mac_address>ABCD012345670A02</mac_address>
 				<type>router</type>
 				<reachable>true</reachable>
 				<power_source>mains</power_source>
@@ -579,7 +579,7 @@
 		</services>
 		<protocols>
 			<zig_bee_node id='9468211aeaf340aab36c58624ce8abfe'>
-				<mac_address>012345670A03</mac_address>
+				<mac_address>ABCD012345670A03</mac_address>
 				<type>end_device</type>
 				<reachable>true</reachable>
 				<power_source>battery</power_source>
@@ -630,7 +630,7 @@
 		</services>
 		<protocols>
 			<zig_bee_node id='9f6a2117b2164257845422183d832caa'>
-				<mac_address>012345670A04</mac_address>
+				<mac_address>ABCD012345670A04</mac_address>
 				<type>router</type>
 				<reachable>false</reachable>
 				<power_source>mains</power_source>
@@ -771,7 +771,7 @@
 		</services>
 		<protocols>
 			<zig_bee_node id='6326dbad401e4745a31cce1650b29851'>
-				<mac_address>012345670A05</mac_address>
+				<mac_address>ABCD012345670A05</mac_address>
 				<type>router</type>
 				<reachable>true</reachable>
 				<power_source>mains</power_source>
@@ -876,7 +876,7 @@
 		</services>
 		<protocols>
 			<zig_bee_node id='6a5ccc5908ba4308996b79751aca45b2'>
-				<mac_address>012345670A06</mac_address>
+				<mac_address>ABCD012345670A06</mac_address>
 				<type>end_device</type>
 				<reachable>true</reachable>
 				<power_source>battery</power_source>
@@ -997,7 +997,7 @@
 		</services>
 		<protocols>
 			<zig_bee_node id='b9425487affb4cf687461eb4be8ff15e'>
-				<mac_address>012345670A07</mac_address>
+				<mac_address>ABCD012345670A07</mac_address>
 				<type>end_device</type>
 				<reachable>true</reachable>
 				<power_source>battery</power_source>
@@ -1043,7 +1043,7 @@
 		</services>
 		<protocols>
 			<zig_bee_node id='d0ab902b286147b3a3aa130789e1fddd'>
-				<mac_address>012345670A08</mac_address>
+				<mac_address>ABCD012345670A08</mac_address>
 				<type>end_device</type>
 				<reachable>true</reachable>
 				<power_source>battery</power_source>
@@ -1098,7 +1098,7 @@
 		</services>
 		<protocols>
 			<zig_bee_node id='1314db193c454638940d8f9629f588ca'>
-				<mac_address>012345670A09</mac_address>
+				<mac_address>ABCD012345670A09</mac_address>
 				<type>end_device</type>
 				<reachable>true</reachable>
 				<power_source>battery</power_source>
@@ -1408,7 +1408,7 @@
 		</services>
 		<protocols>
 			<zig_bee_node id='65dd9860b14b4813879658b5fcd8c236'>
-				<mac_address>012345670A10</mac_address>
+				<mac_address>ABCD012345670A10</mac_address>
 				<type>end_device</type>
 				<reachable>true</reachable>
 				<power_source>battery</power_source>
@@ -1754,7 +1754,7 @@
 		</services>
 		<protocols>
 			<zig_bee_node id='416c77c0526149b1938bb6c4e67dbd83'>
-				<mac_address>012345670A11</mac_address>
+				<mac_address>ABCD012345670A11</mac_address>
 				<type>end_device</type>
 				<reachable>true</reachable>
 				<power_source>battery</power_source>
@@ -1855,7 +1855,7 @@
 		<services/>
 		<protocols>
 			<zig_bee_coordinator id='547bdc305c3a47a58fa9f5f170ca3fc2'>
-				<mac_address>012345670101</mac_address>
+				<mac_address>ABCD012345670101</mac_address>
 				<permit_joining>false</permit_joining>
 				<neighbors><zig_bee_node id='0af3463d7dec46408244e48c7df0914d'/><zig_bee_node id='0c09007091e149dba4b8cc465a9e1bd9'/><zig_bee_node id='1b6b24fc75b74c12b97e65d1f60c2dfc'/><zig_bee_node id='416c77c0526149b1938bb6c4e67dbd83'/><zig_bee_node id='4788d5fbffc84aacbcd91b1abab8ff90'/><zig_bee_node id='56ce8175cbaa4ee886015bfa09373dff'/><zig_bee_node id='6326dbad401e4745a31cce1650b29851'/><zig_bee_node id='9abefede88bf4ea9acc3ad0638cddfaf'/><zig_bee_node id='9f6a2117b2164257845422183d832caa'/><zig_bee_node id='b9425487affb4cf687461eb4be8ff15e'/></neighbors>
 				<zig_bee_nodes><zig_bee_node id='04ed662277f045b288312eb607b2c234'/><zig_bee_node id='0af3463d7dec46408244e48c7df0914d'/><zig_bee_node id='0c09007091e149dba4b8cc465a9e1bd9'/><zig_bee_node id='1314db193c454638940d8f9629f588ca'/><zig_bee_node id='1b6b24fc75b74c12b97e65d1f60c2dfc'/><zig_bee_node id='2202545a9c764e56afead1f729f8b1de'/><zig_bee_node id='416c77c0526149b1938bb6c4e67dbd83'/><zig_bee_node id='4788d5fbffc84aacbcd91b1abab8ff90'/><zig_bee_node id='56ce8175cbaa4ee886015bfa09373dff'/><zig_bee_node id='6326dbad401e4745a31cce1650b29851'/><zig_bee_node id='65dd9860b14b4813879658b5fcd8c236'/><zig_bee_node id='6a5ccc5908ba4308996b79751aca45b2'/><zig_bee_node id='9468211aeaf340aab36c58624ce8abfe'/><zig_bee_node id='9abefede88bf4ea9acc3ad0638cddfaf'/><zig_bee_node id='9f6a2117b2164257845422183d832caa'/><zig_bee_node id='b9425487affb4cf687461eb4be8ff15e'/><zig_bee_node id='d0ab902b286147b3a3aa130789e1fddd'/></zig_bee_nodes>
@@ -1927,7 +1927,7 @@
 		</services>
 		<protocols>
 			<zig_bee_node id='4788d5fbffc84aacbcd91b1abab8ff90'>
-				<mac_address>012345670A12</mac_address>
+				<mac_address>ABCD012345670A12</mac_address>
 				<type>router</type>
 				<reachable>true</reachable>
 				<power_source>mains</power_source>
@@ -2997,7 +2997,7 @@
 		</services>
 		<protocols>
 			<zig_bee_node id='1b6b24fc75b74c12b97e65d1f60c2dfc'>
-				<mac_address>012345670A13</mac_address>
+				<mac_address>ABCD012345670A13</mac_address>
 				<type>router</type>
 				<reachable>true</reachable>
 				<power_source>mains</power_source>
@@ -3048,7 +3048,7 @@
 		</services>
 		<protocols>
 			<zig_bee_node id='0c09007091e149dba4b8cc465a9e1bd9'>
-				<mac_address>012345670A14</mac_address>
+				<mac_address>ABCD012345670A14</mac_address>
 				<type>router</type>
 				<reachable>true</reachable>
 				<power_source>mains</power_source>
@@ -3099,7 +3099,7 @@
 		</services>
 		<protocols>
 			<zig_bee_node id='56ce8175cbaa4ee886015bfa09373dff'>
-				<mac_address>012345670A15</mac_address>
+				<mac_address>ABCD012345670A15</mac_address>
 				<type>router</type>
 				<reachable>true</reachable>
 				<power_source>mains</power_source>
@@ -3129,7 +3129,7 @@
 		</services>
 		<protocols>
 			<zig_bee_node id='2202545a9c764e56afead1f729f8b1de'>
-				<mac_address>012345670A16</mac_address>
+				<mac_address>ABCD012345670A16</mac_address>
 				<type>router</type>
 				<reachable>true</reachable>
 				<power_source>mains</power_source>
@@ -3408,7 +3408,7 @@
 		</services>
 		<protocols>
 			<zig_bee_node id='9abefede88bf4ea9acc3ad0638cddfaf'>
-				<mac_address>012345670A17</mac_address>
+				<mac_address>ABCD012345670A17</mac_address>
 				<type>end_device</type>
 				<reachable>true</reachable>
 				<power_source>battery</power_source>

--- a/userdata/adam_multiple_devices_per_zone/core.modules.xml
+++ b/userdata/adam_multiple_devices_per_zone/core.modules.xml
@@ -24,7 +24,7 @@
 		</services>
 		<protocols>
 			<zig_bee_node id='9468211aeaf340aab36c58624ce8abfe'>
-				<mac_address>012345670A03</mac_address>
+				<mac_address>ABCD012345670A03</mac_address>
 				<type>end_device</type>
 				<reachable>true</reachable>
 				<power_source>battery</power_source>
@@ -66,7 +66,7 @@
 		</services>
 		<protocols>
 			<zig_bee_node id='1314db193c454638940d8f9629f588ca'>
-				<mac_address>012345670A09</mac_address>
+				<mac_address>ABCD012345670A09</mac_address>
 				<type>end_device</type>
 				<reachable>true</reachable>
 				<power_source>battery</power_source>
@@ -123,7 +123,7 @@
 		</services>
 		<protocols>
 			<zig_bee_node id='9f6a2117b2164257845422183d832caa'>
-				<mac_address>012345670A04</mac_address>
+				<mac_address>ABCD012345670A04</mac_address>
 				<type>router</type>
 				<reachable>false</reachable>
 				<power_source>mains</power_source>
@@ -166,7 +166,7 @@
 		</services>
 		<protocols>
 			<zig_bee_node id='65dd9860b14b4813879658b5fcd8c236'>
-				<mac_address>012345670A10</mac_address>
+				<mac_address>ABCD012345670A10</mac_address>
 				<type>end_device</type>
 				<reachable>true</reachable>
 				<power_source>battery</power_source>
@@ -212,7 +212,7 @@
 		</services>
 		<protocols>
 			<zig_bee_node id='0c09007091e149dba4b8cc465a9e1bd9'>
-				<mac_address>012345670A14</mac_address>
+				<mac_address>ABCD012345670A14</mac_address>
 				<type>router</type>
 				<reachable>true</reachable>
 				<power_source>mains</power_source>
@@ -242,7 +242,7 @@
 		</services>
 		<protocols>
 			<zig_bee_node id='6326dbad401e4745a31cce1650b29851'>
-				<mac_address>012345670A05</mac_address>
+				<mac_address>ABCD012345670A05</mac_address>
 				<type>router</type>
 				<reachable>true</reachable>
 				<power_source>mains</power_source>
@@ -314,7 +314,7 @@
 		</services>
 		<protocols>
 			<zig_bee_node id='416c77c0526149b1938bb6c4e67dbd83'>
-				<mac_address>012345670A11</mac_address>
+				<mac_address>ABCD012345670A11</mac_address>
 				<type>end_device</type>
 				<reachable>true</reachable>
 				<power_source>battery</power_source>
@@ -344,7 +344,7 @@
 		</services>
 		<protocols>
 			<zig_bee_node id='2202545a9c764e56afead1f729f8b1de'>
-				<mac_address>012345670A16</mac_address>
+				<mac_address>ABCD012345670A16</mac_address>
 				<type>router</type>
 				<reachable>true</reachable>
 				<power_source>mains</power_source>
@@ -377,7 +377,7 @@
 		</services>
 		<protocols>
 			<zig_bee_node id='6a5ccc5908ba4308996b79751aca45b2'>
-				<mac_address>012345670A06</mac_address>
+				<mac_address>ABCD012345670A06</mac_address>
 				<type>end_device</type>
 				<reachable>true</reachable>
 				<power_source>battery</power_source>
@@ -463,7 +463,7 @@
 		</services>
 		<protocols>
 			<zig_bee_node id='0af3463d7dec46408244e48c7df0914d'>
-				<mac_address>012345670A02</mac_address>
+				<mac_address>ABCD012345670A02</mac_address>
 				<type>router</type>
 				<reachable>true</reachable>
 				<power_source>mains</power_source>
@@ -493,7 +493,7 @@
 		</services>
 		<protocols>
 			<zig_bee_node id='4788d5fbffc84aacbcd91b1abab8ff90'>
-				<mac_address>012345670A12</mac_address>
+				<mac_address>ABCD012345670A12</mac_address>
 				<type>router</type>
 				<reachable>true</reachable>
 				<power_source>mains</power_source>
@@ -523,7 +523,7 @@
 		</services>
 		<protocols>
 			<zig_bee_node id='1b6b24fc75b74c12b97e65d1f60c2dfc'>
-				<mac_address>012345670A13</mac_address>
+				<mac_address>ABCD012345670A13</mac_address>
 				<type>router</type>
 				<reachable>true</reachable>
 				<power_source>mains</power_source>
@@ -590,7 +590,7 @@
 		</services>
 		<protocols>
 			<zig_bee_node id='9abefede88bf4ea9acc3ad0638cddfaf'>
-				<mac_address>012345670A17</mac_address>
+				<mac_address>ABCD012345670A17</mac_address>
 				<type>end_device</type>
 				<reachable>true</reachable>
 				<power_source>battery</power_source>
@@ -623,7 +623,7 @@
 		</services>
 		<protocols>
 			<zig_bee_node id='b9425487affb4cf687461eb4be8ff15e'>
-				<mac_address>012345670A07</mac_address>
+				<mac_address>ABCD012345670A07</mac_address>
 				<type>end_device</type>
 				<reachable>true</reachable>
 				<power_source>battery</power_source>
@@ -643,7 +643,7 @@
 		<services/>
 		<protocols>
 			<zig_bee_coordinator id='547bdc305c3a47a58fa9f5f170ca3fc2'>
-				<mac_address>012345670101</mac_address>
+				<mac_address>ABCD012345670101</mac_address>
 				<permit_joining>false</permit_joining>
 				<neighbors><zig_bee_node id='0af3463d7dec46408244e48c7df0914d'/><zig_bee_node id='0c09007091e149dba4b8cc465a9e1bd9'/><zig_bee_node id='1b6b24fc75b74c12b97e65d1f60c2dfc'/><zig_bee_node id='416c77c0526149b1938bb6c4e67dbd83'/><zig_bee_node id='4788d5fbffc84aacbcd91b1abab8ff90'/><zig_bee_node id='56ce8175cbaa4ee886015bfa09373dff'/><zig_bee_node id='6326dbad401e4745a31cce1650b29851'/><zig_bee_node id='9abefede88bf4ea9acc3ad0638cddfaf'/><zig_bee_node id='9f6a2117b2164257845422183d832caa'/><zig_bee_node id='b9425487affb4cf687461eb4be8ff15e'/></neighbors>
 				<zig_bee_nodes><zig_bee_node id='04ed662277f045b288312eb607b2c234'/><zig_bee_node id='0af3463d7dec46408244e48c7df0914d'/><zig_bee_node id='0c09007091e149dba4b8cc465a9e1bd9'/><zig_bee_node id='1314db193c454638940d8f9629f588ca'/><zig_bee_node id='1b6b24fc75b74c12b97e65d1f60c2dfc'/><zig_bee_node id='2202545a9c764e56afead1f729f8b1de'/><zig_bee_node id='416c77c0526149b1938bb6c4e67dbd83'/><zig_bee_node id='4788d5fbffc84aacbcd91b1abab8ff90'/><zig_bee_node id='56ce8175cbaa4ee886015bfa09373dff'/><zig_bee_node id='6326dbad401e4745a31cce1650b29851'/><zig_bee_node id='65dd9860b14b4813879658b5fcd8c236'/><zig_bee_node id='6a5ccc5908ba4308996b79751aca45b2'/><zig_bee_node id='9468211aeaf340aab36c58624ce8abfe'/><zig_bee_node id='9abefede88bf4ea9acc3ad0638cddfaf'/><zig_bee_node id='9f6a2117b2164257845422183d832caa'/><zig_bee_node id='b9425487affb4cf687461eb4be8ff15e'/><zig_bee_node id='d0ab902b286147b3a3aa130789e1fddd'/></zig_bee_nodes>
@@ -671,7 +671,7 @@
 		</services>
 		<protocols>
 			<zig_bee_node id='56ce8175cbaa4ee886015bfa09373dff'>
-				<mac_address>012345670A15</mac_address>
+				<mac_address>ABCD012345670A15</mac_address>
 				<type>router</type>
 				<reachable>true</reachable>
 				<power_source>mains</power_source>
@@ -701,7 +701,7 @@
 		</services>
 		<protocols>
 			<zig_bee_node id='04ed662277f045b288312eb607b2c234'>
-				<mac_address>012345670A01</mac_address>
+				<mac_address>ABCD012345670A01</mac_address>
 				<type>router</type>
 				<reachable>true</reachable>
 				<power_source>mains</power_source>
@@ -734,7 +734,7 @@
 		</services>
 		<protocols>
 			<zig_bee_node id='d0ab902b286147b3a3aa130789e1fddd'>
-				<mac_address>012345670A08</mac_address>
+				<mac_address>ABCD012345670A08</mac_address>
 				<type>end_device</type>
 				<reachable>true</reachable>
 				<power_source>battery</power_source>

--- a/userdata/adam_plus_anna/core.domain_objects.xml
+++ b/userdata/adam_plus_anna/core.domain_objects.xml
@@ -21,7 +21,7 @@
 		</services>
 		<protocols>
 			<zig_bee_node id='9ca5df0038564aeeb59709ab3de23f97'>
-				<mac_address>012345670A01</mac_address>
+				<mac_address>ABCD012345670A01</mac_address>
 				<type>router</type>
 				<reachable>true</reachable>
 				<power_source>mains</power_source>
@@ -127,7 +127,7 @@
 		</services>
 		<protocols>
 			<zig_bee_node id='87f66dac0b92499897598c95fe55286e'>
-				<mac_address>012345670A02</mac_address>
+				<mac_address>ABCD012345670A02</mac_address>
 				<type>router</type>
 				<reachable>true</reachable>
 				<power_source>mains</power_source>
@@ -1272,7 +1272,7 @@
 		<services/>
 		<protocols>
 			<zig_bee_coordinator id='fcd3478dede94c5c87b5ea39a3404708'>
-				<mac_address>012345670101</mac_address>
+				<mac_address>ABCD012345670101</mac_address>
 				<permit_joining>false</permit_joining>
 				<neighbors><zig_bee_node id='87f66dac0b92499897598c95fe55286e'/><zig_bee_node id='9ca5df0038564aeeb59709ab3de23f97'/></neighbors>
 				<zig_bee_nodes><zig_bee_node id='87f66dac0b92499897598c95fe55286e'/><zig_bee_node id='9ca5df0038564aeeb59709ab3de23f97'/></zig_bee_nodes>

--- a/userdata/adam_plus_anna/core.modules.xml
+++ b/userdata/adam_plus_anna/core.modules.xml
@@ -136,7 +136,7 @@
 		</services>
 		<protocols>
 			<zig_bee_node id='9ca5df0038564aeeb59709ab3de23f97'>
-				<mac_address>012345670A01</mac_address>
+				<mac_address>ABCD012345670A01</mac_address>
 				<type>router</type>
 				<reachable>true</reachable>
 				<power_source>mains</power_source>
@@ -232,7 +232,7 @@
 		<services/>
 		<protocols>
 			<zig_bee_coordinator id='fcd3478dede94c5c87b5ea39a3404708'>
-				<mac_address>012345670101</mac_address>
+				<mac_address>ABCD012345670101</mac_address>
 				<permit_joining>false</permit_joining>
 				<neighbors><zig_bee_node id='87f66dac0b92499897598c95fe55286e'/><zig_bee_node id='9ca5df0038564aeeb59709ab3de23f97'/></neighbors>
 				<zig_bee_nodes><zig_bee_node id='87f66dac0b92499897598c95fe55286e'/><zig_bee_node id='9ca5df0038564aeeb59709ab3de23f97'/></zig_bee_nodes>
@@ -260,7 +260,7 @@
 		</services>
 		<protocols>
 			<zig_bee_node id='87f66dac0b92499897598c95fe55286e'>
-				<mac_address>012345670A02</mac_address>
+				<mac_address>ABCD012345670A02</mac_address>
 				<type>router</type>
 				<reachable>true</reachable>
 				<power_source>mains</power_source>

--- a/userdata/adam_plus_anna_new/core.domain_objects.xml
+++ b/userdata/adam_plus_anna_new/core.domain_objects.xml
@@ -34,7 +34,7 @@
 		</services>
 		<protocols>
 			<zig_bee_node id='877114bc3e864b0fa40f22a1f4c6f55f'>
-				<mac_address>012345670A01</mac_address>
+				<mac_address>ABCD012345670A01</mac_address>
 				<type>end_device</type>
 				<reachable>true</reachable>
 				<power_source>battery</power_source>
@@ -738,7 +738,7 @@
 		</services>
 		<protocols>
 			<zig_bee_node id='83886db4bd684d19b7b1faf50c5361fa'>
-				<mac_address>012345670A02</mac_address>
+				<mac_address>ABCD012345670A02</mac_address>
 				<type>router</type>
 				<reachable>true</reachable>
 				<power_source>mains</power_source>
@@ -1148,7 +1148,7 @@
 		</services>
 		<protocols>
 			<zig_bee_node id='53819792a4164090863f6f2eed3d9a5e'>
-				<mac_address>012345670A03</mac_address>
+				<mac_address>ABCD012345670A03</mac_address>
 				<type>router</type>
 				<reachable>true</reachable>
 				<power_source>mains</power_source>
@@ -1554,7 +1554,7 @@
 		</services>
 		<protocols>
 			<zig_bee_node id='25a6e7a5583945048c127dfc00542423'>
-				<mac_address>012345670A04</mac_address>
+				<mac_address>ABCD012345670A04</mac_address>
 				<type>end_device</type>
 				<reachable>true</reachable>
 				<power_source>battery</power_source>
@@ -1727,7 +1727,7 @@
 		<services/>
 		<protocols>
 			<zig_bee_coordinator id='822b55485e1e444d9e74131b2564ae71'>
-				<mac_address>012345670101</mac_address>
+				<mac_address>ABCD012345670101</mac_address>
 				<permit_joining>false</permit_joining>
 				<neighbors>
 					<neighbor mac_address='0123456789AB'>
@@ -1800,7 +1800,7 @@
 		</services>
 		<protocols>
 			<zig_bee_node id='73576be0ca0c40309009de47239adee0'>
-				<mac_address>012345670A05</mac_address>
+				<mac_address>ABCD012345670A05</mac_address>
 				<type>router</type>
 				<reachable>true</reachable>
 				<power_source>mains</power_source>

--- a/userdata/adam_plus_anna_new/core.modules.xml
+++ b/userdata/adam_plus_anna_new/core.modules.xml
@@ -58,7 +58,7 @@
 		</services>
 		<protocols>
 			<zig_bee_node id='877114bc3e864b0fa40f22a1f4c6f55f'>
-				<mac_address>012345670A01</mac_address>
+				<mac_address>ABCD012345670A01</mac_address>
 				<type>end_device</type>
 				<reachable>true</reachable>
 				<power_source>battery</power_source>
@@ -123,7 +123,7 @@
 		<services/>
 		<protocols>
 			<zig_bee_coordinator id='822b55485e1e444d9e74131b2564ae71'>
-				<mac_address>012345670101</mac_address>
+				<mac_address>ABCD012345670101</mac_address>
 				<permit_joining>false</permit_joining>
 				<neighbors>
 					<neighbor mac_address='0123456789AB'>
@@ -175,7 +175,7 @@
 		</services>
 		<protocols>
 			<zig_bee_node id='83886db4bd684d19b7b1faf50c5361fa'>
-				<mac_address>012345670A02</mac_address>
+				<mac_address>ABCD012345670A02</mac_address>
 				<type>router</type>
 				<reachable>true</reachable>
 				<power_source>mains</power_source>
@@ -253,7 +253,7 @@
 		</services>
 		<protocols>
 			<zig_bee_node id='73576be0ca0c40309009de47239adee0'>
-				<mac_address>012345670A05</mac_address>
+				<mac_address>ABCD012345670A05</mac_address>
 				<type>router</type>
 				<reachable>true</reachable>
 				<power_source>mains</power_source>
@@ -305,7 +305,7 @@
 		</services>
 		<protocols>
 			<zig_bee_node id='25a6e7a5583945048c127dfc00542423'>
-				<mac_address>012345670A04</mac_address>
+				<mac_address>ABCD012345670A04</mac_address>
 				<type>end_device</type>
 				<reachable>true</reachable>
 				<power_source>battery</power_source>
@@ -370,7 +370,7 @@
 		</services>
 		<protocols>
 			<zig_bee_node id='53819792a4164090863f6f2eed3d9a5e'>
-				<mac_address>012345670A03</mac_address>
+				<mac_address>ABCD012345670A03</mac_address>
 				<type>router</type>
 				<reachable>true</reachable>
 				<power_source>mains</power_source>

--- a/userdata/adam_plus_anna_new_copy_cooling/core.domain_objects.xml
+++ b/userdata/adam_plus_anna_new_copy_cooling/core.domain_objects.xml
@@ -11,7 +11,7 @@
 		<services/>
 		<protocols>
 			<zig_bee_coordinator id='fcd3478dede94c5c87b5ea39a3404708'>
-				<mac_address>012345670101</mac_address>
+				<mac_address>ABCD012345670101</mac_address>
 				<permit_joining>false</permit_joining>
 				<neighbors><zig_bee_node id='0374084c2e2843f19688e289235859ce'/><zig_bee_node id='87f66dac0b92499897598c95fe55286e'/><zig_bee_node id='9074cd5161764e8eb0261d5ba99a0428'/><zig_bee_node id='9ca5df0038564aeeb59709ab3de23f97'/><zig_bee_node id='a7c4a564cd4943a1ab9eee428270b2ae'/></neighbors>
 				<zig_bee_nodes><zig_bee_node id='0374084c2e2843f19688e289235859ce'/><zig_bee_node id='87f66dac0b92499897598c95fe55286e'/><zig_bee_node id='9074cd5161764e8eb0261d5ba99a0428'/><zig_bee_node id='9ca5df0038564aeeb59709ab3de23f97'/><zig_bee_node id='a7c4a564cd4943a1ab9eee428270b2ae'/></zig_bee_nodes>
@@ -81,7 +81,7 @@
 		</services>
 		<protocols>
 			<zig_bee_node id='9074cd5161764e8eb0261d5ba99a0428'>
-				<mac_address>012345670A01</mac_address>
+				<mac_address>ABCD012345670A01</mac_address>
 				<type>end_device</type>
 				<reachable>true</reachable>
 				<power_source>battery</power_source>
@@ -219,7 +219,7 @@
 		</services>
 		<protocols>
 			<zig_bee_node id='0374084c2e2843f19688e289235859ce'>
-				<mac_address>012345670A02</mac_address>
+				<mac_address>ABCD012345670A02</mac_address>
 				<type>end_device</type>
 				<reachable>true</reachable>
 				<power_source>battery</power_source>
@@ -350,7 +350,7 @@
 		</services>
 		<protocols>
 			<zig_bee_node id='87f66dac0b92499897598c95fe55286e'>
-				<mac_address>012345670A03</mac_address>
+				<mac_address>ABCD012345670A03</mac_address>
 				<type>router</type>
 				<reachable>true</reachable>
 				<power_source>mains</power_source>
@@ -590,7 +590,7 @@
 		</services>
 		<protocols>
 			<zig_bee_node id='9ca5df0038564aeeb59709ab3de23f97'>
-				<mac_address>012345670A04</mac_address>
+				<mac_address>ABCD012345670A04</mac_address>
 				<type>router</type>
 				<reachable>true</reachable>
 				<power_source>mains</power_source>
@@ -1580,7 +1580,7 @@
 		</services>
 		<protocols>
 			<zig_bee_node id='a7c4a564cd4943a1ab9eee428270b2ae'>
-				<mac_address>012345670A05</mac_address>
+				<mac_address>ABCD012345670A05</mac_address>
 				<type>router</type>
 				<reachable>true</reachable>
 				<power_source>mains</power_source>

--- a/userdata/adam_plus_anna_new_copy_cooling/core.modules.xml
+++ b/userdata/adam_plus_anna_new_copy_cooling/core.modules.xml
@@ -11,7 +11,7 @@
 		<services/>
 		<protocols>
 			<zig_bee_coordinator id='fcd3478dede94c5c87b5ea39a3404708'>
-				<mac_address>012345670101</mac_address>
+				<mac_address>ABCD012345670101</mac_address>
 				<permit_joining>false</permit_joining>
 				<neighbors><zig_bee_node id='0374084c2e2843f19688e289235859ce'/><zig_bee_node id='9074cd5161764e8eb0261d5ba99a0428'/><zig_bee_node id='9ca5df0038564aeeb59709ab3de23f97'/><zig_bee_node id='a7c4a564cd4943a1ab9eee428270b2ae'/></neighbors>
 				<zig_bee_nodes><zig_bee_node id='0374084c2e2843f19688e289235859ce'/><zig_bee_node id='87f66dac0b92499897598c95fe55286e'/><zig_bee_node id='9074cd5161764e8eb0261d5ba99a0428'/><zig_bee_node id='9ca5df0038564aeeb59709ab3de23f97'/><zig_bee_node id='a7c4a564cd4943a1ab9eee428270b2ae'/></zig_bee_nodes>
@@ -81,7 +81,7 @@
 		</services>
 		<protocols>
 			<zig_bee_node id='9074cd5161764e8eb0261d5ba99a0428'>
-				<mac_address>012345670A01</mac_address>
+				<mac_address>ABCD012345670A01</mac_address>
 				<type>end_device</type>
 				<reachable>true</reachable>
 				<power_source>battery</power_source>
@@ -114,7 +114,7 @@
 		</services>
 		<protocols>
 			<zig_bee_node id='9ca5df0038564aeeb59709ab3de23f97'>
-				<mac_address>012345670A04</mac_address>
+				<mac_address>ABCD012345670A04</mac_address>
 				<type>router</type>
 				<reachable>true</reachable>
 				<power_source>mains</power_source>
@@ -145,7 +145,7 @@
 		</services>
 		<protocols>
 			<zig_bee_node id='87f66dac0b92499897598c95fe55286e'>
-				<mac_address>012345670A03</mac_address>
+				<mac_address>ABCD012345670A03</mac_address>
 				<type>router</type>
 				<reachable>false</reachable>
 				<power_source>mains</power_source>
@@ -179,7 +179,7 @@
 		</services>
 		<protocols>
 			<zig_bee_node id='0374084c2e2843f19688e289235859ce'>
-				<mac_address>012345670A02</mac_address>
+				<mac_address>ABCD012345670A02</mac_address>
 				<type>end_device</type>
 				<reachable>true</reachable>
 				<power_source>battery</power_source>
@@ -234,7 +234,7 @@
 		</services>
 		<protocols>
 			<zig_bee_node id='a7c4a564cd4943a1ab9eee428270b2ae'>
-				<mac_address>012345670A05</mac_address>
+				<mac_address>ABCD012345670A05</mac_address>
 				<type>router</type>
 				<reachable>true</reachable>
 				<power_source>mains</power_source>

--- a/userdata/adam_plus_anna_new_copy_dhw_and_cooling/core.domain_objects.xml
+++ b/userdata/adam_plus_anna_new_copy_dhw_and_cooling/core.domain_objects.xml
@@ -11,7 +11,7 @@
 		<services/>
 		<protocols>
 			<zig_bee_coordinator id='fcd3478dede94c5c87b5ea39a3404708'>
-				<mac_address>012345670101</mac_address>
+				<mac_address>ABCD012345670101</mac_address>
 				<permit_joining>false</permit_joining>
 				<neighbors><zig_bee_node id='0374084c2e2843f19688e289235859ce'/><zig_bee_node id='87f66dac0b92499897598c95fe55286e'/><zig_bee_node id='9074cd5161764e8eb0261d5ba99a0428'/><zig_bee_node id='9ca5df0038564aeeb59709ab3de23f97'/><zig_bee_node id='a7c4a564cd4943a1ab9eee428270b2ae'/></neighbors>
 				<zig_bee_nodes><zig_bee_node id='0374084c2e2843f19688e289235859ce'/><zig_bee_node id='87f66dac0b92499897598c95fe55286e'/><zig_bee_node id='9074cd5161764e8eb0261d5ba99a0428'/><zig_bee_node id='9ca5df0038564aeeb59709ab3de23f97'/><zig_bee_node id='a7c4a564cd4943a1ab9eee428270b2ae'/></zig_bee_nodes>
@@ -81,7 +81,7 @@
 		</services>
 		<protocols>
 			<zig_bee_node id='9074cd5161764e8eb0261d5ba99a0428'>
-				<mac_address>012345670A01</mac_address>
+				<mac_address>ABCD012345670A01</mac_address>
 				<type>end_device</type>
 				<reachable>true</reachable>
 				<power_source>battery</power_source>
@@ -219,7 +219,7 @@
 		</services>
 		<protocols>
 			<zig_bee_node id='0374084c2e2843f19688e289235859ce'>
-				<mac_address>012345670A02</mac_address>
+				<mac_address>ABCD012345670A02</mac_address>
 				<type>end_device</type>
 				<reachable>true</reachable>
 				<power_source>battery</power_source>
@@ -350,7 +350,7 @@
 		</services>
 		<protocols>
 			<zig_bee_node id='87f66dac0b92499897598c95fe55286e'>
-				<mac_address>012345670A03</mac_address>
+				<mac_address>ABCD012345670A03</mac_address>
 				<type>router</type>
 				<reachable>true</reachable>
 				<power_source>mains</power_source>
@@ -590,7 +590,7 @@
 		</services>
 		<protocols>
 			<zig_bee_node id='9ca5df0038564aeeb59709ab3de23f97'>
-				<mac_address>012345670A04</mac_address>
+				<mac_address>ABCD012345670A04</mac_address>
 				<type>router</type>
 				<reachable>true</reachable>
 				<power_source>mains</power_source>
@@ -1580,7 +1580,7 @@
 		</services>
 		<protocols>
 			<zig_bee_node id='a7c4a564cd4943a1ab9eee428270b2ae'>
-				<mac_address>012345670A05</mac_address>
+				<mac_address>ABCD012345670A05</mac_address>
 				<type>router</type>
 				<reachable>true</reachable>
 				<power_source>mains</power_source>

--- a/userdata/adam_plus_anna_new_copy_dhw_and_cooling/core.modules.xml
+++ b/userdata/adam_plus_anna_new_copy_dhw_and_cooling/core.modules.xml
@@ -11,7 +11,7 @@
 		<services/>
 		<protocols>
 			<zig_bee_coordinator id='fcd3478dede94c5c87b5ea39a3404708'>
-				<mac_address>012345670101</mac_address>
+				<mac_address>ABCD012345670101</mac_address>
 				<permit_joining>false</permit_joining>
 				<neighbors><zig_bee_node id='0374084c2e2843f19688e289235859ce'/><zig_bee_node id='9074cd5161764e8eb0261d5ba99a0428'/><zig_bee_node id='9ca5df0038564aeeb59709ab3de23f97'/><zig_bee_node id='a7c4a564cd4943a1ab9eee428270b2ae'/></neighbors>
 				<zig_bee_nodes><zig_bee_node id='0374084c2e2843f19688e289235859ce'/><zig_bee_node id='87f66dac0b92499897598c95fe55286e'/><zig_bee_node id='9074cd5161764e8eb0261d5ba99a0428'/><zig_bee_node id='9ca5df0038564aeeb59709ab3de23f97'/><zig_bee_node id='a7c4a564cd4943a1ab9eee428270b2ae'/></zig_bee_nodes>
@@ -81,7 +81,7 @@
 		</services>
 		<protocols>
 			<zig_bee_node id='9074cd5161764e8eb0261d5ba99a0428'>
-				<mac_address>012345670A01</mac_address>
+				<mac_address>ABCD012345670A01</mac_address>
 				<type>end_device</type>
 				<reachable>true</reachable>
 				<power_source>battery</power_source>
@@ -114,7 +114,7 @@
 		</services>
 		<protocols>
 			<zig_bee_node id='9ca5df0038564aeeb59709ab3de23f97'>
-				<mac_address>012345670A04</mac_address>
+				<mac_address>ABCD012345670A04</mac_address>
 				<type>router</type>
 				<reachable>true</reachable>
 				<power_source>mains</power_source>
@@ -145,7 +145,7 @@
 		</services>
 		<protocols>
 			<zig_bee_node id='87f66dac0b92499897598c95fe55286e'>
-				<mac_address>012345670A03</mac_address>
+				<mac_address>ABCD012345670A03</mac_address>
 				<type>router</type>
 				<reachable>false</reachable>
 				<power_source>mains</power_source>
@@ -179,7 +179,7 @@
 		</services>
 		<protocols>
 			<zig_bee_node id='0374084c2e2843f19688e289235859ce'>
-				<mac_address>012345670A02</mac_address>
+				<mac_address>ABCD012345670A02</mac_address>
 				<type>end_device</type>
 				<reachable>true</reachable>
 				<power_source>battery</power_source>
@@ -234,7 +234,7 @@
 		</services>
 		<protocols>
 			<zig_bee_node id='a7c4a564cd4943a1ab9eee428270b2ae'>
-				<mac_address>012345670A05</mac_address>
+				<mac_address>ABCD012345670A05</mac_address>
 				<type>router</type>
 				<reachable>true</reachable>
 				<power_source>mains</power_source>

--- a/userdata/adam_plus_anna_new_copy_dhw_and_heating/core.domain_objects.xml
+++ b/userdata/adam_plus_anna_new_copy_dhw_and_heating/core.domain_objects.xml
@@ -11,7 +11,7 @@
 		<services/>
 		<protocols>
 			<zig_bee_coordinator id='fcd3478dede94c5c87b5ea39a3404708'>
-				<mac_address>012345670101</mac_address>
+				<mac_address>ABCD012345670101</mac_address>
 				<permit_joining>false</permit_joining>
 				<neighbors><zig_bee_node id='0374084c2e2843f19688e289235859ce'/><zig_bee_node id='87f66dac0b92499897598c95fe55286e'/><zig_bee_node id='9074cd5161764e8eb0261d5ba99a0428'/><zig_bee_node id='9ca5df0038564aeeb59709ab3de23f97'/><zig_bee_node id='a7c4a564cd4943a1ab9eee428270b2ae'/></neighbors>
 				<zig_bee_nodes><zig_bee_node id='0374084c2e2843f19688e289235859ce'/><zig_bee_node id='87f66dac0b92499897598c95fe55286e'/><zig_bee_node id='9074cd5161764e8eb0261d5ba99a0428'/><zig_bee_node id='9ca5df0038564aeeb59709ab3de23f97'/><zig_bee_node id='a7c4a564cd4943a1ab9eee428270b2ae'/></zig_bee_nodes>
@@ -81,7 +81,7 @@
 		</services>
 		<protocols>
 			<zig_bee_node id='9074cd5161764e8eb0261d5ba99a0428'>
-				<mac_address>012345670A01</mac_address>
+				<mac_address>ABCD012345670A01</mac_address>
 				<type>end_device</type>
 				<reachable>true</reachable>
 				<power_source>battery</power_source>
@@ -219,7 +219,7 @@
 		</services>
 		<protocols>
 			<zig_bee_node id='0374084c2e2843f19688e289235859ce'>
-				<mac_address>012345670A02</mac_address>
+				<mac_address>ABCD012345670A02</mac_address>
 				<type>end_device</type>
 				<reachable>true</reachable>
 				<power_source>battery</power_source>
@@ -350,7 +350,7 @@
 		</services>
 		<protocols>
 			<zig_bee_node id='87f66dac0b92499897598c95fe55286e'>
-				<mac_address>012345670A03</mac_address>
+				<mac_address>ABCD012345670A03</mac_address>
 				<type>router</type>
 				<reachable>true</reachable>
 				<power_source>mains</power_source>
@@ -590,7 +590,7 @@
 		</services>
 		<protocols>
 			<zig_bee_node id='9ca5df0038564aeeb59709ab3de23f97'>
-				<mac_address>012345670A04</mac_address>
+				<mac_address>ABCD012345670A04</mac_address>
 				<type>router</type>
 				<reachable>true</reachable>
 				<power_source>mains</power_source>
@@ -1580,7 +1580,7 @@
 		</services>
 		<protocols>
 			<zig_bee_node id='a7c4a564cd4943a1ab9eee428270b2ae'>
-				<mac_address>012345670A05</mac_address>
+				<mac_address>ABCD012345670A05</mac_address>
 				<type>router</type>
 				<reachable>true</reachable>
 				<power_source>mains</power_source>

--- a/userdata/adam_plus_anna_new_copy_dhw_and_heating/core.modules.xml
+++ b/userdata/adam_plus_anna_new_copy_dhw_and_heating/core.modules.xml
@@ -11,7 +11,7 @@
 		<services/>
 		<protocols>
 			<zig_bee_coordinator id='fcd3478dede94c5c87b5ea39a3404708'>
-				<mac_address>012345670101</mac_address>
+				<mac_address>ABCD012345670101</mac_address>
 				<permit_joining>false</permit_joining>
 				<neighbors><zig_bee_node id='0374084c2e2843f19688e289235859ce'/><zig_bee_node id='9074cd5161764e8eb0261d5ba99a0428'/><zig_bee_node id='9ca5df0038564aeeb59709ab3de23f97'/><zig_bee_node id='a7c4a564cd4943a1ab9eee428270b2ae'/></neighbors>
 				<zig_bee_nodes><zig_bee_node id='0374084c2e2843f19688e289235859ce'/><zig_bee_node id='87f66dac0b92499897598c95fe55286e'/><zig_bee_node id='9074cd5161764e8eb0261d5ba99a0428'/><zig_bee_node id='9ca5df0038564aeeb59709ab3de23f97'/><zig_bee_node id='a7c4a564cd4943a1ab9eee428270b2ae'/></zig_bee_nodes>
@@ -81,7 +81,7 @@
 		</services>
 		<protocols>
 			<zig_bee_node id='9074cd5161764e8eb0261d5ba99a0428'>
-				<mac_address>012345670A01</mac_address>
+				<mac_address>ABCD012345670A01</mac_address>
 				<type>end_device</type>
 				<reachable>true</reachable>
 				<power_source>battery</power_source>
@@ -114,7 +114,7 @@
 		</services>
 		<protocols>
 			<zig_bee_node id='9ca5df0038564aeeb59709ab3de23f97'>
-				<mac_address>012345670A04</mac_address>
+				<mac_address>ABCD012345670A04</mac_address>
 				<type>router</type>
 				<reachable>true</reachable>
 				<power_source>mains</power_source>
@@ -145,7 +145,7 @@
 		</services>
 		<protocols>
 			<zig_bee_node id='87f66dac0b92499897598c95fe55286e'>
-				<mac_address>012345670A03</mac_address>
+				<mac_address>ABCD012345670A03</mac_address>
 				<type>router</type>
 				<reachable>false</reachable>
 				<power_source>mains</power_source>
@@ -179,7 +179,7 @@
 		</services>
 		<protocols>
 			<zig_bee_node id='0374084c2e2843f19688e289235859ce'>
-				<mac_address>012345670A02</mac_address>
+				<mac_address>ABCD012345670A02</mac_address>
 				<type>end_device</type>
 				<reachable>true</reachable>
 				<power_source>battery</power_source>
@@ -234,7 +234,7 @@
 		</services>
 		<protocols>
 			<zig_bee_node id='a7c4a564cd4943a1ab9eee428270b2ae'>
-				<mac_address>012345670A05</mac_address>
+				<mac_address>ABCD012345670A05</mac_address>
 				<type>router</type>
 				<reachable>true</reachable>
 				<power_source>mains</power_source>

--- a/userdata/adam_zone_per_device/core.domain_objects.xml
+++ b/userdata/adam_zone_per_device/core.domain_objects.xml
@@ -34,7 +34,7 @@
 		</services>
 		<protocols>
 			<zig_bee_node id='04ed662277f045b288312eb607b2c234'>
-				<mac_address>012345670A01</mac_address>
+				<mac_address>ABCD012345670A01</mac_address>
 				<type>router</type>
 				<reachable>true</reachable>
 				<power_source>mains</power_source>
@@ -377,7 +377,7 @@
 		</services>
 		<protocols>
 			<zig_bee_node id='0af3463d7dec46408244e48c7df0914d'>
-				<mac_address>012345670A02</mac_address>
+				<mac_address>ABCD012345670A02</mac_address>
 				<type>router</type>
 				<reachable>true</reachable>
 				<power_source>mains</power_source>
@@ -579,7 +579,7 @@
 		</services>
 		<protocols>
 			<zig_bee_node id='9468211aeaf340aab36c58624ce8abfe'>
-				<mac_address>012345670A03</mac_address>
+				<mac_address>ABCD012345670A03</mac_address>
 				<type>end_device</type>
 				<reachable>true</reachable>
 				<power_source>battery</power_source>
@@ -630,7 +630,7 @@
 		</services>
 		<protocols>
 			<zig_bee_node id='9f6a2117b2164257845422183d832caa'>
-				<mac_address>012345670A04</mac_address>
+				<mac_address>ABCD012345670A04</mac_address>
 				<type>router</type>
 				<reachable>false</reachable>
 				<power_source>mains</power_source>
@@ -771,7 +771,7 @@
 		</services>
 		<protocols>
 			<zig_bee_node id='6326dbad401e4745a31cce1650b29851'>
-				<mac_address>012345670A05</mac_address>
+				<mac_address>ABCD012345670A05</mac_address>
 				<type>router</type>
 				<reachable>true</reachable>
 				<power_source>mains</power_source>
@@ -919,7 +919,7 @@
 		</services>
 		<protocols>
 			<zig_bee_node id='6a5ccc5908ba4308996b79751aca45b2'>
-				<mac_address>012345670A06</mac_address>
+				<mac_address>ABCD012345670A06</mac_address>
 				<type>end_device</type>
 				<reachable>true</reachable>
 				<power_source>battery</power_source>
@@ -1040,7 +1040,7 @@
 		</services>
 		<protocols>
 			<zig_bee_node id='b9425487affb4cf687461eb4be8ff15e'>
-				<mac_address>012345670A07</mac_address>
+				<mac_address>ABCD012345670A07</mac_address>
 				<type>end_device</type>
 				<reachable>true</reachable>
 				<power_source>battery</power_source>
@@ -1129,7 +1129,7 @@
 		</services>
 		<protocols>
 			<zig_bee_node id='d0ab902b286147b3a3aa130789e1fddd'>
-				<mac_address>012345670A08</mac_address>
+				<mac_address>ABCD012345670A08</mac_address>
 				<type>end_device</type>
 				<reachable>true</reachable>
 				<power_source>battery</power_source>
@@ -1325,7 +1325,7 @@
 		</services>
 		<protocols>
 			<zig_bee_node id='1314db193c454638940d8f9629f588ca'>
-				<mac_address>012345670A09</mac_address>
+				<mac_address>ABCD012345670A09</mac_address>
 				<type>end_device</type>
 				<reachable>true</reachable>
 				<power_source>battery</power_source>
@@ -1722,7 +1722,7 @@
 		</services>
 		<protocols>
 			<zig_bee_node id='65dd9860b14b4813879658b5fcd8c236'>
-				<mac_address>012345670A10</mac_address>
+				<mac_address>ABCD012345670A10</mac_address>
 				<type>end_device</type>
 				<reachable>true</reachable>
 				<power_source>battery</power_source>
@@ -1960,7 +1960,7 @@
 		</services>
 		<protocols>
 			<zig_bee_node id='416c77c0526149b1938bb6c4e67dbd83'>
-				<mac_address>012345670A11</mac_address>
+				<mac_address>ABCD012345670A11</mac_address>
 				<type>end_device</type>
 				<reachable>true</reachable>
 				<power_source>battery</power_source>
@@ -2061,7 +2061,7 @@
 		<services/>
 		<protocols>
 			<zig_bee_coordinator id='547bdc305c3a47a58fa9f5f170ca3fc2'>
-				<mac_address>012345670101</mac_address>
+				<mac_address>ABCD012345670101</mac_address>
 				<permit_joining>false</permit_joining>
 				<neighbors><zig_bee_node id='0af3463d7dec46408244e48c7df0914d'/><zig_bee_node id='0c09007091e149dba4b8cc465a9e1bd9'/><zig_bee_node id='1b6b24fc75b74c12b97e65d1f60c2dfc'/><zig_bee_node id='416c77c0526149b1938bb6c4e67dbd83'/><zig_bee_node id='4788d5fbffc84aacbcd91b1abab8ff90'/><zig_bee_node id='56ce8175cbaa4ee886015bfa09373dff'/><zig_bee_node id='6326dbad401e4745a31cce1650b29851'/><zig_bee_node id='9abefede88bf4ea9acc3ad0638cddfaf'/><zig_bee_node id='9f6a2117b2164257845422183d832caa'/><zig_bee_node id='b9425487affb4cf687461eb4be8ff15e'/></neighbors>
 				<zig_bee_nodes><zig_bee_node id='04ed662277f045b288312eb607b2c234'/><zig_bee_node id='0af3463d7dec46408244e48c7df0914d'/><zig_bee_node id='0c09007091e149dba4b8cc465a9e1bd9'/><zig_bee_node id='1314db193c454638940d8f9629f588ca'/><zig_bee_node id='1b6b24fc75b74c12b97e65d1f60c2dfc'/><zig_bee_node id='2202545a9c764e56afead1f729f8b1de'/><zig_bee_node id='416c77c0526149b1938bb6c4e67dbd83'/><zig_bee_node id='4788d5fbffc84aacbcd91b1abab8ff90'/><zig_bee_node id='56ce8175cbaa4ee886015bfa09373dff'/><zig_bee_node id='6326dbad401e4745a31cce1650b29851'/><zig_bee_node id='65dd9860b14b4813879658b5fcd8c236'/><zig_bee_node id='6a5ccc5908ba4308996b79751aca45b2'/><zig_bee_node id='9468211aeaf340aab36c58624ce8abfe'/><zig_bee_node id='9abefede88bf4ea9acc3ad0638cddfaf'/><zig_bee_node id='9f6a2117b2164257845422183d832caa'/><zig_bee_node id='b9425487affb4cf687461eb4be8ff15e'/><zig_bee_node id='d0ab902b286147b3a3aa130789e1fddd'/></zig_bee_nodes>
@@ -2133,7 +2133,7 @@
 		</services>
 		<protocols>
 			<zig_bee_node id='4788d5fbffc84aacbcd91b1abab8ff90'>
-				<mac_address>012345670A12</mac_address>
+				<mac_address>ABCD012345670A12</mac_address>
 				<type>router</type>
 				<reachable>true</reachable>
 				<power_source>mains</power_source>
@@ -3198,7 +3198,7 @@
 		</services>
 		<protocols>
 			<zig_bee_node id='1b6b24fc75b74c12b97e65d1f60c2dfc'>
-				<mac_address>012345670A13</mac_address>
+				<mac_address>ABCD012345670A13</mac_address>
 				<type>router</type>
 				<reachable>true</reachable>
 				<power_source>mains</power_source>
@@ -3249,7 +3249,7 @@
 		</services>
 		<protocols>
 			<zig_bee_node id='0c09007091e149dba4b8cc465a9e1bd9'>
-				<mac_address>012345670A14</mac_address>
+				<mac_address>ABCD012345670A14</mac_address>
 				<type>router</type>
 				<reachable>true</reachable>
 				<power_source>mains</power_source>
@@ -3300,7 +3300,7 @@
 		</services>
 		<protocols>
 			<zig_bee_node id='56ce8175cbaa4ee886015bfa09373dff'>
-				<mac_address>012345670A15</mac_address>
+				<mac_address>ABCD012345670A15</mac_address>
 				<type>router</type>
 				<reachable>true</reachable>
 				<power_source>mains</power_source>
@@ -3330,7 +3330,7 @@
 		</services>
 		<protocols>
 			<zig_bee_node id='2202545a9c764e56afead1f729f8b1de'>
-				<mac_address>012345670A16</mac_address>
+				<mac_address>ABCD012345670A16</mac_address>
 				<type>router</type>
 				<reachable>true</reachable>
 				<power_source>mains</power_source>
@@ -3609,7 +3609,7 @@
 		</services>
 		<protocols>
 			<zig_bee_node id='9abefede88bf4ea9acc3ad0638cddfaf'>
-				<mac_address>012345670A17</mac_address>
+				<mac_address>ABCD012345670A17</mac_address>
 				<type>end_device</type>
 				<reachable>true</reachable>
 				<power_source>battery</power_source>

--- a/userdata/adam_zone_per_device/core.modules.xml
+++ b/userdata/adam_zone_per_device/core.modules.xml
@@ -24,7 +24,7 @@
 		</services>
 		<protocols>
 			<zig_bee_node id='9468211aeaf340aab36c58624ce8abfe'>
-				<mac_address>012345670A03</mac_address>
+				<mac_address>ABCD012345670A03</mac_address>
 				<type>end_device</type>
 				<reachable>true</reachable>
 				<power_source>battery</power_source>
@@ -66,7 +66,7 @@
 		</services>
 		<protocols>
 			<zig_bee_node id='1314db193c454638940d8f9629f588ca'>
-				<mac_address>012345670A09</mac_address>
+				<mac_address>ABCD012345670A09</mac_address>
 				<type>end_device</type>
 				<reachable>true</reachable>
 				<power_source>battery</power_source>
@@ -123,7 +123,7 @@
 		</services>
 		<protocols>
 			<zig_bee_node id='9f6a2117b2164257845422183d832caa'>
-				<mac_address>012345670A04</mac_address>
+				<mac_address>ABCD012345670A04</mac_address>
 				<type>router</type>
 				<reachable>false</reachable>
 				<power_source>mains</power_source>
@@ -166,7 +166,7 @@
 		</services>
 		<protocols>
 			<zig_bee_node id='65dd9860b14b4813879658b5fcd8c236'>
-				<mac_address>012345670A10</mac_address>
+				<mac_address>ABCD012345670A10</mac_address>
 				<type>end_device</type>
 				<reachable>true</reachable>
 				<power_source>battery</power_source>
@@ -212,7 +212,7 @@
 		</services>
 		<protocols>
 			<zig_bee_node id='0c09007091e149dba4b8cc465a9e1bd9'>
-				<mac_address>012345670A14</mac_address>
+				<mac_address>ABCD012345670A14</mac_address>
 				<type>router</type>
 				<reachable>true</reachable>
 				<power_source>mains</power_source>
@@ -242,7 +242,7 @@
 		</services>
 		<protocols>
 			<zig_bee_node id='6326dbad401e4745a31cce1650b29851'>
-				<mac_address>012345670A05</mac_address>
+				<mac_address>ABCD012345670A05</mac_address>
 				<type>router</type>
 				<reachable>true</reachable>
 				<power_source>mains</power_source>
@@ -314,7 +314,7 @@
 		</services>
 		<protocols>
 			<zig_bee_node id='416c77c0526149b1938bb6c4e67dbd83'>
-				<mac_address>012345670A11</mac_address>
+				<mac_address>ABCD012345670A11</mac_address>
 				<type>end_device</type>
 				<reachable>true</reachable>
 				<power_source>battery</power_source>
@@ -344,7 +344,7 @@
 		</services>
 		<protocols>
 			<zig_bee_node id='2202545a9c764e56afead1f729f8b1de'>
-				<mac_address>012345670A16</mac_address>
+				<mac_address>ABCD012345670A16</mac_address>
 				<type>router</type>
 				<reachable>true</reachable>
 				<power_source>mains</power_source>
@@ -377,7 +377,7 @@
 		</services>
 		<protocols>
 			<zig_bee_node id='6a5ccc5908ba4308996b79751aca45b2'>
-				<mac_address>012345670A06</mac_address>
+				<mac_address>ABCD012345670A06</mac_address>
 				<type>end_device</type>
 				<reachable>true</reachable>
 				<power_source>battery</power_source>
@@ -463,7 +463,7 @@
 		</services>
 		<protocols>
 			<zig_bee_node id='0af3463d7dec46408244e48c7df0914d'>
-				<mac_address>012345670A02</mac_address>
+				<mac_address>ABCD012345670A02</mac_address>
 				<type>router</type>
 				<reachable>true</reachable>
 				<power_source>mains</power_source>
@@ -493,7 +493,7 @@
 		</services>
 		<protocols>
 			<zig_bee_node id='4788d5fbffc84aacbcd91b1abab8ff90'>
-				<mac_address>012345670A12</mac_address>
+				<mac_address>ABCD012345670A12</mac_address>
 				<type>router</type>
 				<reachable>true</reachable>
 				<power_source>mains</power_source>
@@ -523,7 +523,7 @@
 		</services>
 		<protocols>
 			<zig_bee_node id='1b6b24fc75b74c12b97e65d1f60c2dfc'>
-				<mac_address>012345670A13</mac_address>
+				<mac_address>ABCD012345670A13</mac_address>
 				<type>router</type>
 				<reachable>true</reachable>
 				<power_source>mains</power_source>
@@ -590,7 +590,7 @@
 		</services>
 		<protocols>
 			<zig_bee_node id='9abefede88bf4ea9acc3ad0638cddfaf'>
-				<mac_address>012345670A17</mac_address>
+				<mac_address>ABCD012345670A17</mac_address>
 				<type>end_device</type>
 				<reachable>true</reachable>
 				<power_source>battery</power_source>
@@ -623,7 +623,7 @@
 		</services>
 		<protocols>
 			<zig_bee_node id='b9425487affb4cf687461eb4be8ff15e'>
-				<mac_address>012345670A07</mac_address>
+				<mac_address>ABCD012345670A07</mac_address>
 				<type>end_device</type>
 				<reachable>true</reachable>
 				<power_source>battery</power_source>
@@ -643,7 +643,7 @@
 		<services/>
 		<protocols>
 			<zig_bee_coordinator id='547bdc305c3a47a58fa9f5f170ca3fc2'>
-				<mac_address>012345670101</mac_address>
+				<mac_address>ABCD012345670101</mac_address>
 				<permit_joining>false</permit_joining>
 				<neighbors><zig_bee_node id='0af3463d7dec46408244e48c7df0914d'/><zig_bee_node id='0c09007091e149dba4b8cc465a9e1bd9'/><zig_bee_node id='1b6b24fc75b74c12b97e65d1f60c2dfc'/><zig_bee_node id='416c77c0526149b1938bb6c4e67dbd83'/><zig_bee_node id='4788d5fbffc84aacbcd91b1abab8ff90'/><zig_bee_node id='56ce8175cbaa4ee886015bfa09373dff'/><zig_bee_node id='6326dbad401e4745a31cce1650b29851'/><zig_bee_node id='9abefede88bf4ea9acc3ad0638cddfaf'/><zig_bee_node id='9f6a2117b2164257845422183d832caa'/><zig_bee_node id='b9425487affb4cf687461eb4be8ff15e'/></neighbors>
 				<zig_bee_nodes><zig_bee_node id='04ed662277f045b288312eb607b2c234'/><zig_bee_node id='0af3463d7dec46408244e48c7df0914d'/><zig_bee_node id='0c09007091e149dba4b8cc465a9e1bd9'/><zig_bee_node id='1314db193c454638940d8f9629f588ca'/><zig_bee_node id='1b6b24fc75b74c12b97e65d1f60c2dfc'/><zig_bee_node id='2202545a9c764e56afead1f729f8b1de'/><zig_bee_node id='416c77c0526149b1938bb6c4e67dbd83'/><zig_bee_node id='4788d5fbffc84aacbcd91b1abab8ff90'/><zig_bee_node id='56ce8175cbaa4ee886015bfa09373dff'/><zig_bee_node id='6326dbad401e4745a31cce1650b29851'/><zig_bee_node id='65dd9860b14b4813879658b5fcd8c236'/><zig_bee_node id='6a5ccc5908ba4308996b79751aca45b2'/><zig_bee_node id='9468211aeaf340aab36c58624ce8abfe'/><zig_bee_node id='9abefede88bf4ea9acc3ad0638cddfaf'/><zig_bee_node id='9f6a2117b2164257845422183d832caa'/><zig_bee_node id='b9425487affb4cf687461eb4be8ff15e'/><zig_bee_node id='d0ab902b286147b3a3aa130789e1fddd'/></zig_bee_nodes>
@@ -671,7 +671,7 @@
 		</services>
 		<protocols>
 			<zig_bee_node id='56ce8175cbaa4ee886015bfa09373dff'>
-				<mac_address>012345670A15</mac_address>
+				<mac_address>ABCD012345670A15</mac_address>
 				<type>router</type>
 				<reachable>true</reachable>
 				<power_source>mains</power_source>
@@ -701,7 +701,7 @@
 		</services>
 		<protocols>
 			<zig_bee_node id='04ed662277f045b288312eb607b2c234'>
-				<mac_address>012345670A01</mac_address>
+				<mac_address>ABCD012345670A01</mac_address>
 				<type>router</type>
 				<reachable>true</reachable>
 				<power_source>mains</power_source>
@@ -734,7 +734,7 @@
 		</services>
 		<protocols>
 			<zig_bee_node id='d0ab902b286147b3a3aa130789e1fddd'>
-				<mac_address>012345670A08</mac_address>
+				<mac_address>ABCD012345670A08</mac_address>
 				<type>end_device</type>
 				<reachable>true</reachable>
 				<power_source>battery</power_source>

--- a/userdata/faulty_stretch/core.domain_objects.xml
+++ b/userdata/faulty_stretch/core.domain_objects.xml
@@ -13,7 +13,7 @@
 		</services>
 		<protocols>
 			<master_controller id='f0bcf042cad9418ea65ecf0bf6133250'>
-				<mac_address>012345670101</mac_address>
+				<mac_address>ABCD012345670101</mac_address>
 				<network id='259882df3c05415b99c2d962534ce820'/><network id='259882df3c05415b99c2d962534ce820'/>
 			</master_controller>
 		</protocols>
@@ -53,7 +53,7 @@
 		</services>
 		<protocols>
 			<network_router id='f323d992f1c44ec880386c568d809645'>
-				<mac_address>012345670A01</mac_address><network id='259882df3c05415b99c2d962534ce820'/>
+				<mac_address>ABCD012345670A01</mac_address><network id='259882df3c05415b99c2d962534ce820'/>
 			</network_router>
 		</protocols>
 	</module>
@@ -92,40 +92,40 @@
 		</services>
 		<protocols>
 			<network_router id='51408e71a38745c98c9fe992412bc6e0'>
-				<mac_address>012345670A02</mac_address><network id='259882df3c05415b99c2d962534ce820'/>
+				<mac_address>ABCD012345670A02</mac_address><network id='259882df3c05415b99c2d962534ce820'/>
 			</network_router>
 		</protocols>
 	</module>
 	<network id='259882df3c05415b99c2d962534ce820'>
 		<master_controller id='f0bcf042cad9418ea65ecf0bf6133250'>
-			<mac_address>012345670101</mac_address>
+			<mac_address>ABCD012345670101</mac_address>
 			<module id='cd197a863b6b4f319fd03a9ed8cb8416'/>
 			<upgrade/>
 		</master_controller>
 		<network_coordinator id='6f0db124f7c6429ea2721d61e5d62f93'>
-			<mac_address>012345670102</mac_address>
+			<mac_address>ABCD012345670102</mac_address>
 			<module id='b09d787ee9a247ed9efcd9ad865b13ad'/>
 			<upgrade/>
 			<search_nodes>false</search_nodes>
 		</network_coordinator>
 		<nodes>
 			<network_router id='57b6184bdc5140898eb8c53462589097'>
-				<mac_address>012345670A03</mac_address>
+				<mac_address>ABCD012345670A03</mac_address>
 				<module id='5db2e050da204f97a6a132e4267c6f7f'/>
 				<upgrade/>
 			</network_router>
 			<network_router id='51408e71a38745c98c9fe992412bc6e0'>
-				<mac_address>012345670A02</mac_address>
+				<mac_address>ABCD012345670A02</mac_address>
 				<module id='b7f5a95616cf450da237c008143ee062'/>
 				<upgrade/>
 			</network_router>
 			<network_router id='f323d992f1c44ec880386c568d809645'>
-				<mac_address>012345670A01</mac_address>
+				<mac_address>ABCD012345670A01</mac_address>
 				<module id='7d29adfb8361415b877bfcd1d56d8de2'/>
 				<upgrade/>
 			</network_router>
 			<network_router id='af7ebe75a9aa47d9b3ae26297be742d7'>
-				<mac_address>012345670A06</mac_address>
+				<mac_address>ABCD012345670A06</mac_address>
 				<module id='3b52239a9160497ebeb2164d07d3d399'/>
 				<upgrade/>
 			</network_router>
@@ -397,18 +397,18 @@
 		</services>
 		<protocols>
 			<network_router id='af7ebe75a9aa47d9b3ae26297be742d7'>
-				<mac_address>012345670A06</mac_address><network id='259882df3c05415b99c2d962534ce820'/>
+				<mac_address>ABCD012345670A06</mac_address><network id='259882df3c05415b99c2d962534ce820'/>
 			</network_router>
 		</protocols>
 	</module>
 	<network id='56de2443c34743c799353c3cedbff0eb'>
 		<master_controller id='fee80187abd54cc5982f7503b4c7c17f'>
-			<mac_address>012345670101</mac_address>
+			<mac_address>ABCD012345670101</mac_address>
 			<module id='3a65097960694644ac8f56e192cbe980'/>
 			<upgrade/>
 		</master_controller>
 		<network_coordinator id='ffda6867864248a89dfa2f8e0c3e67e8'>
-			<mac_address>012345670102</mac_address>
+			<mac_address>ABCD012345670102</mac_address>
 			<module id='5d0dfedb743447b0ada65b3c07185abe'/>
 			<upgrade/>
 			<search_nodes>false</search_nodes>
@@ -445,7 +445,7 @@
 		</services>
 		<protocols>
 			<network_coordinator id='ffda6867864248a89dfa2f8e0c3e67e8'>
-				<mac_address>012345670101</mac_address><network id='56de2443c34743c799353c3cedbff0eb'/>
+				<mac_address>ABCD012345670101</mac_address><network id='56de2443c34743c799353c3cedbff0eb'/>
 			</network_coordinator>
 		</protocols>
 	</module>
@@ -462,7 +462,7 @@
 		</services>
 		<protocols>
 			<master_controller id='fee80187abd54cc5982f7503b4c7c17f'>
-				<mac_address>012345670101</mac_address>
+				<mac_address>ABCD012345670101</mac_address>
 				<network id='56de2443c34743c799353c3cedbff0eb'/><network id='56de2443c34743c799353c3cedbff0eb'/>
 			</master_controller>
 		</protocols>
@@ -587,7 +587,7 @@
 		</services>
 		<protocols>
 			<network_coordinator id='6f0db124f7c6429ea2721d61e5d62f93'>
-				<mac_address>012345670101</mac_address><network id='259882df3c05415b99c2d962534ce820'/>
+				<mac_address>ABCD012345670101</mac_address><network id='259882df3c05415b99c2d962534ce820'/>
 			</network_coordinator>
 		</protocols>
 	</module>
@@ -798,7 +798,7 @@
 		</services>
 		<protocols>
 			<network_router id='57b6184bdc5140898eb8c53462589097'>
-				<mac_address>012345670A03</mac_address><network id='259882df3c05415b99c2d962534ce820'/>
+				<mac_address>ABCD012345670A03</mac_address><network id='259882df3c05415b99c2d962534ce820'/>
 			</network_router>
 		</protocols>
 	</module>

--- a/userdata/faulty_stretch/core.modules.xml
+++ b/userdata/faulty_stretch/core.modules.xml
@@ -53,7 +53,7 @@
 		</services>
 		<protocols>
 			<network_router id='f323d992f1c44ec880386c568d809645'>
-				<mac_address>012345670A01</mac_address><network id='259882df3c05415b99c2d962534ce820'/>
+				<mac_address>ABCD012345670A01</mac_address><network id='259882df3c05415b99c2d962534ce820'/>
 			</network_router>
 		</protocols>
 	</module>
@@ -92,7 +92,7 @@
 		</services>
 		<protocols>
 			<network_router id='51408e71a38745c98c9fe992412bc6e0'>
-				<mac_address>012345670A02</mac_address><network id='259882df3c05415b99c2d962534ce820'/>
+				<mac_address>ABCD012345670A02</mac_address><network id='259882df3c05415b99c2d962534ce820'/>
 			</network_router>
 		</protocols>
 	</module>
@@ -190,7 +190,7 @@
 		</services>
 		<protocols>
 			<network_router id='57b6184bdc5140898eb8c53462589097'>
-				<mac_address>012345670A03</mac_address><network id='259882df3c05415b99c2d962534ce820'/>
+				<mac_address>ABCD012345670A03</mac_address><network id='259882df3c05415b99c2d962534ce820'/>
 			</network_router>
 		</protocols>
 	</module>
@@ -260,7 +260,7 @@
 		</services>
 		<protocols>
 			<network_router id='af7ebe75a9aa47d9b3ae26297be742d7'>
-				<mac_address>012345670A06</mac_address><network id='259882df3c05415b99c2d962534ce820'/>
+				<mac_address>ABCD012345670A06</mac_address><network id='259882df3c05415b99c2d962534ce820'/>
 			</network_router>
 		</protocols>
 	</module>

--- a/userdata/stretch_v23/core.domain_objects.xml
+++ b/userdata/stretch_v23/core.domain_objects.xml
@@ -113,7 +113,7 @@
 		</services>
 		<protocols>
 			<network_router id='0e369c55ace04c128c11c327c96127fb'>
-				<mac_address>012345670A01</mac_address><network id='6e3e708b07ca4648964795a582c90ad1'/>
+				<mac_address>ABCD012345670A01</mac_address><network id='6e3e708b07ca4648964795a582c90ad1'/>
 			</network_router>
 		</protocols>
 	</module>
@@ -139,7 +139,7 @@
 		</services>
 		<protocols>
 			<network_router id='42412df9d7df4a64b40a9f46d1a4d761'>
-				<mac_address>012345670A02</mac_address><network id='6e3e708b07ca4648964795a582c90ad1'/>
+				<mac_address>ABCD012345670A02</mac_address><network id='6e3e708b07ca4648964795a582c90ad1'/>
 			</network_router>
 		</protocols>
 	</module>
@@ -235,7 +235,7 @@
 		</services>
 		<protocols>
 			<network_router id='f525a27f849d4b3eaca1f6cf21d9249a'>
-				<mac_address>012345670A03</mac_address><network id='6e3e708b07ca4648964795a582c90ad1'/>
+				<mac_address>ABCD012345670A03</mac_address><network id='6e3e708b07ca4648964795a582c90ad1'/>
 			</network_router>
 		</protocols>
 	</module>
@@ -261,7 +261,7 @@
 		</services>
 		<protocols>
 			<network_router id='230c70a7b4544591946472d99584863b'>
-				<mac_address>012345670A04</mac_address><network id='6e3e708b07ca4648964795a582c90ad1'/>
+				<mac_address>ABCD012345670A04</mac_address><network id='6e3e708b07ca4648964795a582c90ad1'/>
 			</network_router>
 		</protocols>
 	</module>
@@ -288,7 +288,7 @@
 		</services>
 		<protocols>
 			<network_router id='9e2033f74def4a8a84c196d7f85c105d'>
-				<mac_address>012345670A05</mac_address><network id='6e3e708b07ca4648964795a582c90ad1'/>
+				<mac_address>ABCD012345670A05</mac_address><network id='6e3e708b07ca4648964795a582c90ad1'/>
 			</network_router>
 		</protocols>
 	</module>
@@ -475,7 +475,7 @@
 		</services>
 		<protocols>
 			<network_router id='2cb47d68a15f484185bc8dbb80c835f5'>
-				<mac_address>012345670A06</mac_address><network id='6e3e708b07ca4648964795a582c90ad1'/>
+				<mac_address>ABCD012345670A06</mac_address><network id='6e3e708b07ca4648964795a582c90ad1'/>
 			</network_router>
 		</protocols>
 	</module>
@@ -501,7 +501,7 @@
 		</services>
 		<protocols>
 			<network_router id='61e55886728f4c36a321758ec97b47f9'>
-				<mac_address>012345670A07</mac_address><network id='6e3e708b07ca4648964795a582c90ad1'/>
+				<mac_address>ABCD012345670A07</mac_address><network id='6e3e708b07ca4648964795a582c90ad1'/>
 			</network_router>
 		</protocols>
 	</module>
@@ -632,7 +632,7 @@
 		</services>
 		<protocols>
 			<master_controller id='a0861f26d34b465f89a9ab77b105eb4f'>
-				<mac_address>012345670101</mac_address><network id='6e3e708b07ca4648964795a582c90ad1'/>
+				<mac_address>ABCD012345670101</mac_address><network id='6e3e708b07ca4648964795a582c90ad1'/>
 			</master_controller>
 		</protocols>
 	</module>
@@ -813,7 +813,7 @@
 		</services>
 		<protocols>
 			<network_router id='b06442aee20646f9bf6cec7589e82fcd'>
-				<mac_address>012345670A08</mac_address><network id='6e3e708b07ca4648964795a582c90ad1'/>
+				<mac_address>ABCD012345670A08</mac_address><network id='6e3e708b07ca4648964795a582c90ad1'/>
 			</network_router>
 		</protocols>
 	</module>
@@ -905,7 +905,7 @@
 		</services>
 		<protocols>
 			<network_router id='58dbcce4a2794a39bf7f18178d508e33'>
-				<mac_address>012345670A09</mac_address><network id='6e3e708b07ca4648964795a582c90ad1'/>
+				<mac_address>ABCD012345670A09</mac_address><network id='6e3e708b07ca4648964795a582c90ad1'/>
 			</network_router>
 		</protocols>
 	</module>
@@ -932,7 +932,7 @@
 		</services>
 		<protocols>
 			<network_router id='17500b080b204a2c9cbae4a10ee1a7ba'>
-				<mac_address>012345670A10</mac_address><network id='6e3e708b07ca4648964795a582c90ad1'/>
+				<mac_address>ABCD012345670A10</mac_address><network id='6e3e708b07ca4648964795a582c90ad1'/>
 			</network_router>
 		</protocols>
 	</module>
@@ -1320,7 +1320,7 @@
 		</services>
 		<protocols>
 			<network_router id='9940d76caaa44328ab05f8c5429f6736'>
-				<mac_address>012345670A11</mac_address><network id='6e3e708b07ca4648964795a582c90ad1'/>
+				<mac_address>ABCD012345670A11</mac_address><network id='6e3e708b07ca4648964795a582c90ad1'/>
 			</network_router>
 		</protocols>
 	</module>
@@ -1415,7 +1415,7 @@
 		</services>
 		<protocols>
 			<network_router id='59a798969b874d1793fbf6515f75470c'>
-				<mac_address>012345670A12</mac_address><network id='6e3e708b07ca4648964795a582c90ad1'/>
+				<mac_address>ABCD012345670A12</mac_address><network id='6e3e708b07ca4648964795a582c90ad1'/>
 			</network_router>
 		</protocols>
 	</module>
@@ -1442,7 +1442,7 @@
 		</services>
 		<protocols>
 			<network_router id='0c2096fe64e94836bcd0b21ba7bfc208'>
-				<mac_address>012345670A13</mac_address><network id='6e3e708b07ca4648964795a582c90ad1'/>
+				<mac_address>ABCD012345670A13</mac_address><network id='6e3e708b07ca4648964795a582c90ad1'/>
 			</network_router>
 		</protocols>
 	</module>
@@ -1469,7 +1469,7 @@
 		</services>
 		<protocols>
 			<network_router id='4d6ec2327a864c14b5aff7d01fed77f9'>
-				<mac_address>012345670A14</mac_address><network id='6e3e708b07ca4648964795a582c90ad1'/>
+				<mac_address>ABCD012345670A14</mac_address><network id='6e3e708b07ca4648964795a582c90ad1'/>
 			</network_router>
 		</protocols>
 	</module>
@@ -1713,7 +1713,7 @@
 		</services>
 		<protocols>
 			<network_router id='4769551535434cdc98f0a01a8b0d0c8c'>
-				<mac_address>012345670A15</mac_address><network id='6e3e708b07ca4648964795a582c90ad1'/>
+				<mac_address>ABCD012345670A15</mac_address><network id='6e3e708b07ca4648964795a582c90ad1'/>
 			</network_router>
 		</protocols>
 	</module>
@@ -1808,7 +1808,7 @@
 		</services>
 		<protocols>
 			<network_router id='08189c78b5ae4a6b9ac271c1380d03e9'>
-				<mac_address>012345670A16</mac_address><network id='6e3e708b07ca4648964795a582c90ad1'/>
+				<mac_address>ABCD012345670A16</mac_address><network id='6e3e708b07ca4648964795a582c90ad1'/>
 			</network_router>
 		</protocols>
 	</module>

--- a/userdata/stretch_v23/core.modules.xml
+++ b/userdata/stretch_v23/core.modules.xml
@@ -22,7 +22,7 @@
 		</services>
 		<protocols>
 			<network_router id='59a798969b874d1793fbf6515f75470c'>
-				<mac_address>012345670A12</mac_address><network id='6e3e708b07ca4648964795a582c90ad1'/>
+				<mac_address>ABCD012345670A12</mac_address><network id='6e3e708b07ca4648964795a582c90ad1'/>
 			</network_router>
 		</protocols>
 	</module>
@@ -49,7 +49,7 @@
 		</services>
 		<protocols>
 			<network_router id='4d6ec2327a864c14b5aff7d01fed77f9'>
-				<mac_address>012345670A14</mac_address><network id='6e3e708b07ca4648964795a582c90ad1'/>
+				<mac_address>ABCD012345670A14</mac_address><network id='6e3e708b07ca4648964795a582c90ad1'/>
 			</network_router>
 		</protocols>
 	</module>
@@ -76,7 +76,7 @@
 		</services>
 		<protocols>
 			<network_router id='17500b080b204a2c9cbae4a10ee1a7ba'>
-				<mac_address>012345670A10</mac_address><network id='6e3e708b07ca4648964795a582c90ad1'/>
+				<mac_address>ABCD012345670A10</mac_address><network id='6e3e708b07ca4648964795a582c90ad1'/>
 			</network_router>
 		</protocols>
 	</module>
@@ -102,7 +102,7 @@
 		</services>
 		<protocols>
 			<network_router id='230c70a7b4544591946472d99584863b'>
-				<mac_address>012345670A04</mac_address><network id='6e3e708b07ca4648964795a582c90ad1'/>
+				<mac_address>ABCD012345670A04</mac_address><network id='6e3e708b07ca4648964795a582c90ad1'/>
 			</network_router>
 		</protocols>
 	</module>
@@ -128,7 +128,7 @@
 		</services>
 		<protocols>
 			<network_router id='58dbcce4a2794a39bf7f18178d508e33'>
-				<mac_address>012345670A09</mac_address><network id='6e3e708b07ca4648964795a582c90ad1'/>
+				<mac_address>ABCD012345670A09</mac_address><network id='6e3e708b07ca4648964795a582c90ad1'/>
 			</network_router>
 		</protocols>
 	</module>
@@ -181,7 +181,7 @@
 		</services>
 		<protocols>
 			<network_router id='0e369c55ace04c128c11c327c96127fb'>
-				<mac_address>012345670A01</mac_address><network id='6e3e708b07ca4648964795a582c90ad1'/>
+				<mac_address>ABCD012345670A01</mac_address><network id='6e3e708b07ca4648964795a582c90ad1'/>
 			</network_router>
 		</protocols>
 	</module>
@@ -208,7 +208,7 @@
 		</services>
 		<protocols>
 			<network_router id='9e2033f74def4a8a84c196d7f85c105d'>
-				<mac_address>012345670A05</mac_address><network id='6e3e708b07ca4648964795a582c90ad1'/>
+				<mac_address>ABCD012345670A05</mac_address><network id='6e3e708b07ca4648964795a582c90ad1'/>
 			</network_router>
 		</protocols>
 	</module>
@@ -235,7 +235,7 @@
 		</services>
 		<protocols>
 			<network_router id='f525a27f849d4b3eaca1f6cf21d9249a'>
-				<mac_address>012345670A03</mac_address><network id='6e3e708b07ca4648964795a582c90ad1'/>
+				<mac_address>ABCD012345670A03</mac_address><network id='6e3e708b07ca4648964795a582c90ad1'/>
 			</network_router>
 		</protocols>
 	</module>
@@ -262,7 +262,7 @@
 		</services>
 		<protocols>
 			<network_router id='4769551535434cdc98f0a01a8b0d0c8c'>
-				<mac_address>012345670A15</mac_address><network id='6e3e708b07ca4648964795a582c90ad1'/>
+				<mac_address>ABCD012345670A15</mac_address><network id='6e3e708b07ca4648964795a582c90ad1'/>
 			</network_router>
 		</protocols>
 	</module>
@@ -289,7 +289,7 @@
 		</services>
 		<protocols>
 			<network_router id='2cb47d68a15f484185bc8dbb80c835f5'>
-				<mac_address>012345670A06</mac_address><network id='6e3e708b07ca4648964795a582c90ad1'/>
+				<mac_address>ABCD012345670A06</mac_address><network id='6e3e708b07ca4648964795a582c90ad1'/>
 			</network_router>
 		</protocols>
 	</module>
@@ -305,7 +305,7 @@
 		</services>
 		<protocols>
 			<master_controller id='a0861f26d34b465f89a9ab77b105eb4f'>
-				<mac_address>012345670101</mac_address><network id='6e3e708b07ca4648964795a582c90ad1'/>
+				<mac_address>ABCD012345670101</mac_address><network id='6e3e708b07ca4648964795a582c90ad1'/>
 			</master_controller>
 		</protocols>
 	</module>
@@ -331,7 +331,7 @@
 		</services>
 		<protocols>
 			<network_router id='08189c78b5ae4a6b9ac271c1380d03e9'>
-				<mac_address>012345670A16</mac_address><network id='6e3e708b07ca4648964795a582c90ad1'/>
+				<mac_address>ABCD012345670A16</mac_address><network id='6e3e708b07ca4648964795a582c90ad1'/>
 			</network_router>
 		</protocols>
 	</module>
@@ -357,7 +357,7 @@
 		</services>
 		<protocols>
 			<network_router id='42412df9d7df4a64b40a9f46d1a4d761'>
-				<mac_address>012345670A02</mac_address><network id='6e3e708b07ca4648964795a582c90ad1'/>
+				<mac_address>ABCD012345670A02</mac_address><network id='6e3e708b07ca4648964795a582c90ad1'/>
 			</network_router>
 		</protocols>
 	</module>
@@ -383,7 +383,7 @@
 		</services>
 		<protocols>
 			<network_router id='61e55886728f4c36a321758ec97b47f9'>
-				<mac_address>012345670A07</mac_address><network id='6e3e708b07ca4648964795a582c90ad1'/>
+				<mac_address>ABCD012345670A07</mac_address><network id='6e3e708b07ca4648964795a582c90ad1'/>
 			</network_router>
 		</protocols>
 	</module>
@@ -410,7 +410,7 @@
 		</services>
 		<protocols>
 			<network_router id='0c2096fe64e94836bcd0b21ba7bfc208'>
-				<mac_address>012345670A13</mac_address><network id='6e3e708b07ca4648964795a582c90ad1'/>
+				<mac_address>ABCD012345670A13</mac_address><network id='6e3e708b07ca4648964795a582c90ad1'/>
 			</network_router>
 		</protocols>
 	</module>
@@ -454,7 +454,7 @@
 		</services>
 		<protocols>
 			<network_router id='b06442aee20646f9bf6cec7589e82fcd'>
-				<mac_address>012345670A08</mac_address><network id='6e3e708b07ca4648964795a582c90ad1'/>
+				<mac_address>ABCD012345670A08</mac_address><network id='6e3e708b07ca4648964795a582c90ad1'/>
 			</network_router>
 		</protocols>
 	</module>
@@ -481,7 +481,7 @@
 		</services>
 		<protocols>
 			<network_router id='9940d76caaa44328ab05f8c5429f6736'>
-				<mac_address>012345670A11</mac_address><network id='6e3e708b07ca4648964795a582c90ad1'/>
+				<mac_address>ABCD012345670A11</mac_address><network id='6e3e708b07ca4648964795a582c90ad1'/>
 			</network_router>
 		</protocols>
 	</module>

--- a/userdata/stretch_v27_no_domain/core.modules.xml
+++ b/userdata/stretch_v27_no_domain/core.modules.xml
@@ -23,7 +23,7 @@
 			</electricity_point_meter>
 		</services>
 		<protocols>
-			<network_router id='0434b142dd9f4a4895de4d266b0328a8'><mac_address>012345670A01</mac_address><network id='d2bf005993784e1389a7d2be58d3af46'/></network_router>
+			<network_router id='0434b142dd9f4a4895de4d266b0328a8'><mac_address>ABCD012345670A01</mac_address><network id='d2bf005993784e1389a7d2be58d3af46'/></network_router>
 		</protocols>
 	</module>
 	<module id='b7a753cf9dc34b17834740afeb97679c'>
@@ -49,7 +49,7 @@
 			</electricity_point_meter>
 		</services>
 		<protocols>
-			<network_router id='372571ad3ef34939afe1cf08fa2529a5'><mac_address>012345670A02</mac_address><network id='d2bf005993784e1389a7d2be58d3af46'/></network_router>
+			<network_router id='372571ad3ef34939afe1cf08fa2529a5'><mac_address>ABCD012345670A02</mac_address><network id='d2bf005993784e1389a7d2be58d3af46'/></network_router>
 		</protocols>
 	</module>
 	<module id='f9d3122b5b8f4567baeb3169bc36d602'>
@@ -75,7 +75,7 @@
 			</relay>
 		</services>
 		<protocols>
-			<network_router id='35577449d85948f8be8522761e37eb64'><mac_address>012345670A03</mac_address><network id='d2bf005993784e1389a7d2be58d3af46'/></network_router>
+			<network_router id='35577449d85948f8be8522761e37eb64'><mac_address>ABCD012345670A03</mac_address><network id='d2bf005993784e1389a7d2be58d3af46'/></network_router>
 		</protocols>
 	</module>
 	<module id='96c006f023a247fb9d25f5bda03eac24'>
@@ -101,7 +101,7 @@
 			</electricity_interval_meter>
 		</services>
 		<protocols>
-			<network_coordinator id='f97c758a6d6c44ca873990071f7e9fdf'><mac_address>012345670A04</mac_address><network id='d2bf005993784e1389a7d2be58d3af46'/></network_coordinator>
+			<network_coordinator id='f97c758a6d6c44ca873990071f7e9fdf'><mac_address>ABCD012345670A04</mac_address><network id='d2bf005993784e1389a7d2be58d3af46'/></network_coordinator>
 		</protocols>
 	</module>
 	<module id='1fcf42fd5fe64b36b7a6178964c5171a'>
@@ -116,7 +116,7 @@
 		<services>
 		</services>
 		<protocols>
-			<master_controller id='d2cecd94cb80400c9f264906447fd082'><mac_address>012345670101</mac_address><network id='d2bf005993784e1389a7d2be58d3af46'/></master_controller>
+			<master_controller id='d2cecd94cb80400c9f264906447fd082'><mac_address>ABCD012345670101</mac_address><network id='d2bf005993784e1389a7d2be58d3af46'/></master_controller>
 		</protocols>
 	</module>
 	<module id='1823595c558d4cfda1bed3a4993700a6'>
@@ -142,7 +142,7 @@
 			</electricity_point_meter>
 		</services>
 		<protocols>
-			<network_router id='abb7ea3694eb4b8b9bf10520b54db49e'><mac_address>012345670A05</mac_address><network id='d2bf005993784e1389a7d2be58d3af46'/></network_router>
+			<network_router id='abb7ea3694eb4b8b9bf10520b54db49e'><mac_address>ABCD012345670A05</mac_address><network id='d2bf005993784e1389a7d2be58d3af46'/></network_router>
 		</protocols>
 	</module>
 	<module id='cbda99f796444ad298e57a4310435385'>
@@ -168,7 +168,7 @@
 			</electricity_point_meter>
 		</services>
 		<protocols>
-			<network_router id='08afc1a4c34b4b45b777aacf1d0fb690'><mac_address>012345670A06</mac_address><network id='d2bf005993784e1389a7d2be58d3af46'/></network_router>
+			<network_router id='08afc1a4c34b4b45b777aacf1d0fb690'><mac_address>ABCD012345670A06</mac_address><network id='d2bf005993784e1389a7d2be58d3af46'/></network_router>
 		</protocols>
 	</module>
 	<module id='35f34295d20540e4861b570e0b37b503'>
@@ -194,7 +194,7 @@
 			</electricity_point_meter>
 		</services>
 		<protocols>
-			<network_router id='9b2c3b1dc79a4c93b7fd8ac668ba368e'><mac_address>012345670A07</mac_address><network id='d2bf005993784e1389a7d2be58d3af46'/></network_router>
+			<network_router id='9b2c3b1dc79a4c93b7fd8ac668ba368e'><mac_address>ABCD012345670A07</mac_address><network id='d2bf005993784e1389a7d2be58d3af46'/></network_router>
 		</protocols>
 	</module>
 	<module id='ebf1c61a3b5445268ff6c8b133e940b3'>
@@ -220,7 +220,7 @@
 			</electricity_interval_meter>
 		</services>
 		<protocols>
-			<network_router id='7e615e83ccad46a4a90c1ae5364a94d2'><mac_address>012345670A08</mac_address><network id='d2bf005993784e1389a7d2be58d3af46'/></network_router>
+			<network_router id='7e615e83ccad46a4a90c1ae5364a94d2'><mac_address>ABCD012345670A08</mac_address><network id='d2bf005993784e1389a7d2be58d3af46'/></network_router>
 		</protocols>
 	</module>
 	<module id='cc6020f0afc242e09331472049e18982'>
@@ -246,7 +246,7 @@
 			</relay>
 		</services>
 		<protocols>
-			<network_router id='8c27a5d65a0f40e0b380904ea738bdad'><mac_address>012345670A09</mac_address><network id='d2bf005993784e1389a7d2be58d3af46'/></network_router>
+			<network_router id='8c27a5d65a0f40e0b380904ea738bdad'><mac_address>ABCD012345670A09</mac_address><network id='d2bf005993784e1389a7d2be58d3af46'/></network_router>
 		</protocols>
 	</module>
 	<module id='6b84f10a5d284e43b5c22cb052531527'>
@@ -272,7 +272,7 @@
 			</relay>
 		</services>
 		<protocols>
-			<network_router id='107eff9197c14c7e9c5569c97aafb177'><mac_address>012345670A10</mac_address><network id='d2bf005993784e1389a7d2be58d3af46'/></network_router>
+			<network_router id='107eff9197c14c7e9c5569c97aafb177'><mac_address>ABCD012345670A10</mac_address><network id='d2bf005993784e1389a7d2be58d3af46'/></network_router>
 		</protocols>
 	</module>
 	<module id='cdb711951fde451aa66390b44643a2af'>
@@ -298,7 +298,7 @@
 			</electricity_interval_meter>
 		</services>
 		<protocols>
-			<network_router id='929568cbd1324f57811a6f4c1285f73b'><mac_address>012345670A11</mac_address><network id='d2bf005993784e1389a7d2be58d3af46'/></network_router>
+			<network_router id='929568cbd1324f57811a6f4c1285f73b'><mac_address>ABCD012345670A11</mac_address><network id='d2bf005993784e1389a7d2be58d3af46'/></network_router>
 		</protocols>
 	</module>
 	<module id='a3512dceff4d4aeea5d75c80317fa751'>
@@ -324,7 +324,7 @@
 			</electricity_interval_meter>
 		</services>
 		<protocols>
-			<network_router id='1430a9df10874df39c615070f2fe9a12'><mac_address>012345670A12</mac_address><network id='d2bf005993784e1389a7d2be58d3af46'/></network_router>
+			<network_router id='1430a9df10874df39c615070f2fe9a12'><mac_address>ABCD012345670A12</mac_address><network id='d2bf005993784e1389a7d2be58d3af46'/></network_router>
 		</protocols>
 	</module>
 	<module id='6e68d0911d554aa5ad22f803fac22b5d'>
@@ -350,7 +350,7 @@
 			</electricity_interval_meter>
 		</services>
 		<protocols>
-			<network_router id='8bed50428c964e21ae8270cfb0176cb5'><mac_address>012345670A13</mac_address><network id='d2bf005993784e1389a7d2be58d3af46'/></network_router>
+			<network_router id='8bed50428c964e21ae8270cfb0176cb5'><mac_address>ABCD012345670A13</mac_address><network id='d2bf005993784e1389a7d2be58d3af46'/></network_router>
 		</protocols>
 	</module>
 </modules>

--- a/userdata/stretch_v31/core.domain_objects.xml
+++ b/userdata/stretch_v31/core.domain_objects.xml
@@ -536,7 +536,7 @@
 		</services>
 		<protocols>
 			<master_controller id='fee80187abd54cc5982f7503b4c7c17f'>
-				<mac_address>012345670101</mac_address>
+				<mac_address>ABCD012345670101</mac_address>
 				<network id='56de2443c34743c799353c3cedbff0eb'/><network id='56de2443c34743c799353c3cedbff0eb'/>
 			</master_controller>
 		</protocols>
@@ -583,12 +583,12 @@
 	</module>
 	<network id='56de2443c34743c799353c3cedbff0eb'>
 		<master_controller id='fee80187abd54cc5982f7503b4c7c17f'>
-			<mac_address>012345670101</mac_address>
+			<mac_address>ABCD012345670101</mac_address>
 			<module id='3a65097960694644ac8f56e192cbe980'/>
 			<upgrade/>
 		</master_controller>
 		<network_coordinator id='ffda6867864248a89dfa2f8e0c3e67e8'>
-			<mac_address>012345670102</mac_address>
+			<mac_address>ABCD012345670102</mac_address>
 			<module id='5d0dfedb743447b0ada65b3c07185abe'/>
 			<upgrade/>
 			<search_nodes>false</search_nodes>
@@ -634,7 +634,7 @@
 		</services>
 		<protocols>
 			<network_router id='51408e71a38745c98c9fe992412bc6e0'>
-				<mac_address>012345670A01</mac_address><network id='259882df3c05415b99c2d962534ce820'/>
+				<mac_address>ABCD012345670A01</mac_address><network id='259882df3c05415b99c2d962534ce820'/>
 			</network_router>
 		</protocols>
 	</module>
@@ -761,7 +761,7 @@
 		</services>
 		<protocols>
 			<network_router id='57b6184bdc5140898eb8c53462589097'>
-				<mac_address>012345670A02</mac_address><network id='259882df3c05415b99c2d962534ce820'/>
+				<mac_address>ABCD012345670A02</mac_address><network id='259882df3c05415b99c2d962534ce820'/>
 			</network_router>
 		</protocols>
 	</module>
@@ -860,7 +860,7 @@
 		</services>
 		<protocols>
 			<network_router id='9c2dadabf7324fae81bc00742ddb2e9a'>
-				<mac_address>012345670A03</mac_address><network id='259882df3c05415b99c2d962534ce820'/>
+				<mac_address>ABCD012345670A03</mac_address><network id='259882df3c05415b99c2d962534ce820'/>
 			</network_router>
 		</protocols>
 	</module>
@@ -956,49 +956,49 @@
 	</appliance>
 	<network id='259882df3c05415b99c2d962534ce820'>
 		<master_controller id='f0bcf042cad9418ea65ecf0bf6133250'>
-			<mac_address>012345670101</mac_address>
+			<mac_address>ABCD012345670101</mac_address>
 			<module id='cd197a863b6b4f319fd03a9ed8cb8416'/>
 			<upgrade/>
 		</master_controller>
 		<network_coordinator id='6f0db124f7c6429ea2721d61e5d62f93'>
-			<mac_address>012345670102</mac_address>
+			<mac_address>ABCD012345670102</mac_address>
 			<module id='b09d787ee9a247ed9efcd9ad865b13ad'/>
 			<upgrade/>
 			<search_nodes>false</search_nodes>
 		</network_coordinator>
 		<nodes>
 			<network_router id='f323d992f1c44ec880386c568d809645'>
-				<mac_address>012345670A04</mac_address>
+				<mac_address>ABCD012345670A04</mac_address>
 				<module id='7d29adfb8361415b877bfcd1d56d8de2'/>
 				<upgrade/>
 			</network_router>
 			<network_router id='51408e71a38745c98c9fe992412bc6e0'>
-				<mac_address>012345670A01</mac_address>
+				<mac_address>ABCD012345670A01</mac_address>
 				<module id='b7f5a95616cf450da237c008143ee062'/>
 				<upgrade/>
 			</network_router>
 			<network_router id='63a2b496da94454a9e62b93e5ede27f4'>
-				<mac_address>012345670A06</mac_address>
+				<mac_address>ABCD012345670A06</mac_address>
 				<module id='8e951f7a71b041d3a13915e25123b79e'/>
 				<upgrade/>
 			</network_router>
 			<network_router id='af7ebe75a9aa47d9b3ae26297be742d7'>
-				<mac_address>012345670A07</mac_address>
+				<mac_address>ABCD012345670A07</mac_address>
 				<module id='3b52239a9160497ebeb2164d07d3d399'/>
 				<upgrade/>
 			</network_router>
 			<network_router id='82949565aa9b46eebf2b28889917e082'>
-				<mac_address>012345670A08</mac_address>
+				<mac_address>ABCD012345670A08</mac_address>
 				<module id='359b5e2ee8444c4faec6b2ecc00e17ff'/>
 				<upgrade/>
 			</network_router>
 			<network_router id='9c2dadabf7324fae81bc00742ddb2e9a'>
-				<mac_address>012345670A03</mac_address>
+				<mac_address>ABCD012345670A03</mac_address>
 				<module id='cbb07250ec324d9eb0a51c92ebf73c83'/>
 				<upgrade/>
 			</network_router>
 			<network_router id='57b6184bdc5140898eb8c53462589097'>
-				<mac_address>012345670A02</mac_address>
+				<mac_address>ABCD012345670A02</mac_address>
 				<module id='5db2e050da204f97a6a132e4267c6f7f'/>
 				<upgrade/>
 			</network_router>
@@ -1101,7 +1101,7 @@
 		</services>
 		<protocols>
 			<network_router id='af7ebe75a9aa47d9b3ae26297be742d7'>
-				<mac_address>012345670A07</mac_address><network id='259882df3c05415b99c2d962534ce820'/>
+				<mac_address>ABCD012345670A07</mac_address><network id='259882df3c05415b99c2d962534ce820'/>
 			</network_router>
 		</protocols>
 	</module>
@@ -1140,7 +1140,7 @@
 		</services>
 		<protocols>
 			<network_router id='f323d992f1c44ec880386c568d809645'>
-				<mac_address>012345670A04</mac_address><network id='259882df3c05415b99c2d962534ce820'/>
+				<mac_address>ABCD012345670A04</mac_address><network id='259882df3c05415b99c2d962534ce820'/>
 			</network_router>
 		</protocols>
 	</module>
@@ -1157,7 +1157,7 @@
 		</services>
 		<protocols>
 			<master_controller id='f0bcf042cad9418ea65ecf0bf6133250'>
-				<mac_address>012345670101</mac_address>
+				<mac_address>ABCD012345670101</mac_address>
 				<network id='259882df3c05415b99c2d962534ce820'/><network id='259882df3c05415b99c2d962534ce820'/>
 			</master_controller>
 		</protocols>
@@ -1198,7 +1198,7 @@
 		</services>
 		<protocols>
 			<network_router id='63a2b496da94454a9e62b93e5ede27f4'>
-				<mac_address>012345670A06</mac_address><network id='259882df3c05415b99c2d962534ce820'/>
+				<mac_address>ABCD012345670A06</mac_address><network id='259882df3c05415b99c2d962534ce820'/>
 			</network_router>
 		</protocols>
 	</module>
@@ -1238,7 +1238,7 @@
 		</services>
 		<protocols>
 			<network_router id='82949565aa9b46eebf2b28889917e082'>
-				<mac_address>012345670A08</mac_address><network id='259882df3c05415b99c2d962534ce820'/>
+				<mac_address>ABCD012345670A08</mac_address><network id='259882df3c05415b99c2d962534ce820'/>
 			</network_router>
 		</protocols>
 	</module>

--- a/userdata/stretch_v31/core.modules.xml
+++ b/userdata/stretch_v31/core.modules.xml
@@ -13,7 +13,7 @@
 		</services>
 		<protocols>
 			<master_controller id='f0bcf042cad9418ea65ecf0bf6133250'>
-				<mac_address>012345670101</mac_address>
+				<mac_address>ABCD012345670101</mac_address>
 				<network id='259882df3c05415b99c2d962534ce820'/><network id='259882df3c05415b99c2d962534ce820'/>
 			</master_controller>
 		</protocols>
@@ -53,7 +53,7 @@
 		</services>
 		<protocols>
 			<network_router id='f323d992f1c44ec880386c568d809645'>
-				<mac_address>012345670A04</mac_address><network id='259882df3c05415b99c2d962534ce820'/>
+				<mac_address>ABCD012345670A04</mac_address><network id='259882df3c05415b99c2d962534ce820'/>
 			</network_router>
 		</protocols>
 	</module>
@@ -92,7 +92,7 @@
 		</services>
 		<protocols>
 			<network_router id='51408e71a38745c98c9fe992412bc6e0'>
-				<mac_address>012345670A01</mac_address><network id='259882df3c05415b99c2d962534ce820'/>
+				<mac_address>ABCD012345670A01</mac_address><network id='259882df3c05415b99c2d962534ce820'/>
 			</network_router>
 		</protocols>
 	</module>
@@ -109,7 +109,7 @@
 		</services>
 		<protocols>
 			<master_controller id='fee80187abd54cc5982f7503b4c7c17f'>
-				<mac_address>012345670101</mac_address>
+				<mac_address>ABCD012345670101</mac_address>
 				<network id='56de2443c34743c799353c3cedbff0eb'/><network id='56de2443c34743c799353c3cedbff0eb'/>
 			</master_controller>
 		</protocols>
@@ -190,7 +190,7 @@
 		</services>
 		<protocols>
 			<network_router id='57b6184bdc5140898eb8c53462589097'>
-				<mac_address>012345670A02</mac_address><network id='259882df3c05415b99c2d962534ce820'/>
+				<mac_address>ABCD012345670A02</mac_address><network id='259882df3c05415b99c2d962534ce820'/>
 			</network_router>
 		</protocols>
 	</module>
@@ -260,7 +260,7 @@
 		</services>
 		<protocols>
 			<network_router id='af7ebe75a9aa47d9b3ae26297be742d7'>
-				<mac_address>012345670A07</mac_address><network id='259882df3c05415b99c2d962534ce820'/>
+				<mac_address>ABCD012345670A07</mac_address><network id='259882df3c05415b99c2d962534ce820'/>
 			</network_router>
 		</protocols>
 	</module>


### PR DESCRIPTION
Re-set mac addresses that were obfuscated back to 64b instead of the 48b of ethernet addresses