### PR TITLE
Revert codecov-action to v3

### DIFF
--- a/.github/workflows/verify.yml
+++ b/.github/workflows/verify.yml
@@ -331,7 +331,7 @@ jobs:
           coverage report --fail-under=94
           coverage xml
       - name: Upload coverage to Codecov
-        uses: codecov/codecov-action@v4
+        uses: codecov/codecov-action@v3
 
   test-publishing:
     name: Build and publish Python 🐍 distributions 📦 to TestPyPI


### PR DESCRIPTION
Looks like codecov-action@v4 is still in beta, revert to v3 until v4 is formally released.