### PR TITLE
Reorder device-dicts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Ongoing
 
+- Reorder device-dicts: gateway first, optionally heater_central second
 - Improve handling of obsolete sensors (solution for [HA Core issue #100306](https://github.com/home-assistant/core/issues/100306)
 - Improve handling of invalid actuator xml-data (partial solution for [HA Core issue #99372](https://github.com/home-assistant/core/issues/99372)
 

--- a/plugwise/helper.py
+++ b/plugwise/helper.py
@@ -717,6 +717,16 @@ class SmileHelper:
                     # Leave for-loop to avoid a 2nd device_id switch
                     break
 
+        # Place the gateway and optional heater_central devices as 1st and 2nd
+        for dev_class in ("heater_central", "gateway"):
+            for dev_id, device in dict(self.gw_devices).items():
+                if device["dev_class"] == dev_class:
+                    tmp_device = device
+                    self.gw_devices.pop(dev_id)
+                    cleared_dict = self.gw_devices
+                    add_to_front = {dev_id: tmp_device}
+                    self.gw_devices = {**add_to_front, **cleared_dict}
+
     def _match_locations(self) -> dict[str, ThermoLoc]:
         """Helper-function for _scan_thermostats().
 


### PR DESCRIPTION
This make sure that the various heater-central states are known before the device-dicts for thermostats are created.