### PR TITLE
 Fix issue introduced by ruff: replace using .keys() in xml-find result

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-### Ongoing
+## Ongoing
 
 - Fix issue introduced by ruff: replace using .keys() in xml-find result
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+### Ongoing
+
+- Fix issue introduced by ruff: replace using .keys() in xml-find result
+
 ## v0.31.9: Further typing improvements
 
 - Add NumberType, SelectType and SelectOptionsType constants to improve typing further

--- a/plugwise/helper.py
+++ b/plugwise/helper.py
@@ -80,7 +80,7 @@ def etree_to_dict(element: etree) -> dict[str, str]:
     """Helper-function translating xml Element to dict."""
     node: dict[str, str] = {}
 
-    text = getattr(element, "text", None)
+    getattr(element, "text", None)
     if element is not None:
         node.update(element.items())
 

--- a/plugwise/helper.py
+++ b/plugwise/helper.py
@@ -76,6 +76,19 @@ from .util import (
 # from typing import cast
 
 
+def etree_to_dict(element):
+    """Helper-function translating xml Element to dict."""
+    node: dict[str, str] = {}
+
+    if (text := getattr(element, "text", None)) is not None:
+        node["text"] = text
+
+    if element is not None:
+        node.update(element.items())
+
+    return node
+
+
 def update_helper(
     data: DeviceData,
     devices: dict[str, DeviceData],
@@ -1303,10 +1316,12 @@ class SmileHelper:
 
         locator = "./rule[active='true']/directives/when/then"
         if (
-            active_rule := self._domain_objects.find(locator)
-        ) is None or "icon" not in active_rule.keys():  # noqa: SIM118
+            not (active_rule := etree_to_dict(self._domain_objects.find(locator)))
+            or "icon" not in active_rule
+        ):
             return None
-        return str(active_rule.attrib["icon"])
+
+        return active_rule["icon"]
 
     def _schedules_legacy(
         self, avail: list[str], sel: str

--- a/plugwise/helper.py
+++ b/plugwise/helper.py
@@ -79,7 +79,6 @@ from .util import (
 def etree_to_dict(element: etree) -> dict[str, str]:
     """Helper-function translating xml Element to dict."""
     node: dict[str, str] = {}
-
     getattr(element, "text", None)
     if element is not None:
         node.update(element.items())

--- a/plugwise/helper.py
+++ b/plugwise/helper.py
@@ -80,9 +80,7 @@ def etree_to_dict(element: etree) -> dict[str, str]:
     """Helper-function translating xml Element to dict."""
     node: dict[str, str] = {}
 
-    if (text := getattr(element, "text", None)) is not None:
-        node["text"] = text
-
+    text = getattr(element, "text", None)
     if element is not None:
         node.update(element.items())
 

--- a/plugwise/helper.py
+++ b/plugwise/helper.py
@@ -76,7 +76,7 @@ from .util import (
 # from typing import cast
 
 
-def etree_to_dict(element):
+def etree_to_dict(element: etree) -> dict[str, str]:
     """Helper-function translating xml Element to dict."""
     node: dict[str, str] = {}
 


### PR DESCRIPTION
This removes the need for the `# noqa: SIM118`