### PR TITLE
Improve set_schedule_state()

### DIFF
--- a/.github/workflows/verify.yml
+++ b/.github/workflows/verify.yml
@@ -4,7 +4,7 @@
 name: Latest commit
 
 env:
-  CACHE_VERSION: 2
+  CACHE_VERSION: 3
   DEFAULT_PYTHON: "3.11"
   PRE_COMMIT_HOME: ~/.cache/pre-commit
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Ongoing
 
+- Bugfix for [Core Issue #102204](https://github.com/home-assistant/core/issues/102204)
 - Add item-count to output
 - Support python 3.12
 

--- a/plugwise/__init__.py
+++ b/plugwise/__init__.py
@@ -602,6 +602,24 @@ class Smile(SmileComm, SmileData):
         await self._request(uri, method="put", data=data)
         self._schedule_old_states[loc_id][name] = new_state
 
+    def determine_contexts(self, loc_id: str, schedule_rule_id: str) -> etree
+        """Helper function for set_schedule_state()."""
+        locator = f'.//*[@id="{schedule_rule_id}"]/contexts'
+        contexts = self._domain_objects.find(locator)
+        locator = f'.//*[@id="{loc_id}"].../...'
+        if (subject := contexts.find(locator)) is None:
+            subject = f'<context><zone><location id="{loc_id}" /></zone></context>'
+            subject = etree.fromstring(subject)
+
+        if new_state == "off":
+            self._last_active[loc_id] = name
+            contexts.remove(subject)
+        if new_state == "on":
+            contexts.append(subject)
+
+        contexts = etree.tostring(contexts, encoding="unicode").rstrip()
+        return contexts
+
     async def set_schedule_state(
         self,
         loc_id: str,
@@ -647,21 +665,7 @@ class Smile(SmileComm, SmileData):
             template_id = self._domain_objects.find(locator).attrib["id"]
             template = f'<template id="{template_id}" />'
 
-        locator = f'.//*[@id="{schedule_rule_id}"]/contexts'
-        contexts = self._domain_objects.find(locator)
-        locator = f'.//*[@id="{loc_id}"].../...'
-        if (subject := contexts.find(locator)) is None:
-            subject = f'<context><zone><location id="{loc_id}" /></zone></context>'
-            subject = etree.fromstring(subject)
-
-        if new_state == "off":
-            self._last_active[loc_id] = name
-            contexts.remove(subject)
-        if new_state == "on":
-            contexts.append(subject)
-
-        contexts = etree.tostring(contexts, encoding="unicode").rstrip()
-
+        self.determine_contexts(loc_id, schedule_rule_id)
         uri = f"{RULES};id={schedule_rule_id}"
         data = (
             f'<rules><rule id="{schedule_rule_id}"><name><![CDATA[{name}]]></name>'

--- a/plugwise/__init__.py
+++ b/plugwise/__init__.py
@@ -602,19 +602,19 @@ class Smile(SmileComm, SmileData):
         await self._request(uri, method="put", data=data)
         self._schedule_old_states[loc_id][name] = new_state
 
-    def determine_contexts(self, loc_id: str, schedule_rule_id: str) -> etree:
+    def determine_contexts(self, loc_id: str, state: str, sched_id: str) -> etree:
         """Helper function for set_schedule_state()."""
-        locator = f'.//*[@id="{schedule_rule_id}"]/contexts'
+        locator = f'.//*[@id="{sched_id}"]/contexts'
         contexts = self._domain_objects.find(locator)
         locator = f'.//*[@id="{loc_id}"].../...'
         if (subject := contexts.find(locator)) is None:
             subject = f'<context><zone><location id="{loc_id}" /></zone></context>'
             subject = etree.fromstring(subject)
 
-        if new_state == "off":
+        if state == "off":
             self._last_active[loc_id] = name
             contexts.remove(subject)
-        if new_state == "on":
+        if state == "on":
             contexts.append(subject)
 
         contexts = etree.tostring(contexts, encoding="unicode").rstrip()
@@ -665,7 +665,7 @@ class Smile(SmileComm, SmileData):
             template_id = self._domain_objects.find(locator).attrib["id"]
             template = f'<template id="{template_id}" />'
 
-        self.determine_contexts(loc_id, schedule_rule_id)
+        self.determine_contexts(loc_id, new_state, schedule_rule_id)
         uri = f"{RULES};id={schedule_rule_id}"
         data = (
             f'<rules><rule id="{schedule_rule_id}"><name><![CDATA[{name}]]></name>'

--- a/plugwise/__init__.py
+++ b/plugwise/__init__.py
@@ -603,7 +603,10 @@ class Smile(SmileComm, SmileData):
         self._schedule_old_states[loc_id][name] = new_state
 
     async def set_schedule_state(
-        self, loc_id: str, new_state: str, name: str | None = None, 
+        self,
+        loc_id: str,
+        new_state: str,
+        name: str | None = None,
     ) -> None:
         """Activate/deactivate the Schedule, with the given name, on the relevant Thermostat.
 

--- a/plugwise/__init__.py
+++ b/plugwise/__init__.py
@@ -611,15 +611,17 @@ class Smile(SmileComm, SmileData):
         """Activate/deactivate the Schedule, with the given name, on the relevant Thermostat.
 
         Determined from - DOMAIN_OBJECTS.
-        In HA Core used to set the hvac_mode: in practice switch between schedule on - off.
+        Used in HA Core to set the hvac_mode: in practice switch between schedule on - off.
         """
         # Input checking
         if new_state not in ["on", "off"]:
             raise PlugwiseError("Plugwise: invalid schedule state.")
         if name is None:
             for device in self.gw_devices:
-                if device["location"] == loc_id:
+                if device["location"] == loc_id and device["last_used"]:
                     name = device["last_used"]
+                else:
+                    return
 
         if self._smile_legacy:
             await self._set_schedule_state_legacy(loc_id, name, new_state)

--- a/plugwise/__init__.py
+++ b/plugwise/__init__.py
@@ -623,6 +623,7 @@ class Smile(SmileComm, SmileData):
                 else:
                     return
 
+        assert isinstance(name, str)
         if self._smile_legacy:
             await self._set_schedule_state_legacy(loc_id, name, new_state)
             return

--- a/plugwise/__init__.py
+++ b/plugwise/__init__.py
@@ -602,7 +602,7 @@ class Smile(SmileComm, SmileData):
         await self._request(uri, method="put", data=data)
         self._schedule_old_states[loc_id][name] = new_state
 
-    def determine_contexts(self, loc_id: str, state: str, sched_id: str) -> etree:
+    def determine_contexts(self, loc_id: str, name: str, state: str, sched_id: str) -> etree:
         """Helper function for set_schedule_state()."""
         locator = f'.//*[@id="{sched_id}"]/contexts'
         contexts = self._domain_objects.find(locator)
@@ -664,7 +664,7 @@ class Smile(SmileComm, SmileData):
             template_id = self._domain_objects.find(locator).attrib["id"]
             template = f'<template id="{template_id}" />'
 
-        contexts = self.determine_contexts(loc_id, new_state, schedule_rule_id)
+        contexts = self.determine_contexts(loc_id, name, new_state, schedule_rule_id)
         uri = f"{RULES};id={schedule_rule_id}"
         data = (
             f'<rules><rule id="{schedule_rule_id}"><name><![CDATA[{name}]]></name>'

--- a/plugwise/__init__.py
+++ b/plugwise/__init__.py
@@ -602,7 +602,9 @@ class Smile(SmileComm, SmileData):
         await self._request(uri, method="put", data=data)
         self._schedule_old_states[loc_id][name] = new_state
 
-    def determine_contexts(self, loc_id: str, name: str, state: str, sched_id: str) -> etree:
+    def determine_contexts(
+        self, loc_id: str, name: str, state: str, sched_id: str
+    ) -> etree:
         """Helper-function for set_schedule_state()."""
         locator = f'.//*[@id="{sched_id}"]/contexts'
         contexts = self._domain_objects.find(locator)

--- a/plugwise/__init__.py
+++ b/plugwise/__init__.py
@@ -617,7 +617,7 @@ class Smile(SmileComm, SmileData):
         if new_state not in ["on", "off"]:
             raise PlugwiseError("Plugwise: invalid schedule state.")
         if name is None:
-            for device in self.gw_devices:
+            for device in self.gw_devices.values():
                 if device["location"] == loc_id and device["last_used"]:
                     name = device["last_used"]
                 else:

--- a/plugwise/__init__.py
+++ b/plugwise/__init__.py
@@ -602,7 +602,7 @@ class Smile(SmileComm, SmileData):
         await self._request(uri, method="put", data=data)
         self._schedule_old_states[loc_id][name] = new_state
 
-    def determine_contexts(self, loc_id: str, schedule_rule_id: str) -> etree
+    def determine_contexts(self, loc_id: str, schedule_rule_id: str) -> etree:
         """Helper function for set_schedule_state()."""
         locator = f'.//*[@id="{schedule_rule_id}"]/contexts'
         contexts = self._domain_objects.find(locator)

--- a/plugwise/__init__.py
+++ b/plugwise/__init__.py
@@ -617,8 +617,7 @@ class Smile(SmileComm, SmileData):
         if state == "on":
             contexts.append(subject)
 
-        contexts = etree.tostring(contexts, encoding="unicode").rstrip()
-        return contexts
+        return etree.tostring(contexts, encoding="unicode").rstrip()
 
     async def set_schedule_state(
         self,
@@ -665,7 +664,7 @@ class Smile(SmileComm, SmileData):
             template_id = self._domain_objects.find(locator).attrib["id"]
             template = f'<template id="{template_id}" />'
 
-        self.determine_contexts(loc_id, new_state, schedule_rule_id)
+        contexts = self.determine_contexts(loc_id, new_state, schedule_rule_id)
         uri = f"{RULES};id={schedule_rule_id}"
         data = (
             f'<rules><rule id="{schedule_rule_id}"><name><![CDATA[{name}]]></name>'

--- a/plugwise/__init__.py
+++ b/plugwise/__init__.py
@@ -603,7 +603,7 @@ class Smile(SmileComm, SmileData):
         self._schedule_old_states[loc_id][name] = new_state
 
     async def set_schedule_state(
-        self, loc_id: str, name: str | None, new_state: str
+        self, loc_id: str, new_state: str, name: str | None = None, 
     ) -> None:
         """Activate/deactivate the Schedule, with the given name, on the relevant Thermostat.
 
@@ -614,9 +614,9 @@ class Smile(SmileComm, SmileData):
         if new_state not in ["on", "off"]:
             raise PlugwiseError("Plugwise: invalid schedule state.")
         if name is None:
-            raise PlugwiseError(
-                "Plugwise: cannot change schedule-state: no schedule name provided"
-            )
+            for device in self.gw_devices:
+                if device["location"] == loc_id:
+                    name = device["last_used"]
 
         if self._smile_legacy:
             await self._set_schedule_state_legacy(loc_id, name, new_state)

--- a/plugwise/__init__.py
+++ b/plugwise/__init__.py
@@ -603,7 +603,7 @@ class Smile(SmileComm, SmileData):
         self._schedule_old_states[loc_id][name] = new_state
 
     def determine_contexts(self, loc_id: str, name: str, state: str, sched_id: str) -> etree:
-        """Helper function for set_schedule_state()."""
+        """Helper-function for set_schedule_state()."""
         locator = f'.//*[@id="{sched_id}"]/contexts'
         contexts = self._domain_objects.find(locator)
         locator = f'.//*[@id="{loc_id}"].../...'

--- a/tests/test_smile.py
+++ b/tests/test_smile.py
@@ -553,11 +553,11 @@ class TestPlugwise:  # pylint: disable=attribute-defined-outside-init
                     new_schedule = new_schedule[1:]
                 _LOGGER.info("- Adjusting schedule to %s", f"{new_schedule}{warning}")
                 try:
-                    await smile.set_schedule_state(loc_id, new_schedule, state)
+                    await smile.set_schedule_state(loc_id, state, new_schedule)
                     tinker_schedule_passed = True
                     _LOGGER.info("  + working as intended")
                 except pw_exceptions.PlugwiseError:
-                    _LOGGER.info("  + failed as expected")
+                    _LOGGER.info("  + failed as expected")te
                     tinker_schedule_passed = True
                 except (
                     pw_exceptions.ErrorSendingCommandError,

--- a/tests/test_smile.py
+++ b/tests/test_smile.py
@@ -1953,6 +1953,9 @@ class TestPlugwise:  # pylint: disable=attribute-defined-outside-init
         )
         assert result
 
+        # special test-case for turning a schedule back on based onthe  last_used schedule
+        await smile.set_schedule_state("f2bf9048bef64cc5b6d5110154e33c81", "off")
+
         # bad schedule-state test
         result = await self.tinker_thermostat_schedule(
             smile,

--- a/tests/test_smile.py
+++ b/tests/test_smile.py
@@ -557,7 +557,7 @@ class TestPlugwise:  # pylint: disable=attribute-defined-outside-init
                     tinker_schedule_passed = True
                     _LOGGER.info("  + working as intended")
                 except pw_exceptions.PlugwiseError:
-                    _LOGGER.info("  + failed as expected")te
+                    _LOGGER.info("  + failed as expected")
                     tinker_schedule_passed = True
                 except (
                     pw_exceptions.ErrorSendingCommandError,

--- a/tests/test_smile.py
+++ b/tests/test_smile.py
@@ -1953,7 +1953,7 @@ class TestPlugwise:  # pylint: disable=attribute-defined-outside-init
         )
         assert result
 
-        # special test-case for turning a schedule back on based onthe  last_used schedule
+        # special test-case for turning a schedule back on based on the last_used schedule
         await smile.set_schedule_state("f2bf9048bef64cc5b6d5110154e33c81", "off")
 
         # bad schedule-state test


### PR DESCRIPTION
Solution for - https://github.com/home-assistant/core/issues/102204

Background of the Issue, this PR: https://github.com/plugwise/plugwise-beta/issues/276#issuecomment-1767139202 :
`set_schedule_state()` is called without a schedule-name from the `climate.turn_on` service.