### PR TITLE
Release drafter

### DIFF
--- a/.github/release.yml
+++ b/.github/release.yml
@@ -1,0 +1,35 @@
+# Release drafter
+
+changelog:
+  categories:
+    - title: Breaking Changes 🛠
+      labels:
+        - Semver-Major
+        - breaking-change
+    - title: Exciting New Features 🎉
+      labels:
+        - Semver-Minor
+        - "feature"
+        - "enhancement"
+        - "quality"
+        - "smile"
+    - title: Bug Fixes 🐛
+      labels:
+        - "fix"
+        - "bugfix"
+        - "bug"
+    - title: Maintenance 🧰
+      labels:
+        - "chore"
+        - "dashboard"
+        - "auto-merge"
+        - "dependencies"
+        - "python"
+        - "documentation"
+        - "github-actions"
+        - "userdata"
+        - "pre-commit"
+        - "manual-merge"
+    - title: Other Changes
+      labels:
+        - "*"


### PR DESCRIPTION
Using https://docs.github.com/en/repositories/releasing-projects-on-github/automation-for-release-forms-with-query-parameters to pre-generate drafts for releases. Which we probably can use to automatically update our changelog as well in the near future.

Requires to properly set labels on PRs, but should s(h)ave some work - the Github intended way is to just use release(notes) as changelog.