### PR TITLE
Set-functions: rework to raise instead of return

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+# v0.17.5: Smile: rework to raise instead of return
+- raise in error-cases, move LOGGER.debug messages into raise
+- clean up code
+
+# v0.17.4 - Smile: improve typing hints, implement mypy testing
+
 # v0.17.3 - Smile Adam: add support for heater_electric type Plugs
 
 # v0.17.2 - Smile Adam: more bugfixes, improvementds

--- a/plugwise/__init__.py
+++ b/plugwise/__init__.py
@@ -1,6 +1,6 @@
 """Plugwise module."""
 
-__version__ = "0.17.3"
+__version__ = "0.17.5a0"
 
 from plugwise.smile import Smile
 from plugwise.stick import Stick

--- a/plugwise/__init__.py
+++ b/plugwise/__init__.py
@@ -1,6 +1,6 @@
 """Plugwise module."""
 
-__version__ = "0.17.5a0"
+__version__ = "0.17.5"
 
 from plugwise.smile import Smile
 from plugwise.stick import Stick

--- a/plugwise/exceptions.py
+++ b/plugwise/exceptions.py
@@ -59,6 +59,10 @@ class InvalidSetupError(PlugwiseException):
     """Raised when adding an Anna while an Adam exists."""
 
 
+class PlugwiseError(PlugwiseException):
+    """Raise when a non-specific error happens."""
+
+
 class UnsupportedDeviceError(PlugwiseException):
     """Raised when device is not supported."""
 

--- a/plugwise/helper.py
+++ b/plugwise/helper.py
@@ -227,18 +227,18 @@ class SmileComm:
             return
 
         if resp.status == 401:
-            raise InvalidAuthentication
+            raise InvalidAuthentication(
+                "Invalid login, please retry with the correct credentials."
+            )
 
         if not (result := await resp.text()) or "<error>" in result:
-            LOGGER.error("Smile response empty or error in %s", result)
-            raise ResponseError
+            raise ResponseError(f"Smile response empty or error in {result}.")
 
         try:
             # Encode to ensure utf8 parsing
             xml = etree.XML(escape_illegal_xml_characters(result).encode())
         except etree.ParseError:
-            LOGGER.error("Smile returns invalid XML for %s", self._endpoint)
-            raise InvalidXMLError
+            raise InvalidXMLError(f"Smile returns invalid XML for {self._endpoint}.")
 
         return xml
 
@@ -271,8 +271,9 @@ class SmileComm:
                 )
         except ServerTimeoutError:
             if retry < 1:
-                LOGGER.error("Timed out sending %s command to Plugwise", command)
-                raise DeviceTimeoutError
+                raise DeviceTimeoutError(
+                    f"Timed out sending {command} command to Plugwise"
+                )
             return await self._request(command, retry - 1)
 
         return await self._request_validate(resp, method)

