### PR TITLE
Various improvements and fixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,62 +1,69 @@
 # Changelog
 
+# v0.xy.z - Smile: more changes and improvements
+- Combine helper-functions, possible after removing code related to the device_state sensor.
+- Remove single_master_thermostat() function and the related self's, no longer needed.
+- Use .get() where possible.
+- Implement walrus constructs ( := ) where possible.
+- Improve and simplify.
+
 # v0.16.6 - Smile: various changes/improvements
-  - Provide cooling_state and heating_state as `binary_sensors`, show cooling_state only when cooling is present
-  - Clean up gw_data, e.g. remove `single_master_thermostat` key
+- Provide cooling_state and heating_state as `binary_sensors`, show cooling_state only when cooling is present
+- Clean up gw_data, e.g. remove `single_master_thermostat` key
 
 # v0.16.5 - Smile: small improvements
-  - Move schedule debug-message to the correct position
-  - Code quality fixes
+- Move schedule debug-message to the correct position
+- Code quality fixes
 
 # v0.16.4 - Adding measurements
-  - Expose mac-addresses for network and zigbee devices
-  - Expose min/max thermostat (and heater) values and resolution (step in HA)
-  - Changed mac-addresses in userdata/fixtures to be obfuscated but unique 
+- Expose mac-addresses for network and zigbee devices
+- Expose min/max thermostat (and heater) values and resolution (step in HA)
+- Changed mac-addresses in userdata/fixtures to be obfuscated but unique 
 
 # v0.16.3 - Typing
-  - Code quality improvements
+- Code quality improvements
 
 # v0.16.2 - Generic and Stretch
-  - As per Core deprecation of python 3.8, removed CI/CD testing and bumped pypi to 3.9 and production
-  - Add support for Stretch with fw 2.7.18
+- As per Core deprecation of python 3.8, removed CI/CD testing and bumped pypi to 3.9 and production
+- Add support for Stretch with fw 2.7.18
 
 # v0.16.1 - Smile - various updates:
-  - BREAKING: Change active device detection, detect both OpenTherm (replace Auxiliary) and OnOff (new) heating and cooling devices.
-  - Stretch: base detection on the always present Stick
-  - Add Adam v3.6.x (beta) and Anna firmware 4.2 support (representation and switching on/off of a schedule has changed)
-  - Anna: Fix cooling_active prediction
-  - Schedules: always show `available_schemas` and `selected_schema`, also with "None" available and/or selected
-  - Cleanup and optimize code
-  - Adapt and improve testcode
+- BREAKING: Change active device detection, detect both OpenTherm (replace Auxiliary) and OnOff (new) heating and cooling devices.
+- Stretch: base detection on the always present Stick
+- Add Adam v3.6.x (beta) and Anna firmware 4.2 support (representation and switching on/off of a schedule has changed)
+- Anna: Fix cooling_active prediction
+- Schedules: always show `available_schemas` and `selected_schema`, also with "None" available and/or selected
+- Cleanup and optimize code
+- Adapt and improve testcode
 
 # v0.16.0 - Smile - Change output format, allowing full use of Core DataUpdateCoordintor in plugwise-beta
-  - Change from list- to dict-format for binary_sensors, sensors and switches
-  - Provide gateway-devices for Legacy Anna and Stretch
-  - Code-optimizations
+- Change from list- to dict-format for binary_sensors, sensors and switches
+- Provide gateway-devices for Legacy Anna and Stretch
+- Code-optimizations
 
 # v0.15.7 - Smile - Improve implementation of cooling-function-detection
- - Anna: add two sensors related to automatic switching between heating and cooling and add a heating/cooling-mode active indication
- - Adam: also provide a heating/cooling-mode active indication
- - Fixing #171
- - Improved dependency handling (@dependabot)
+- Anna: add two sensors related to automatic switching between heating and cooling and add a heating/cooling-mode active indication
+- Adam: also provide a heating/cooling-mode active indication
+- Fixing #171
+- Improved dependency handling (@dependabot)
 
 # v0.15.6 - Smile - Various fixes and improvements
-  - Adam: collect `control_state` from master thermostats, allows showing the thermostat state as on the Plugwise App
-  - Adam: collect `allowed_modes` and look for `cooling`, indicating cooling capability being available
-  - Optimize code: use `_all_appliances()` once instead of 3 times, by updating/changing `single_master_thermostat()`,
-  - Protect several more variables,
-  - Change/improve how `illuminance` and `outdoor_temperature` are obtained,
-  - Use walrus operator where applicable,
-  - Various small code improvements,
-  - Add and adapt testcode
-  - Add testing for python 3.10, improve dependencies (github workflow)
-  - Bump aiohttp to 3.8.1, remove fixed dependencies
+- Adam: collect `control_state` from master thermostats, allows showing the thermostat state as on the Plugwise App
+- Adam: collect `allowed_modes` and look for `cooling`, indicating cooling capability being available
+- Optimize code: use `_all_appliances()` once instead of 3 times, by updating/changing `single_master_thermostat()`,
+- Protect several more variables,
+- Change/improve how `illuminance` and `outdoor_temperature` are obtained,
+- Use walrus operator where applicable,
+- Various small code improvements,
+- Add and adapt testcode
+- Add testing for python 3.10, improve dependencies (github workflow)
+- Bump aiohttp to 3.8.1, remove fixed dependencies
 
 # v0.15.5 - Skipping, not released
 
 ## v0.15.4 - Smile - Bugfix: handle removed thermostats
-  - Recognize when a thermostat has been removed from a zone and don't show it in Core
-  - Rename Group Switch to Switchgroup, remove vendor name
+- Recognize when a thermostat has been removed from a zone and don't show it in Core
+- Rename Group Switch to Switchgroup, remove vendor name
 
 ## v0.15.3 - Skipping, not released
 
