### PR TITLE
Final fix for https://github.com/plugwise/plugwise-beta/issues/320

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 # Changelog
 
+## v0.27.10: Anna + Elga: final fix for [#320](https://github.com/plugwise/plugwise-beta/issues/320)
+
 ## v0.27.9: P1 legacy: collect data from /core/modules
 
 - Collect P1 legacy data from /core/modules - fix for [#368](https://github.com/plugwise/plugwise-beta/issues/368)

--- a/plugwise/helper.py
+++ b/plugwise/helper.py
@@ -968,6 +968,10 @@ class SmileHelper:
                 else:
                     data["heating_state"] = data["c_heating_state"]
 
+        if self._elga:
+            # Anna + Elga: use central_heating_state to show heating_state
+            data["heating_state"] = data["c_heating_state"]
+
     def _get_appliance_data(self, d_id: str) -> DeviceData:
         """Helper-function for smile.py: _get_device_data().
 
@@ -1008,16 +1012,10 @@ class SmileHelper:
 
         if d_id == self._heater_id and self.smile_name == "Smile Anna":
             if "elga_status_code" in data:
-                # Base heating_/cooling_state on the elga-status-code
-                data["heating_state"] = False
-                data["cooling_state"] = False
-                if data["elga_status_code"] in [4, 10] or (
-                    data["elga_status_code"] in [3, 5, 6, 11] and not data["dhw_state"]
-                ):
-                    data["heating_state"] = True
-                if data["elga_status_code"] == 8:
-                    data["cooling_state"] = self._cooling_active = True
-
+                # Base cooling_state on the elga-status-code
+                data["cooling_state"] = self._cooling_active = (
+                    data["elga_status_code"] == 8
+                )
                 data.pop("elga_status_code", None)
 
                 # Determine _cooling_present and _cooling_enabled

--- a/plugwise/helper.py
+++ b/plugwise/helper.py
@@ -940,12 +940,12 @@ class SmileHelper:
         if "temperature" in data:
             data.pop("heating_state", None)
 
-        # Don't show cooling-related when no cooling present
+        # Don't show cooling-related when no cooling present,
+        # but, keep cooling_enabled for Elga
         if not self._cooling_present:
             for item in ("cooling_state", "cooling_ena_switch"):
                 if item in data:
                     data.pop(item)
-            # Keep cooling_enabled for Elga
             if not self._elga and "cooling_enabled" in data:
                 data.pop("cooling_enabled")  # pragma: no cover
 
@@ -960,16 +960,16 @@ class SmileHelper:
             if self.smile_name == "Smile Anna":
                 data["heating_state"] = data["c_heating_state"]
 
+            # Adam + OnOff cooling: use central_heating_state to show heating/cooling_state
             if self.smile_name == "Adam":
-                data["heating_state"] = False
-                # Adam + OnOff cooling: use central_heating_state to show heating/cooling_state
+                data["cooling_state"] = data["heating_state"] = False
                 if self._cooling_enabled:
                     data["cooling_state"] = data["c_heating_state"]
                 else:
                     data["heating_state"] = data["c_heating_state"]
 
+        # Anna + Elga: use central_heating_state to show heating_state
         if self._elga:
-            # Anna + Elga: use central_heating_state to show heating_state
             data["heating_state"] = data["c_heating_state"]
 
     def _get_appliance_data(self, d_id: str) -> DeviceData:
@@ -1011,8 +1011,8 @@ class SmileHelper:
             data.pop("c_heating_state")
 
         if d_id == self._heater_id and self.smile_name == "Smile Anna":
+            # Anna+Elga: base cooling_state on the elga-status-code
             if "elga_status_code" in data:
-                # Base cooling_state on the elga-status-code
                 data["cooling_state"] = self._cooling_active = (
                     data["elga_status_code"] == 8
                 )
@@ -1026,8 +1026,10 @@ class SmileHelper:
                 # Elga has no cooling-switch
                 if "cooling_ena_switch" in data:
                     data.pop("cooling_ena_switch")
+
+            # Loria/Thermastage: cooling-related is based on cooling_state
+            # and modulation_level
             else:
-                # Loria/Thermastage: cooling-related is based on cooling_state and modulation_level
                 if self._cooling_present and "cooling_state" in data:
                     self._cooling_enabled = data["cooling_state"]
                     self._cooling_active = data["modulation_level"] == 100

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name            = "plugwise"
-version         = "0.27.9"
+version         = "0.27.10"
 license         = {file = "LICENSE"}
 description     = "Plugwise Smile (Adam/Anna/P1), Stretch and USB (Stick) module for Python 3."
 readme          = "README.md"


### PR DESCRIPTION
https://github.com/plugwise/plugwise-beta/issues/320#issuecomment-1501164797 shows that the xml-key `central_heating_state` represents the heating_state of the Elga-based heating-system correctly.