--- a/plugwise/smile.py
+++ b/plugwise/smile.py
@@ -490,7 +490,8 @@ class Smile(SmileComm, SmileData):
         Determined from - DOMAIN_OBJECTS.
         """
         if self._smile_legacy:
-            return await self._set_schedule_state_legacy(name, state)
+            await self._set_schedule_state_legacy(name, state)
+            return
 
         schedule_rule = self._rule_ids_by_name(name, loc_id)
         if not schedule_rule or schedule_rule is None:
@@ -544,6 +545,7 @@ class Smile(SmileComm, SmileData):
         """Set the given Preset on the relevant Thermostat - from LOCATIONS."""
         if self._smile_legacy:
             await self._set_preset_legacy(preset)
+            return
 
         current_location = self._locations.find(f'location[@id="{loc_id}"]')
         location_name = current_location.find("name").text

--- a/plugwise/smile.py
+++ b/plugwise/smile.py
@@ -529,7 +529,7 @@ class Smile(SmileComm, SmileData):
         )
         await self._request(uri, method="put", data=data)
 
-    async def _set_preset_legacy(self, preset: str) -> bool:
+    async def _set_preset_legacy(self, preset: str) -> None:
         """Set the given Preset on the relevant Thermostat - from DOMAIN_OBJECTS."""
         locator = f'rule/directives/when/then[@icon="{preset}"].../.../...'
         if (rule := self._domain_objects.find(locator)) is None:
@@ -543,7 +543,7 @@ class Smile(SmileComm, SmileData):
     async def set_preset(self, loc_id: str, preset: str) -> None:
         """Set the given Preset on the relevant Thermostat - from LOCATIONS."""
         if self._smile_legacy:
-            return await self._set_preset_legacy(preset)
+            await self._set_preset_legacy(preset)
 
         current_location = self._locations.find(f'location[@id="{loc_id}"]')
         location_name = current_location.find("name").text

--- a/plugwise/smile.py
+++ b/plugwise/smile.py
@@ -459,7 +459,7 @@ class Smile(SmileComm, SmileData):
 
         return [self.gw_data, self.gw_devices]
 
-    async def _set_schedule_state_legacy(self, name: str, status: str) -> bool:
+    async def _set_schedule_state_legacy(self, name: str, status: str) -> None:
         """Helper-function for set_schedule_state()."""
         schedule_rule_id: str | None = None
         for rule in self._domain_objects.findall("rule"):
@@ -485,7 +485,7 @@ class Smile(SmileComm, SmileData):
 
         await self._request(uri, method="put", data=data)
 
-    async def set_schedule_state(self, loc_id: str, name: str, state: str) -> bool:
+    async def set_schedule_state(self, loc_id: str, name: str, state: str) -> None:
         """Set the Schedule, with the given name, on the relevant Thermostat.
         Determined from - DOMAIN_OBJECTS.
         """
@@ -540,7 +540,7 @@ class Smile(SmileComm, SmileData):
 
         await self._request(uri, method="put", data=data)
 
-    async def set_preset(self, loc_id: str, preset: str) -> bool:
+    async def set_preset(self, loc_id: str, preset: str) -> None:
         """Set the given Preset on the relevant Thermostat - from LOCATIONS."""
         if self._smile_legacy:
             return await self._set_preset_legacy(preset)
@@ -561,7 +561,7 @@ class Smile(SmileComm, SmileData):
 
         await self._request(uri, method="put", data=data)
 
-    async def set_temperature(self, loc_id: str, temperature: str) -> bool:
+    async def set_temperature(self, loc_id: str, temperature: str) -> None:
         """Set the given Temperature on the relevant Thermostat."""
         uri = self._thermostat_uri(loc_id)
         data = (
@@ -571,7 +571,7 @@ class Smile(SmileComm, SmileData):
 
         await self._request(uri, method="put", data=data)
 
-    async def set_max_boiler_temperature(self, temperature: str) -> bool:
+    async def set_max_boiler_temperature(self, temperature: str) -> None:
         """Set the max. Boiler Temperature on the Central heating boiler."""
         locator = f'appliance[@id="{self._heater_id}"]/actuator_functionalities/thermostat_functionality'
         th_func = self._appliances.find(locator)
@@ -585,7 +585,7 @@ class Smile(SmileComm, SmileData):
 
     async def _set_groupswitch_member_state(
         self, members: list[str], state: str, switch: Munch
-    ) -> bool:
+    ) -> None:
         """Helper-function for set_switch_state() .
         Set the given State of the relevant Switch within a group of members.
         """
@@ -601,7 +601,7 @@ class Smile(SmileComm, SmileData):
 
     async def set_switch_state(
         self, appl_id: str, members: list[str] | None, model: str, state: str
-    ) -> bool:
+    ) -> None:
         """Set the given State of the relevant Switch."""
         switch = Munch()
         switch.actuator = "actuator_functionalities"
@@ -641,7 +641,7 @@ class Smile(SmileComm, SmileData):
 
         await self._request(uri, method="put", data=data)
 
-    async def set_regulation_mode(self, mode: str) -> bool:
+    async def set_regulation_mode(self, mode: str) -> None:
         """Set the heating regulation mode."""
         if mode not in self._allowed_modes:
             raise PlugwiseError("Invalid regulation mode.")
@@ -654,7 +654,7 @@ class Smile(SmileComm, SmileData):
 
         await self._request(uri, method="put", data=data)
 
-    async def delete_notification(self) -> bool:
+    async def delete_notification(self) -> None:
         """Delete the active Plugwise Notification."""
         uri = NOTIFICATIONS
 

--- a/plugwise/smile.py
+++ b/plugwise/smile.py
@@ -637,7 +637,7 @@ class Smile(SmileComm, SmileData):
             lock_state: str = self._appliances.find(locator).text
             # Don't bother switching a relay when the corresponding lock-state is true
             if lock_state == "true":
-                return
+                raise PlugwiseException("Cannot switch a locked Relay.")
 
         await self._request(uri, method="put", data=data)
 

--- a/tests/test_smile.py
+++ b/tests/test_smile.py
@@ -465,12 +465,14 @@ class TestPlugwise:  # pylint: disable=attribute-defined-outside-init
             try:
                 await smile.set_switch_state(dev_id, members, model, new_state)
                 switch_change = True
+            except pw_exceptions.PlugwiseException:
+                _LOGGER.info("  + failed as expected")
             except (
                 pw_exceptions.ErrorSendingCommandError,
                 pw_exceptions.ResponseError,
             ):
+                switch_change = False
                 if unhappy:
-                    switch_change = False
                     _LOGGER.info("  + failed as expected")
                 else:  # pragma: no cover
                     _LOGGER.info("  - failed unexpectedly")

--- a/tests/test_smile.py
+++ b/tests/test_smile.py
@@ -465,7 +465,7 @@ class TestPlugwise:  # pylint: disable=attribute-defined-outside-init
             try:
                 await smile.set_switch_state(dev_id, members, model, new_state)
                 switch_change = True
-            except pw_exceptions.PlugwiseException:
+            except pw_exceptions.PlugwiseError:
                 _LOGGER.info("  + failed as expected")
             except (
                 pw_exceptions.ErrorSendingCommandError,
@@ -510,7 +510,7 @@ class TestPlugwise:  # pylint: disable=attribute-defined-outside-init
             try:
                 await smile.set_preset(loc_id, new_preset)
                 _LOGGER.info("  + worked as intended")
-            except pw_exceptions.PlugwiseException:
+            except pw_exceptions.PlugwiseError:
                 _LOGGER.info("  + failed as expected")
             except (
                 pw_exceptions.ErrorSendingCommandError,
@@ -537,7 +537,7 @@ class TestPlugwise:  # pylint: disable=attribute-defined-outside-init
                 try:
                     await smile.set_schedule_state(loc_id, new_schedule, state)
                     _LOGGER.info("  + failed as intended")
-                except pw_exceptions.PlugwiseException:
+                except pw_exceptions.PlugwiseError:
                     _LOGGER.info("  + failed as expected")
                 except (
                     pw_exceptions.ErrorSendingCommandError,
@@ -584,7 +584,7 @@ class TestPlugwise:  # pylint: disable=attribute-defined-outside-init
             try:
                 await smile.set_regulation_mode(mode)
                 _LOGGER.info("  + worked as intended")
-            except pw_exceptions.PlugwiseException:
+            except pw_exceptions.PlugwiseError:
                 _LOGGER.info("  + failed as expected")
 
     @staticmethod

--- a/tests/test_smile.py
+++ b/tests/test_smile.py
@@ -581,8 +581,11 @@ class TestPlugwise:  # pylint: disable=attribute-defined-outside-init
                 warning = " Negative test"
                 mode = mode[1:]
             _LOGGER.info("%s", f"- Adjusting regulation mode to {mode}{warning}")
-            await smile.set_regulation_mode(mode)
-            _LOGGER.info("  + worked as intended")
+            try:
+                await smile.set_regulation_mode(mode)
+                _LOGGER.info("  + worked as intended")
+            except pw_exceptions.PlugwiseException:
+                _LOGGER.info("  + failed as expected")
 
     @staticmethod
     async def tinker_max_boiler_temp(smile):

--- a/tests/test_smile.py
+++ b/tests/test_smile.py
@@ -463,9 +463,8 @@ class TestPlugwise:  # pylint: disable=attribute-defined-outside-init
         for new_state in [False, True, False]:
             _LOGGER.info("- Switching %s", new_state)
             try:
-                switch_change = await smile.set_switch_state(
-                    dev_id, members, model, new_state
-                )
+                await smile.set_switch_state(dev_id, members, model, new_state)
+                switch_change = True
             except (
                 pw_exceptions.ErrorSendingCommandError,
                 pw_exceptions.ResponseError,
@@ -484,8 +483,7 @@ class TestPlugwise:  # pylint: disable=attribute-defined-outside-init
         for new_temp in [20.0, 22.9]:
             _LOGGER.info("- Adjusting temperature to %s", new_temp)
             try:
-                temp_change = await smile.set_temperature(loc_id, new_temp)
-                assert temp_change
+                await smile.set_temperature(loc_id, new_temp)
                 _LOGGER.info("  + worked as intended")
             except (
                 pw_exceptions.ErrorSendingCommandError,
@@ -501,16 +499,13 @@ class TestPlugwise:  # pylint: disable=attribute-defined-outside-init
     async def tinker_thermostat_preset(self, smile, loc_id, unhappy=False):
         """Toggle preset to test functionality."""
         for new_preset in ["asleep", "home", "!bogus"]:
-            assert_state = True
             warning = ""
             if new_preset[0] == "!":
-                assert_state = False
                 warning = " Negative test"
                 new_preset = new_preset[1:]
             _LOGGER.info("%s", f"- Adjusting preset to {new_preset}{warning}")
             try:
-                preset_change = await smile.set_preset(loc_id, new_preset)
-                assert preset_change == assert_state
+                await smile.set_preset(loc_id, new_preset)
                 _LOGGER.info("  + worked as intended")
             except (
                 pw_exceptions.ErrorSendingCommandError,
@@ -529,18 +524,13 @@ class TestPlugwise:  # pylint: disable=attribute-defined-outside-init
         if good_schedules != []:
             good_schedules.append("!VeryBogusScheduleNameThatNobodyEverUsesOrShouldUse")
             for new_schedule in good_schedules:
-                assert_state = True
                 warning = ""
                 if new_schedule[0] == "!":
-                    assert_state = False
                     warning = " Negative test"
                     new_schedule = new_schedule[1:]
                 _LOGGER.info("- Adjusting schedule to %s", f"{new_schedule}{warning}")
                 try:
-                    schedule_change = await smile.set_schedule_state(
-                        loc_id, new_schedule, state
-                    )
-                    assert schedule_change == assert_state
+                    await smile.set_schedule_state(loc_id, new_schedule, state)
                     _LOGGER.info("  + failed as intended")
                 except (
                     pw_exceptions.ErrorSendingCommandError,
@@ -579,15 +569,12 @@ class TestPlugwise:  # pylint: disable=attribute-defined-outside-init
     async def tinker_regulation_mode(smile):
         """Toggle regulation_mode to test functionality."""
         for mode in ["off", "heating", "bleeding_cold", "!bogus"]:
-            assert_state = True
             warning = ""
             if mode[0] == "!":
-                assert_state = False
                 warning = " Negative test"
                 mode = mode[1:]
             _LOGGER.info("%s", f"- Adjusting regulation mode to {mode}{warning}")
-            mode_change = await smile.set_regulation_mode(mode)
-            assert mode_change == assert_state
+            await smile.set_regulation_mode(mode)
             _LOGGER.info("  + worked as intended")
 
     @staticmethod
@@ -595,8 +582,7 @@ class TestPlugwise:  # pylint: disable=attribute-defined-outside-init
         """Change max boiler temp setpoint to test functionality."""
         new_temp = 60.0
         _LOGGER.info("- Adjusting temperature to %s", new_temp)
-        temp_change = await smile.set_max_boiler_temperature(new_temp)
-        assert temp_change
+        await smile.set_max_boiler_temperature(new_temp)
         _LOGGER.info("  + worked as intended")
 
     @pytest.mark.asyncio

--- a/tests/test_smile.py
+++ b/tests/test_smile.py
@@ -553,7 +553,7 @@ class TestPlugwise:  # pylint: disable=attribute-defined-outside-init
             good_schedules = ["Weekschema"]
 
         await self.tinker_thermostat_temp(smile, loc_id, unhappy)
-        await self.tinker_thermostat_preset(smile, loc_id, unhappy)
+        await self.tinker_thermostat_preset(smile, loc_id)
         await self.tinker_thermostat_schedule(
             smile, loc_id, "on", good_schedules, unhappy
         )

--- a/tests/test_smile.py
+++ b/tests/test_smile.py
@@ -470,6 +470,7 @@ class TestPlugwise:  # pylint: disable=attribute-defined-outside-init
                 pw_exceptions.ResponseError,
             ):
                 if unhappy:
+                    switch_change = False
                     _LOGGER.info("  + failed as expected")
                 else:  # pragma: no cover
                     _LOGGER.info("  - failed unexpectedly")

--- a/tests/test_smile.py
+++ b/tests/test_smile.py
@@ -466,7 +466,7 @@ class TestPlugwise:  # pylint: disable=attribute-defined-outside-init
                 await smile.set_switch_state(dev_id, members, model, new_state)
                 switch_change = True
             except pw_exceptions.PlugwiseError:
-                _LOGGER.info("  + failed as expected")
+                _LOGGER.info("  + locked, not switched as expected")
             except (
                 pw_exceptions.ErrorSendingCommandError,
                 pw_exceptions.ResponseError,
@@ -511,7 +511,7 @@ class TestPlugwise:  # pylint: disable=attribute-defined-outside-init
                 await smile.set_preset(loc_id, new_preset)
                 _LOGGER.info("  + worked as intended")
             except pw_exceptions.PlugwiseError:
-                _LOGGER.info("  + failed as expected")
+                _LOGGER.info("  + found invalid preset, as expected")
             except (
                 pw_exceptions.ErrorSendingCommandError,
                 pw_exceptions.ResponseError,
@@ -536,7 +536,7 @@ class TestPlugwise:  # pylint: disable=attribute-defined-outside-init
                 _LOGGER.info("- Adjusting schedule to %s", f"{new_schedule}{warning}")
                 try:
                     await smile.set_schedule_state(loc_id, new_schedule, state)
-                    _LOGGER.info("  + failed as intended")
+                    _LOGGER.info("  + found invalid schedule, as intended")
                 except pw_exceptions.PlugwiseError:
                     _LOGGER.info("  + failed as expected")
                 except (
@@ -585,7 +585,7 @@ class TestPlugwise:  # pylint: disable=attribute-defined-outside-init
                 await smile.set_regulation_mode(mode)
                 _LOGGER.info("  + worked as intended")
             except pw_exceptions.PlugwiseError:
-                _LOGGER.info("  + failed as expected")
+                _LOGGER.info("  + found invalid mode, as expected")
 
     @staticmethod
     async def tinker_max_boiler_temp(smile):

--- a/tests/test_smile.py
+++ b/tests/test_smile.py
@@ -496,7 +496,7 @@ class TestPlugwise:  # pylint: disable=attribute-defined-outside-init
                     raise self.UnexpectedError
 
     @pytest.mark.asyncio
-    async def tinker_thermostat_preset(self, smile, loc_id, unhappy=False):
+    async def tinker_thermostat_preset(self, smile, loc_id):
         """Toggle preset to test functionality."""
         for new_preset in ["asleep", "home", "!bogus"]:
             warning = ""
@@ -511,7 +511,7 @@ class TestPlugwise:  # pylint: disable=attribute-defined-outside-init
                 pw_exceptions.ErrorSendingCommandError,
                 pw_exceptions.ResponseError,
             ):
-                if unhappy:
+                if new_preset[0] == "!":
                     _LOGGER.info("  + failed as expected")
                 else:  # pragma: no cover
                     _LOGGER.info("  - failed unexpectedly")

--- a/tests/test_smile.py
+++ b/tests/test_smile.py
@@ -534,6 +534,8 @@ class TestPlugwise:  # pylint: disable=attribute-defined-outside-init
                 try:
                     await smile.set_schedule_state(loc_id, new_schedule, state)
                     _LOGGER.info("  + failed as intended")
+                except pw_exceptions.PlugwiseException:
+                    _LOGGER.info("  + failed as expected")
                 except (
                     pw_exceptions.ErrorSendingCommandError,
                     pw_exceptions.ResponseError,
@@ -555,7 +557,7 @@ class TestPlugwise:  # pylint: disable=attribute-defined-outside-init
             good_schedules = ["Weekschema"]
 
         await self.tinker_thermostat_temp(smile, loc_id, unhappy)
-        await self.tinker_thermostat_preset(smile, loc_id)
+        await self.tinker_thermostat_preset(smile, loc_id, unhappy)
         await self.tinker_thermostat_schedule(
             smile, loc_id, "on", good_schedules, unhappy
         )

--- a/tests/test_smile.py
+++ b/tests/test_smile.py
@@ -496,7 +496,7 @@ class TestPlugwise:  # pylint: disable=attribute-defined-outside-init
                     raise self.UnexpectedError
 
     @pytest.mark.asyncio
-    async def tinker_thermostat_preset(self, smile, loc_id):
+    async def tinker_thermostat_preset(self, smile, loc_id, unhappy=False):
         """Toggle preset to test functionality."""
         for new_preset in ["asleep", "home", "!bogus"]:
             warning = ""
@@ -507,11 +507,13 @@ class TestPlugwise:  # pylint: disable=attribute-defined-outside-init
             try:
                 await smile.set_preset(loc_id, new_preset)
                 _LOGGER.info("  + worked as intended")
+            except pw_exceptions.PlugwiseException:
+                _LOGGER.info("  + failed as expected")
             except (
                 pw_exceptions.ErrorSendingCommandError,
                 pw_exceptions.ResponseError,
             ):
-                if new_preset[0] == "!":
+                if unhappy:
                     _LOGGER.info("  + failed as expected")
                 else:  # pragma: no cover
                     _LOGGER.info("  - failed unexpectedly")

--- a/tests/test_smile.py
+++ b/tests/test_smile.py
@@ -3041,7 +3041,7 @@ class TestPlugwise:  # pylint: disable=attribute-defined-outside-init
         try:
             _server, _smile, _client = await self.connect_wrapper()
             assert False  # pragma: no cover
-        except pw_exceptions.ConnectionFailedError:
+        except pw_exceptions.InvalidXMLError:
             assert True
 
     @pytest.mark.asyncio


### PR DESCRIPTION
Also:
- move error-messages into the raises
- cleanup unneeded try-excepts, already handled in _request()