### PR TITLE
Show special purpose plugs as binary_sensors too

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 # Changelog
 
+# v0.17.4 - Smile Adam: add binary_sensors showing the state of special purpose plugs
+
 # v0.17.3 - Smile Adam: add support for heater_electric type Plugs
 
 # v0.17.2 - Smile Adam: more bugfixes, improvementds

--- a/plugwise/__init__.py
+++ b/plugwise/__init__.py
@@ -1,6 +1,6 @@
 """Plugwise module."""
 
-__version__ = "0.17.4a0"
+__version__ = "0.17.4a1"
 
 from plugwise.smile import Smile
 from plugwise.stick import Stick

--- a/plugwise/__init__.py
+++ b/plugwise/__init__.py
@@ -1,6 +1,6 @@
 """Plugwise module."""
 
-__version__ = "0.17.3"
+__version__ = "0.17.4a0"
 
 from plugwise.smile import Smile
 from plugwise.stick import Stick

--- a/plugwise/__init__.py
+++ b/plugwise/__init__.py
@@ -1,6 +1,6 @@
 """Plugwise module."""
 
-__version__ = "0.17.4a1"
+__version__ = "0.17.4"
 
 from plugwise.smile import Smile
 from plugwise.stick import Stick

--- a/plugwise/helper.py
+++ b/plugwise/helper.py
@@ -1306,11 +1306,7 @@ class SmileHelper:
                 if item == key:
                     data.pop(key)
                     # Represent special plug-types as binary_sensors
-                    if (
-                        self.smile_name == "Adam"
-                        and device["class"] in SPECIAL_PLUG_TYPES
-                        and key == "relay"
-                    ):
+                    if device["class"] in SPECIAL_PLUG_TYPES and key == "relay":
                         bs_dict[key] = value
                     else:
                         sw_dict[key] = value

--- a/plugwise/helper.py
+++ b/plugwise/helper.py
@@ -1305,7 +1305,11 @@ class SmileHelper:
             for item in SWITCHES:
                 if item == key:
                     data.pop(key)
-                    sw_dict[key] = value
+                    # Represent special plug-types as binary_sensors
+                    if key == "relay" and "lock" not in data:
+                        bs_dict[key] = value
+                    else:
+                        sw_dict[key] = value
 
         # Add plugwise notification binary_sensor to the relevant gateway
         if d_id == self.gateway_id:

--- a/plugwise/helper.py
+++ b/plugwise/helper.py
@@ -1305,11 +1305,11 @@ class SmileHelper:
             for item in SWITCHES:
                 if item == key:
                     data.pop(key)
-                    # Represent special plug-types as binary_sensors
+                    sw_dict[key] = value
+                    # Represent special plug-types as binary_sensors as well
+                    # Temporary, the relevant switches will be depreciated later
                     if device["class"] in SPECIAL_PLUG_TYPES and key == "relay":
                         bs_dict[key] = value
-                    else:
-                        sw_dict[key] = value
 
         # Add plugwise notification binary_sensor to the relevant gateway
         if d_id == self.gateway_id:

--- a/plugwise/helper.py
+++ b/plugwise/helper.py
@@ -1306,7 +1306,11 @@ class SmileHelper:
                 if item == key:
                     data.pop(key)
                     # Represent special plug-types as binary_sensors
-                    if key == "relay" and "lock" not in data:
+                    if (
+                        self.smile_name == "Adam"
+                        and key == "relay"
+                        and "lock" not in data
+                    ):
                         bs_dict[key] = value
                     else:
                         sw_dict[key] = value

--- a/plugwise/helper.py
+++ b/plugwise/helper.py
@@ -1308,8 +1308,8 @@ class SmileHelper:
                     # Represent special plug-types as binary_sensors
                     if (
                         self.smile_name == "Adam"
+                        and device["class"] in SPECIAL_PLUG_TYPES
                         and key == "relay"
-                        and "lock" not in data
                     ):
                         bs_dict[key] = value
                     else:

--- a/tests/test_smile.py
+++ b/tests/test_smile.py
@@ -1442,6 +1442,7 @@ class TestPlugwise:  # pylint: disable=attribute-defined-outside-init
                     "electricity_produced": 0.0,
                     "electricity_produced_interval": 0.0,
                 },
+                "switches": {"relay": True},
             },
             "1772a4ea304041adb83f357b751341ff": {
                 "class": "thermo_sensor",
@@ -1603,6 +1604,7 @@ class TestPlugwise:  # pylint: disable=attribute-defined-outside-init
             "78d1126fc4c743db81b61c20e88342a7": {
                 "binary_sensors": {"relay": True},
                 "sensors": {"electricity_consumed": 35.8},
+                "switches": {"relay": True},
             },
             # Lisa Bios
             "df4a4a8169904cdb9c03d61a21f42140": {
@@ -1827,6 +1829,7 @@ class TestPlugwise:  # pylint: disable=attribute-defined-outside-init
                     "electricity_produced": 0.0,
                     "electricity_produced_interval": 0.0,
                 },
+                "switches": {"relay": True},
             },
             "90986d591dcd426cae3ec3e8111ff730": {
                 "class": "heater_central",

--- a/tests/test_smile.py
+++ b/tests/test_smile.py
@@ -1601,8 +1601,8 @@ class TestPlugwise:  # pylint: disable=attribute-defined-outside-init
             },
             # CV pomp
             "78d1126fc4c743db81b61c20e88342a7": {
+                "binary_sensors": {"relay": True},
                 "sensors": {"electricity_consumed": 35.8},
-                "switches": {"relay": True},
             },
             # Lisa Bios
             "df4a4a8169904cdb9c03d61a21f42140": {

--- a/tests/test_smile.py
+++ b/tests/test_smile.py
@@ -1435,13 +1435,13 @@ class TestPlugwise:  # pylint: disable=attribute-defined-outside-init
                 "model": "Plug",
                 "name": "Plug Vloerverwarming",
                 "vendor": "Plugwise",
+                "binary_sensors": {"relay": True},
                 "sensors": {
                     "electricity_consumed": 46.8,
                     "electricity_consumed_interval": 0.0,
                     "electricity_produced": 0.0,
                     "electricity_produced_interval": 0.0,
                 },
-                "switches": {"relay": True},
             },
             "1772a4ea304041adb83f357b751341ff": {
                 "class": "thermo_sensor",
@@ -1820,13 +1820,13 @@ class TestPlugwise:  # pylint: disable=attribute-defined-outside-init
                 "model": "Plug",
                 "name": "CV Pomp",
                 "vendor": "Plugwise",
+                "binary_sensors": {"relay": True},
                 "sensors": {
                     "electricity_consumed": 35.6,
                     "electricity_consumed_interval": 7.37,
                     "electricity_produced": 0.0,
                     "electricity_produced_interval": 0.0,
                 },
-                "switches": {"relay": True},
             },
             "90986d591dcd426cae3ec3e8111ff730": {
                 "class": "heater_central",


### PR DESCRIPTION
In order to depreciate the related switches at a later point in time.