@@ -77,7 +84,7 @@
 
 ## v0.14.1 - Smile: removing further `last_reset`s
 
- - As per https://developers.home-assistant.io/blog/2021/08/16/state_class_total
+- As per https://developers.home-assistant.io/blog/2021/08/16/state_class_total
 
 ## v0.14.0 - Smile: sensor-platform updates - 2021.9 compatible
 

--- a/plugwise/__init__.py
+++ b/plugwise/__init__.py
@@ -1,6 +1,6 @@
 """Plugwise module."""
 
-__version__ = "0.16.7a1"
+__version__ = "0.16.7a2"
 
 from plugwise.smile import Smile
 from plugwise.stick import Stick

--- a/plugwise/__init__.py
+++ b/plugwise/__init__.py
@@ -1,6 +1,6 @@
 """Plugwise module."""
 
-__version__ = "0.16.7a0"
+__version__ = "0.16.7a1"
 
 from plugwise.smile import Smile
 from plugwise.stick import Stick

--- a/plugwise/__init__.py
+++ b/plugwise/__init__.py
@@ -1,6 +1,6 @@
 """Plugwise module."""
 
-__version__ = "0.16.6"
+__version__ = "0.16.7a0"
 
 from plugwise.smile import Smile
 from plugwise.stick import Stick

--- a/plugwise/helper.py
+++ b/plugwise/helper.py
@@ -338,7 +338,6 @@ class SmileHelper:
             appliances.add(appliance.attrib["id"])
 
         if self.smile_type == "thermostat":
-            self._is_thermostat = True
             self._loc_data[FAKE_LOC] = {
                 "name": "Home",
                 "types": {"temperature"},

--- a/plugwise/helper.py
+++ b/plugwise/helper.py
@@ -491,7 +491,7 @@ class SmileHelper:
 
             # Adam: check for ZigBee mac address
             if self.smile_name == "Adam" and (
-                found := self._domain_objects.find(".//protocols/zig_bee_coordinator")
+                found := self._modules.find(".//protocols/zig_bee_coordinator")
             ):
                 appl.zigbee_mac = found.find("mac_address").text
 
@@ -711,12 +711,12 @@ class SmileHelper:
 
     def _control_state(self, loc_id: str) -> str | None:
         """Helper-function for _device_data_climate().
-        Adam: find the thermostat control_state of a location, from DOMAIN_OBJECTS.
+        Adam: find the thermostat control_state of a location, from LOCATIONS.
         Represents the heating/cooling demand-state of the local master thermostat.
         Note: heating or cooling can still be active when the setpoint has been reached.
         """
         locator = f'location[@id="{loc_id}"]'
-        if (location := self._domain_objects.find(locator)) is not None:
+        if (location := self._locations.find(locator)) is not None:
             locator = (
                 ".//actuator_functionalities/thermostat_functionality/control_state"
             )
@@ -1169,7 +1169,7 @@ class SmileHelper:
         log_type = "schedule_state"
         locator = f"appliance[type='thermostat']/logs/point_log[type='{log_type}']/period/measurement"
         active = False
-        if (result := self._domain_objects.find(locator)) is not None:
+        if (result := self._appliances.find(locator)) is not None:
             active = result.text == "on"
 
         if name is not None:
@@ -1268,7 +1268,7 @@ class SmileHelper:
         Obtain the value/state for the given object.
         """
         val: float | int | None = None
-        search = self._domain_objects
+        search = self._locations
         locator = (
             f'.//location[@id="{obj_id}"]/logs/point_log'
             f'[type="{measurement}"]/period/measurement'

--- a/plugwise/helper.py
+++ b/plugwise/helper.py
@@ -1301,6 +1301,7 @@ class SmileHelper:
 
     def _create_dicts_from_data(
         self,
+        d_id: str,
         data: dict[str, Any],
         bs_dict: dict[str, bool],
         s_dict: dict[str, Any],
@@ -1323,3 +1324,8 @@ class SmileHelper:
                 if item == key:
                     data.pop(key)
                     sw_dict[key] = value
+
+        # Add plugwise notification binary_sensor to the relevant gateway
+        if d_id == self.gateway_id:
+            if self._is_thermostat:
+                bs_dict["plugwise_notification"] = False

--- a/plugwise/helper.py
+++ b/plugwise/helper.py
@@ -842,7 +842,6 @@ class SmileHelper:
                 data[measurement] = format_measure(
                     t_function.text, attrs[ATTR_UNIT_OF_MEASUREMENT]
                 )
-                LOGGER.debug("HOI %s %s", measurement, t_function.text)
 
         return data
 

--- a/plugwise/helper.py
+++ b/plugwise/helper.py
@@ -489,8 +489,7 @@ class SmileHelper:
             # Adam: check for cooling capability and active heating/cooling operation-mode
             mode_list: list[str] = []
             locator = "./actuator_functionalities/regulation_mode_control_functionality"
-            search = appliance.find(locator)
-            if search is not None:
+            if (search := appliance.find(locator)) is not None:
                 if search.find("mode") is not None:
                     self.cooling_active = search.find("mode").text == "cooling"
                 if search.find("allowed_modes") is not None:

--- a/plugwise/helper.py
+++ b/plugwise/helper.py
@@ -229,8 +229,7 @@ class SmileComm:
         if resp.status == 401:
             raise InvalidAuthentication
 
-        result = await resp.text()
-        if not result or "<error>" in result:
+        if not (result := await resp.text()) or "<error>" in result:
             LOGGER.error("Smile response empty or error in %s", result)
             raise ResponseError
 
@@ -390,8 +389,8 @@ class SmileHelper:
 
             # Group of appliances
             locator = ".//appliances/appliance"
-            if location.find(locator) is not None:
-                for member in location.findall(locator):
+            if (locs := location.findall(locator)) is not None:
+                for member in locs:
                     loc.members.add(member.attrib["id"])
 
             # Specials

--- a/plugwise/helper.py
+++ b/plugwise/helper.py
@@ -309,7 +309,6 @@ class SmileHelper:
         self._opentherm_device = False
         self._outdoor_temp: float | None = None
         self._is_thermostat = False
-        self._multi_thermostats = False
         self._smile_legacy = False
         self._stretch_v2 = False
         self._stretch_v3 = False
@@ -940,7 +939,7 @@ class SmileHelper:
         return appl_class
 
     def _scan_thermostats(self, debug_text="missing text") -> None:
-        """Helper-function for smile.py: get_all_devices() and single_master_thermostat().
+        """Helper-function for smile.py: get_all_devices().
         Update locations with thermostat ranking results.
         """
         self._thermo_locs = self._match_locations()

--- a/plugwise/helper.py
+++ b/plugwise/helper.py
@@ -1303,10 +1303,11 @@ class SmileHelper:
         self,
         d_id: str,
         data: dict[str, Any],
+        device: dict[str, Any],
         bs_dict: dict[str, bool],
         s_dict: dict[str, Any],
         sw_dict: dict[str, bool],
-    ) -> None:
+    ) -> dict[str, Any]:
         """Helper-function for smile.py: _all_device_data().
         Create dicts of binary_sensors, sensors, switches from the relevant data.
         """
