### PR TITLE
Enable pre-commit, detect requirements better

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,6 +1,12 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": ["config:base", ":dependencyDashboard", "schedule:daily"],
+  "pre-commit": {
+    "enabled": true
+  },
+  "pip_requirements": {
+    "fileMatch": ["(^|/)([\\w-]*)requirements.*\\.(txt|pip)$"]
+  },
   "packageRules": [
     {
       "matchManagers": ["github-actions"],


### PR DESCRIPTION
Ensure renovatebot pre-commit (beta-only) is enabled and improve requirements detection