### PR TITLE
Update build system requirements

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,5 @@
 [build-system]
-requires = ["setuptools~=62.3", "wheel~=0.37.1"]
+requires = ["setuptools~=68.0", "wheel~=0.40.0"]
 build-backend = "setuptools.build_meta"
 
 [project]


### PR DESCRIPTION
To build packages for Python 3.12 it's necessary to update setuptools to at least `>=66.1.0`.

https://setuptools.pypa.io/en/latest/history.html#v68-0-0
https://wheel.readthedocs.io/en/stable/news.html