@@ -1329,3 +1330,13 @@ class SmileHelper:
         if d_id == self.gateway_id:
             if self._is_thermostat:
                 bs_dict["plugwise_notification"] = False
+
+        device.update(data)
+        if bs_dict:
+            device["binary_sensors"] = bs_dict
+        if s_dict:
+            device["sensors"] = s_dict
+        if sw_dict:
+            device["switches"] = sw_dict
+
+        return device

--- a/plugwise/helper.py
+++ b/plugwise/helper.py
@@ -76,10 +76,9 @@ def update_helper(
             devs[d_id][e_type][item] = data[key]
 
         # Update the PW_Notification binary_sensor state
-        if e_type != "binary_sensors":
-            continue
-        if d_item == "plugwise_notification":
-            devs[d_id][e_type][d_item] = notifs != {}
+        if e_type == "binary_sensors":
+            if d_item == "plugwise_notification":
+                devs[d_id][e_type][d_item] = notifs != {}
 
 
 def check_model(name: str, v_name: str) -> str:

--- a/plugwise/helper.py
+++ b/plugwise/helper.py
@@ -710,7 +710,7 @@ class SmileHelper:
         return matched_locations
 
     def _control_state(self, loc_id: str) -> str | None:
-        """Helper-function for _device_data_climate().
+        """Helper-function for _device_data_adam().
         Adam: find the thermostat control_state of a location, from LOCATIONS.
         Represents the heating/cooling demand-state of the local master thermostat.
         Note: heating or cooling can still be active when the setpoint has been reached.

--- a/plugwise/helper.py
+++ b/plugwise/helper.py
@@ -57,17 +57,6 @@ from .util import (
 )
 
 
-def pw_notification_updater(
-    devs: dict[str, Any], d_id: str, d_dict: dict[str, Any], notifs: dict[str, str]
-) -> None:
-    """Helper-function for async_update().
-    Update the PW_Notification binary_sensor state.
-    """
-    for item in d_dict["binary_sensors"]:
-        if item == "plugwise_notification":
-            devs[d_id]["binary_sensors"][item] = notifs != {}
-
-
 def update_helper(
     data: dict[str, Any],
     devs: dict[str, Any],
@@ -75,6 +64,7 @@ def update_helper(
     d_id: str,
     e_type: str,
     key: str,
+    notifs: dict[str, str],
 ) -> None:
     """Helper-function for async_update()."""
     for dummy in d_dict[e_type]:
@@ -84,6 +74,12 @@ def update_helper(
             if key != item:
                 continue
             devs[d_id][e_type][item] = data[key]
+
+            # Update the PW_Notification binary_sensor state
+            if e_type != "binary_sensors":
+                continue
+            if item == "plugwise_notification":
+                devs[d_id][e_type][item] = notifs != {}
 
 
 def check_model(name: str, v_name: str) -> str:

--- a/plugwise/helper.py
+++ b/plugwise/helper.py
@@ -68,17 +68,17 @@ def update_helper(
 ) -> None:
     """Helper-function for async_update()."""
     for d_item in d_dict[e_type]:
+        # Update the PW_Notification binary_sensor state
+        if e_type == "binary_sensors":
+            if d_item == "plugwise_notification":
+                devs[d_id][e_type][d_item] = notifs != {}
+
         if key != d_item:
             continue
         for item in devs[d_id][e_type]:
             if key != item:
                 continue
             devs[d_id][e_type][item] = data[key]
-
-        # Update the PW_Notification binary_sensor state
-        if e_type == "binary_sensors":
-            if d_item == "plugwise_notification":
-                devs[d_id][e_type][d_item] = notifs != {}
 
 
 def check_model(name: str, v_name: str) -> str:

--- a/plugwise/helper.py
+++ b/plugwise/helper.py
@@ -1161,7 +1161,8 @@ class SmileHelper:
         name: str | None = None
         schemas: dict[str] = {}
 
-        for schema in self._domain_objects.findall(".//rule"):
+        search = self._domain_objects
+        for schema in search.findall(".//rule"):
             if rule_name := schema.find("name").text:
                 if "preset" not in rule_name:
                     name = rule_name
@@ -1169,7 +1170,7 @@ class SmileHelper:
         log_type = "schedule_state"
         locator = f"appliance[type='thermostat']/logs/point_log[type='{log_type}']/period/measurement"
         active = False
-        if (result := self._appliances.find(locator)) is not None:
+        if (result := search.find(locator)) is not None:
             active = result.text == "on"
 
         if name is not None:

--- a/plugwise/helper.py
+++ b/plugwise/helper.py
@@ -119,17 +119,13 @@ def schemas_schedule_temp(schedules: dict[str, Any], name: str) -> float | None:
         return
 
     for i in range(length):
-        result_1 = schema_list[i][0]
-        start = schema_list[i][1]
         j = (i + 1) % (length - 1)
-        result_2 = schema_list[j][0]
-        end = schema_list[j][1]
         now = dt.datetime.now().time()
         if (
-            result_1 == dt.datetime.now().weekday()
-            or result_2 == dt.datetime.now().weekday()
+            schema_list[i][0] == dt.datetime.now().weekday()
+            or schema_list[j][0] == dt.datetime.now().weekday()
         ):
-            if in_between(now, start, end):
+            if in_between(now, schema_list[i][1], schema_list[j][1]):
                 return schema_list[i][2]
 
 
@@ -138,12 +134,12 @@ def types_finder(data: etree) -> set:
     types = set()
     for measure, attrs in HOME_MEASUREMENTS.items():
         locator = f".//logs/point_log[type='{measure}']"
-        if data.find(locator) is not None:
-            log: etree = data.find(locator)
-            p_locator = ".//electricity_point_meter"
-            if log.find(p_locator) is not None:
-                if log.find(p_locator).get("id"):
-                    types.add(attrs.get(ATTR_TYPE))
+        if (log := data.find(locator)) is None:
+            continue
+
+        p_locator = ".//electricity_point_meter"
+        if (p_log := log.find(p_locator)) is not None and p_log.get("id"):
+            types.add(attrs.get(ATTR_TYPE))
 
     return types
 

--- a/plugwise/helper.py
+++ b/plugwise/helper.py
@@ -301,6 +301,7 @@ class SmileHelper:
         self._domain_objects: etree | None = None
         self._heater_id: str | None = None
         self._home_location: str | None = None
+        self._is_thermostat = False
         self._last_active: dict[str, str] = {}
         self._loc_data: dict[str, Any] = {}
         self._locations: etree | None = None
@@ -308,17 +309,16 @@ class SmileHelper:
         self._on_off_device = False
         self._opentherm_device = False
         self._outdoor_temp: float | None = None
-        self._is_thermostat = False
         self._smile_legacy = False
         self._stretch_v2 = False
         self._stretch_v3 = False
         self._thermo_locs: dict[str, Any] = {}
 
         self.cooling_active = False
-        self.smile_fw_version: str | None = None
         self.gateway_id: str | None = None
         self.gw_data: dict[str, Any] = {}
         self.gw_devices: dict[str, Any] = {}
+        self.smile_fw_version: str | None = None
         self.smile_hw_version: str | None = None
         self.smile_mac_address: str | None = None
         self.smile_name: str | None = None
@@ -338,6 +338,7 @@ class SmileHelper:
             appliances.add(appliance.attrib["id"])
 
         if self.smile_type == "thermostat":
+            self._is_thermostat = True
             self._loc_data[FAKE_LOC] = {
                 "name": "Home",
                 "types": {"temperature"},

--- a/plugwise/helper.py
+++ b/plugwise/helper.py
@@ -67,19 +67,19 @@ def update_helper(
     notifs: dict[str, str],
 ) -> None:
     """Helper-function for async_update()."""
-    for dummy in d_dict[e_type]:
-        if key != dummy:
+    for d_item in d_dict[e_type]:
+        if key != d_item:
             continue
         for item in devs[d_id][e_type]:
             if key != item:
                 continue
             devs[d_id][e_type][item] = data[key]
 
-            # Update the PW_Notification binary_sensor state
-            if e_type != "binary_sensors":
-                continue
-            if item == "plugwise_notification":
-                devs[d_id][e_type][item] = notifs != {}
+        # Update the PW_Notification binary_sensor state
+        if e_type != "binary_sensors":
+            continue
+        if d_item == "plugwise_notification":
+            devs[d_id][e_type][d_item] = notifs != {}
 
 
 def check_model(name: str, v_name: str) -> str:

--- a/plugwise/helper.py
+++ b/plugwise/helper.py
@@ -410,7 +410,6 @@ class SmileHelper:
         """Helper-function for _energy_device_info_finder() and _appliance_info_finder().
         Collect requested info from MODULES.
         """
-        appl_search = appliance.find(locator)
         model_data = {
             "contents": False,
             "vendor_name": None,
@@ -419,7 +418,7 @@ class SmileHelper:
             "firmware_version": None,
             "zigbee_mac_address": None,
         }
-        if appl_search is not None:
+        if (appl_search := appliance.find(locator)) is not None:
             link_id = appl_search.attrib["id"]
             locator = f".//{mod_type}[@id='{link_id}']...."
             module = self._modules.find(locator)

--- a/plugwise/helper.py
+++ b/plugwise/helper.py
@@ -1299,7 +1299,7 @@ class SmileHelper:
 
         return data
 
-    def _create_dicts_from_data(
+    def _update_device_with_dicts(
         self,
         d_id: str,
         data: dict[str, Any],
@@ -1309,7 +1309,8 @@ class SmileHelper:
         sw_dict: dict[str, bool],
     ) -> dict[str, Any]:
         """Helper-function for smile.py: _all_device_data().
-        Create dicts of binary_sensors, sensors, switches from the relevant data.
+        Move relevant data into dicts of binary_sensors, sensors, switches,
+        and add these to the output.
         """
         for key, value in list(data.items()):
             for item in BINARY_SENSORS:

--- a/plugwise/smile.py
+++ b/plugwise/smile.py
@@ -223,11 +223,11 @@ class SmileData(SmileHelper):
         device_data = self._device_data_switching_group(details, device_data)
         # Specific, not generic Adam data
         device_data = self._device_data_adam(details, device_data)
-        # Unless thermostat based, no need to walk presets
+        # No need to obtain thermostat data when the device is not a thermostat
         if details["class"] not in THERMOSTAT_CLASSES:
             return device_data
 
-        # Climate based data (presets, temperatures etc)
+        # Thermostat data (presets, temperatures etc)
         device_data = self._device_data_climate(details, device_data)
 
         return device_data

--- a/plugwise/smile.py
+++ b/plugwise/smile.py
@@ -392,6 +392,8 @@ class Smile(SmileComm, SmileData):
 
         self.smile_name = SMILES[target_smile]["friendly_name"]
         self.smile_type = SMILES[target_smile]["type"]
+        if self.smile_type == "thermostat":
+            self._is_thermostat = True
         self.smile_version = (self.smile_fw_version, ver)
 
         if "legacy" in SMILES[target_smile]:

--- a/plugwise/smile.py
+++ b/plugwise/smile.py
@@ -80,7 +80,6 @@ class SmileData(SmileHelper):
         """Determine the devices present from the obtained XML-data."""
         self._devices: dict[str, dict[str, Any]] = {}
         self._scan_thermostats()
-        self.single_master_thermostat()
 
         for appliance, details in self._appl_data.items():
             loc_id = details["location"]
@@ -232,21 +231,6 @@ class SmileData(SmileHelper):
         device_data = self._device_data_climate(details, device_data)
 
         return device_data
-
-    def single_master_thermostat(self) -> None:
-        """Determine if there is a single master thermostat in the setup."""
-        if self.smile_type == "thermostat":
-            self._is_thermostat = True
-            count = 0
-            for dummy, data in self._thermo_locs.items():
-                if "master_prio" in data:
-                    if data.get("master_prio") > 0:
-                        count += 1
-
-            if count == 1:
-                self._multi_thermostats = False
-            if count > 1:
-                self._multi_thermostats = True
 
 
 class Smile(SmileComm, SmileData):
@@ -408,6 +392,8 @@ class Smile(SmileComm, SmileData):
 
         self.smile_name = SMILES[target_smile]["friendly_name"]
         self.smile_type = SMILES[target_smile]["type"]
+        if self.smile_type == "thermostat":
+            self._is_thermostat = True
         self.smile_version = (self.smile_fw_version, ver)
 
         if "legacy" in SMILES[target_smile]:

--- a/plugwise/smile.py
+++ b/plugwise/smile.py
@@ -195,11 +195,6 @@ class SmileData(SmileHelper):
             if power_data is not None:
                 device_data.update(power_data)
 
-        # Adam: indicate active heating/cooling operation-mode
-        # Actual ongoing heating/cooling is shown via heating_state/cooling_state
-        if details["class"] == "heater_central" and self._cooling_present:
-            device_data["cooling_active"] = self.cooling_active
-
         # Switching groups data
         device_data = self._device_data_switching_group(details, device_data)
         # Specific, not generic Adam data
@@ -456,14 +451,6 @@ class Smile(SmileComm, SmileData):
                     update_helper(
                         data, self.gw_devices, dev_dict, dev_id, "switches", key
                     )
-
-        # Anna: update cooling_active to it's final value after all entities have been updated
-        if (
-            not self._smile_legacy
-            and self.smile_name == "Anna"
-            and self._cooling_present
-        ):
-            self.gw_devices[self._heater_id]["cooling_active"] = self.cooling_active
 
         return [self.gw_data, self.gw_devices]
 

--- a/plugwise/smile.py
+++ b/plugwise/smile.py
@@ -43,23 +43,13 @@ class SmileData(SmileHelper):
         Collect initial data for each device and add to self.gw_data and self.gw_devices.
         """
         for device_id, device in self._devices.items():
-            temp_bs_dict: dict[str, bool] = {}
-            temp_s_dict: dict[str, Any] = {}
-            temp_sw_dict: dict[str, bool] = {}
+            bs_dict: dict[str, bool] = {}
+            s_dict: dict[str, Any] = {}
+            sw_dict: dict[str, bool] = {}
             data = self._get_device_data(device_id)
-            self._create_dicts_from_data(
-                device_id, data, temp_bs_dict, temp_s_dict, temp_sw_dict
+            self.gw_devices[device_id] = self._create_dicts_from_data(
+                device_id, data, device, bs_dict, s_dict, sw_dict
             )
-
-            device.update(data)
-            if temp_bs_dict:
-                device["binary_sensors"] = temp_bs_dict
-            if temp_s_dict:
-                device["sensors"] = temp_s_dict
-            if temp_sw_dict:
-                device["switches"] = temp_sw_dict
-
-            self.gw_devices[device_id] = device
 
         self.gw_data["smile_name"] = self.smile_name
         self.gw_data["gateway_id"] = self.gateway_id

--- a/plugwise/smile.py
+++ b/plugwise/smile.py
@@ -76,7 +76,7 @@ class SmileData(SmileHelper):
                     if appliance in self._thermo_locs[loc_id].get("slaves"):
                         details["class"] = "thermo_sensor"
 
-            # Filter for thermostat-devices without a location
+            # Next, filter for thermostat-devices without a location
             if details.get("location") is not None:
                 self._devices[appliance] = details
 
@@ -141,8 +141,7 @@ class SmileData(SmileHelper):
         # Presets
         device_data["preset_modes"] = None
         device_data["active_preset"] = None
-        presets = self._presets(loc_id)
-        if presets:
+        if presets := self._presets(loc_id):
             device_data["presets"] = presets
             device_data["preset_modes"] = list(presets)
             device_data["active_preset"] = self._preset(loc_id)

--- a/plugwise/smile.py
+++ b/plugwise/smile.py
@@ -72,9 +72,9 @@ class SmileData(SmileHelper):
 
             # Override slave thermostat class
             if (loc_id := details.get("location")) in self._thermo_locs:
-                if "slaves" in self._thermo_locs.get(loc_id):
-                    if appliance in self._thermo_locs[loc_id].get("slaves"):
-                        details["class"] = "thermo_sensor"
+                tl_loc_id = self._thermo_locs.get(loc_id)
+                if "slaves" in tl_loc_id and appliance in tl_loc_id.get("slaves"):
+                    details["class"] = "thermo_sensor"
 
             # Next, filter for thermostat-devices without a location
             if details.get("location") is not None:

--- a/plugwise/smile.py
+++ b/plugwise/smile.py
@@ -114,7 +114,7 @@ class SmileData(SmileHelper):
 
     def _device_data_adam(
         self, details: dict[str, Any], device_data: dict[str, Any]
-    ) -> dict[str, bool]:
+    ) -> dict[str, Any]:
         """Helper-function for _get_device_data().
         Determine Adam device data.
         """

--- a/plugwise/smile.py
+++ b/plugwise/smile.py
@@ -38,16 +38,6 @@ from .helper import SmileComm, SmileHelper, pw_notification_updater, update_help
 class SmileData(SmileHelper):
     """The Plugwise Smile main class."""
 
-    def _append_special(
-        self, d_id: str, bs_dict: dict[str, bool], s_dict: dict[str, Any]
-    ) -> None:
-        """Helper-function for smile.py: _all_device_data().
-        When conditions are met, the plugwise_notification binary_sensor is appended.
-        """
-        if d_id == self.gateway_id:
-            if self._is_thermostat:
-                bs_dict["plugwise_notification"] = False
-
     def _all_device_data(self) -> None:
         """Helper-function for get_all_devices().
         Collect initial data for each device and add to self.gw_data and self.gw_devices.
@@ -57,9 +47,10 @@ class SmileData(SmileHelper):
             temp_s_dict: dict[str, Any] = {}
             temp_sw_dict: dict[str, bool] = {}
             data = self._get_device_data(device_id)
+            self._create_dicts_from_data(
+                device_id, data, temp_bs_dict, temp_s_dict, temp_sw_dict
+            )
 
-            self._create_dicts_from_data(data, temp_bs_dict, temp_s_dict, temp_sw_dict)
-            self._append_special(device_id, temp_bs_dict, temp_s_dict)
             device.update(data)
             if temp_bs_dict:
                 device["binary_sensors"] = temp_bs_dict

--- a/plugwise/smile.py
+++ b/plugwise/smile.py
@@ -392,8 +392,6 @@ class Smile(SmileComm, SmileData):
 
         self.smile_name = SMILES[target_smile]["friendly_name"]
         self.smile_type = SMILES[target_smile]["type"]
-        if self.smile_type == "thermostat":
-            self._is_thermostat = True
         self.smile_version = (self.smile_fw_version, ver)
 
         if "legacy" in SMILES[target_smile]:

--- a/plugwise/smile.py
+++ b/plugwise/smile.py
@@ -72,8 +72,8 @@ class SmileData(SmileHelper):
 
             # Override slave thermostat class
             if (loc_id := details.get("location")) in self._thermo_locs:
-                if "slaves" in self._thermo_locs[loc_id]:
-                    if appliance in self._thermo_locs[loc_id]["slaves"]:
+                if "slaves" in self._thermo_locs.get(loc_id):
+                    if appliance in self._thermo_locs[loc_id].get("slaves"):
                         details["class"] = "thermo_sensor"
 
             # Filter for thermostat-devices without a location
@@ -193,7 +193,7 @@ class SmileData(SmileHelper):
                     device_data["outdoor_temperature"] = outdoor_temperature
 
             # Get P1 data from LOCATIONS
-            power_data = self._power_data_from_location(details["location"])
+            power_data = self._power_data_from_location(details.get("location"))
             if power_data is not None:
                 device_data.update(power_data)
 

--- a/plugwise/smile.py
+++ b/plugwise/smile.py
@@ -126,10 +126,6 @@ class SmileData(SmileHelper):
                     if self._heating_valves() == 0:
                         device_data["heating_state"] = False
 
-            # Control_state
-            if ctrl_state := self._control_state(details["location"]):
-                device_data["control_state"] = ctrl_state
-
         return device_data
 
     def _device_data_climate(
@@ -169,6 +165,10 @@ class SmileData(SmileHelper):
             if self._heater_id is not None:
                 if self.cooling_active:
                     device_data["mode"] = "cool"
+
+        # Control_state, only for Adam master thermostats
+        if ctrl_state := self._control_state(details["location"]):
+            device_data["control_state"] = ctrl_state
 
         return device_data
 

--- a/plugwise/smile.py
+++ b/plugwise/smile.py
@@ -413,7 +413,7 @@ class Smile(SmileComm, SmileData):
         if not (self.smile_type == "power" and self._smile_legacy):
             self._appliances = await self._request(APPLIANCES)
 
-        # No need to import domain_objects and modules for P1, no useful info
+        # No need to import domain_objects for P1, no useful info
         if self.smile_type != "power":
             await self._update_domain_objects()
 
@@ -434,7 +434,7 @@ class Smile(SmileComm, SmileData):
                 self._notifications.update({msg_id: {msg_type: msg}})
                 LOGGER.debug("Plugwise notifications: %s", self._notifications)
             except AttributeError:  # pragma: no cover
-                LOGGER.info(
+                LOGGER.debug(
                     "Plugwise notification present but unable to process, manually investigate: %s",
                     f"{self._endpoint}{DOMAIN_OBJECTS}",
                 )

--- a/plugwise/smile.py
+++ b/plugwise/smile.py
@@ -47,7 +47,7 @@ class SmileData(SmileHelper):
             s_dict: dict[str, Any] = {}
             sw_dict: dict[str, bool] = {}
             data = self._get_device_data(device_id)
-            self.gw_devices[device_id] = self._create_dicts_from_data(
+            self.gw_devices[device_id] = self._update_device_with_dicts(
                 device_id, data, device, bs_dict, s_dict, sw_dict
             )
 

--- a/plugwise/smile.py
+++ b/plugwise/smile.py
@@ -392,8 +392,6 @@ class Smile(SmileComm, SmileData):
 
         self.smile_name = SMILES[target_smile]["friendly_name"]
         self.smile_type = SMILES[target_smile]["type"]
-        if self.smile_type == "thermostat":
-            self._is_thermostat = True
         self.smile_version = (self.smile_fw_version, ver)
 
         if "legacy" in SMILES[target_smile]:
@@ -402,6 +400,9 @@ class Smile(SmileComm, SmileData):
         if self.smile_type == "stretch":
             self._stretch_v2 = self.smile_version[1].major == 2
             self._stretch_v3 = self.smile_version[1].major == 3
+
+        if self.smile_type == "thermostat":
+            self._is_thermostat = True
 
     async def _full_update_device(self) -> None:
         """Perform a first fetch of all XML data, needed for initialization."""

--- a/plugwise/smile.py
+++ b/plugwise/smile.py
@@ -32,7 +32,7 @@ from .constants import (
     THERMOSTAT_CLASSES,
 )
 from .exceptions import ConnectionFailedError, InvalidXMLError, UnsupportedDeviceError
-from .helper import SmileComm, SmileHelper, pw_notification_updater, update_helper
+from .helper import SmileComm, SmileHelper, update_helper
 
 
 class SmileData(SmileHelper):
@@ -435,23 +435,20 @@ class Smile(SmileComm, SmileData):
             for key, value in list(data.items()):
                 if key in dev_dict:
                     dev_dict[key] = value
-            if "binary_sensors" in dev_dict:
+
+            for item in ["binary_sensors", "sensors", "switches"]:
+                notifs = None
+                if item == "binary_sensors":
+                    notifs = self._notifications
                 for key, value in list(data.items()):
                     update_helper(
-                        data, self.gw_devices, dev_dict, dev_id, "binary_sensors", key
-                    )
-                pw_notification_updater(
-                    self.gw_devices, dev_id, dev_dict, self._notifications
-                )
-            if "sensors" in dev_dict:
-                for key, value in list(data.items()):
-                    update_helper(
-                        data, self.gw_devices, dev_dict, dev_id, "sensors", key
-                    )
-            if "switches" in dev_dict:
-                for key, value in list(data.items()):
-                    update_helper(
-                        data, self.gw_devices, dev_dict, dev_id, "switches", key
+                        data,
+                        self.gw_devices,
+                        dev_dict,
+                        dev_id,
+                        item,
+                        key,
+                        notifs,
                     )
 
         return [self.gw_data, self.gw_devices]

--- a/plugwise/smile.py
+++ b/plugwise/smile.py
@@ -145,6 +145,10 @@ class SmileData(SmileHelper):
                     if self._heating_valves() == 0:
                         device_data["heating_state"] = False
 
+            # Control_state
+            if ctrl_state := self._control_state(details["location"]):
+                device_data["control_state"] = ctrl_state
+
         return device_data
 
     def _device_data_climate(
@@ -184,10 +188,6 @@ class SmileData(SmileHelper):
             if self._heater_id is not None:
                 if self.cooling_active:
                     device_data["mode"] = "cool"
-
-        # Control_state
-        if ctrl_state := self._control_state(loc_id):
-            device_data["control_state"] = ctrl_state
 
         return device_data
 

--- a/plugwise/smile.py
+++ b/plugwise/smile.py
@@ -440,16 +440,17 @@ class Smile(SmileComm, SmileData):
                 notifs = None
                 if item == "binary_sensors":
                     notifs = self._notifications
-                for key, value in list(data.items()):
-                    update_helper(
-                        data,
-                        self.gw_devices,
-                        dev_dict,
-                        dev_id,
-                        item,
-                        key,
-                        notifs,
-                    )
+                if item in dev_dict:
+                    for key, value in list(data.items()):
+                        update_helper(
+                            data,
+                            self.gw_devices,
+                            dev_dict,
+                            dev_id,
+                            item,
+                            key,
+                            notifs,
+                        )
 
         return [self.gw_data, self.gw_devices]
 

--- a/tests/test_smile.py
+++ b/tests/test_smile.py
@@ -619,9 +619,6 @@ class TestPlugwise:  # pylint: disable=attribute-defined-outside-init
                     "return_temperature": 21.7,
                     "water_pressure": 1.2,
                 },
-                "lower_bound": 50,
-                "upper_bound": 90,
-                "resolution": 1,
             },
             # Gateway
             "0000aaaa0000aaaa0000aaaa0000aa00": {

--- a/tests/test_smile.py
+++ b/tests/test_smile.py
@@ -650,7 +650,6 @@ class TestPlugwise:  # pylint: disable=attribute-defined-outside-init
         assert smile._smile_legacy
 
         await self.device_test(smile, testdata)
-        assert not smile._multi_thermostats
         assert not self.notifications
 
         await self.tinker_thermostat(
@@ -746,7 +745,6 @@ class TestPlugwise:  # pylint: disable=attribute-defined-outside-init
         assert smile._smile_legacy
 
         await self.device_test(smile, testdata)
-        assert not smile._multi_thermostats
         assert not self.notifications
 
         await self.tinker_thermostat(
@@ -932,7 +930,6 @@ class TestPlugwise:  # pylint: disable=attribute-defined-outside-init
         assert not smile._smile_legacy
 
         await self.device_test(smile, testdata)
-        assert not smile._multi_thermostats
         assert not self.notifications
 
         await self.tinker_thermostat(
@@ -975,7 +972,6 @@ class TestPlugwise:  # pylint: disable=attribute-defined-outside-init
         assert not smile._smile_legacy
 
         await self.device_test(smile, testdata)
-        assert not smile._multi_thermostats
 
         await self.tinker_thermostat(
             smile,
@@ -1025,7 +1021,6 @@ class TestPlugwise:  # pylint: disable=attribute-defined-outside-init
         assert not smile._smile_legacy
 
         await self.device_test(smile, testdata)
-        assert not smile._multi_thermostats
         assert not self.notifications
 
         await self.tinker_thermostat(
@@ -1072,7 +1067,6 @@ class TestPlugwise:  # pylint: disable=attribute-defined-outside-init
         assert not smile._smile_legacy
 
         await self.device_test(smile, testdata)
-        assert not smile._multi_thermostats
         assert not self.notifications
 
         await self.tinker_thermostat(
@@ -1160,7 +1154,6 @@ class TestPlugwise:  # pylint: disable=attribute-defined-outside-init
         assert not smile._smile_legacy
 
         await self.device_test(smile, testdata)
-        assert not smile._multi_thermostats
         assert not self.notifications
 
         await self.tinker_thermostat(
@@ -1223,7 +1216,6 @@ class TestPlugwise:  # pylint: disable=attribute-defined-outside-init
         assert not smile._smile_legacy
 
         await self.device_test(smile, testdata)
-        assert not smile._multi_thermostats
         assert not self.notifications
 
         await self.tinker_thermostat(
@@ -1420,7 +1412,6 @@ class TestPlugwise:  # pylint: disable=attribute-defined-outside-init
         assert not smile._smile_legacy
 
         await self.device_test(smile, testdata)
-        assert smile._multi_thermostats
 
         switch_change = await self.tinker_switch(
             smile,
@@ -1528,7 +1519,6 @@ class TestPlugwise:  # pylint: disable=attribute-defined-outside-init
         assert not smile._smile_legacy
 
         await self.device_test(smile, testdata)
-        assert smile._multi_thermostats
 
         assert "af82e4ccf9c548528166d38e560662a4" in self.notifications
         await smile.delete_notification()
@@ -1931,7 +1921,6 @@ class TestPlugwise:  # pylint: disable=attribute-defined-outside-init
         assert not smile._smile_legacy
 
         await self.device_test(smile, testdata)
-        assert smile._multi_thermostats
 
         assert "af82e4ccf9c548528166d38e560662a4" in self.notifications
 
@@ -2166,7 +2155,6 @@ class TestPlugwise:  # pylint: disable=attribute-defined-outside-init
 
         # Preset cooling_active to True, will turn to False due to the lowered outdoor temp
         await self.device_test(smile, testdata, True)
-        assert not smile._multi_thermostats
         assert self.cooling_present
         assert not self.notifications
 
@@ -2220,7 +2208,6 @@ class TestPlugwise:  # pylint: disable=attribute-defined-outside-init
         assert not smile._smile_legacy
 
         await self.device_test(smile, testdata)
-        assert not smile._multi_thermostats
         assert self.cooling_present
         assert not self.notifications
 
@@ -2250,7 +2237,6 @@ class TestPlugwise:  # pylint: disable=attribute-defined-outside-init
         assert not smile._smile_legacy
 
         await self.device_test(smile, testdata, True)
-        assert not smile._multi_thermostats
 
         assert "3d28a20e17cb47dca210a132463721d5" in self.notifications
 

--- a/tests/test_smile.py
+++ b/tests/test_smile.py
@@ -2191,7 +2191,7 @@ class TestPlugwise:  # pylint: disable=attribute-defined-outside-init
             },
             # Gateway
             "015ae9ea3f964e668e490fa39da3870b": {
-                "sensors": {"outdoor_temperature": 22.0}
+                "sensors": {"outdoor_temperature": 20.2}
             },
         }
 

--- a/tests/test_smile.py
+++ b/tests/test_smile.py
@@ -2115,6 +2115,7 @@ class TestPlugwise:  # pylint: disable=attribute-defined-outside-init
             "3cb70739631c4d17a86b8b12e8a5161b": {
                 "selected_schedule": "None",
                 "active_preset": "home",
+                "mode": "heat",
                 "sensors": {
                     "illuminance": 86.0,
                     "cooling_activation_outdoor_temperature": 21.0,
@@ -2123,7 +2124,6 @@ class TestPlugwise:  # pylint: disable=attribute-defined-outside-init
             },
             # Heater central
             "1cbf783bb11e4a7c8a6843dee3a86927": {
-                "cooling_active": False,
                 "binary_sensors": {
                     "cooling_state": False,
                     "dhw_state": False,
@@ -2169,6 +2169,7 @@ class TestPlugwise:  # pylint: disable=attribute-defined-outside-init
             "3cb70739631c4d17a86b8b12e8a5161b": {
                 "selected_schedule": "None",
                 "active_preset": "home",
+                "mode": "cool",
                 "sensors": {
                     "illuminance": 25.5,
                     "cooling_activation_outdoor_temperature": 21.0,
@@ -2177,7 +2178,6 @@ class TestPlugwise:  # pylint: disable=attribute-defined-outside-init
             },
             # Heater central
             "1cbf783bb11e4a7c8a6843dee3a86927": {
-                "cooling_active": True,
                 "binary_sensors": {
                     "cooling_state": True,
                     "dhw_state": False,


### PR DESCRIPTION
Changes:
- Combine helper-functions, possible after removing the `device_state` sensor.
- Remove the `single_master_thermostat()` function and the related `self`'s, no longer used.
- Use `.get()` where possible.
- Implement walrus constructs ( `:=` ) where possible.
- Improve and simplify.