### PR TITLE
Improvements for Anna+Elga

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## Ongoing
+
+- Anna+Elga now always has `cooling_present` set to `True`: the Elga (always) has cooling-capability.
+- Cooling-mode on/off is determined from specific Elga status-codes
+
 ## v0.34.0
 
 - New feature: for Adam, provide mode = off, related to the regulation_mode = off, and mode = cool, for regulation_mode = cooling.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## Ongoing
+## v0.34.1
 
 - Anna+Elga now always has `cooling_present` set to `True`: the Elga (always) has cooling-capability.
 - Cooling-mode on/off is determined from specific Elga status-codes

--- a/fixtures/anna_elga_2/all_data.json
+++ b/fixtures/anna_elga_2/all_data.json
@@ -45,13 +45,7 @@
       "mode": "auto",
       "model": "ThermoTouch",
       "name": "Anna",
-      "preset_modes": [
-        "away",
-        "no_frost",
-        "vacation",
-        "home",
-        "asleep"
-      ],
+      "preset_modes": ["away", "no_frost", "vacation", "home", "asleep"],
       "select_schedule": "Thermostat schedule",
       "sensors": {
         "cooling_activation_outdoor_temperature": 26.0,

--- a/fixtures/anna_elga_2/all_data.json
+++ b/fixtures/anna_elga_2/all_data.json
@@ -5,6 +5,7 @@
       "binary_sensors": {
         "compressor_state": false,
         "cooling_enabled": false,
+        "cooling_state": false,
         "dhw_state": false,
         "flame_state": false,
         "heating_state": false,
@@ -18,7 +19,7 @@
         "setpoint": 60.0,
         "upper_bound": 100.0
       },
-      "model": "Generic heater",
+      "model": "Generic heater/cooler",
       "name": "OpenTherm",
       "sensors": {
         "domestic_hot_water_setpoint": 60.0,
@@ -62,7 +63,8 @@
       "thermostat": {
         "lower_bound": 4.0,
         "resolution": 0.1,
-        "setpoint": 19.5,
+        "setpoint_high": 30.0,
+        "setpoint_low": 19.5,
         "upper_bound": 30.0
       },
       "vendor": "Plugwise"
@@ -85,10 +87,10 @@
     }
   },
   "gateway": {
-    "cooling_present": false,
+    "cooling_present": true,
     "gateway_id": "fb49af122f6e4b0f91267e1cf7666d6f",
     "heater_id": "573c152e7d4f4720878222bd75638f5b",
-    "item_count": 59,
+    "item_count": 62,
     "notifications": {},
     "smile_name": "Smile Anna"
   }

--- a/fixtures/anna_elga_2/all_data.json
+++ b/fixtures/anna_elga_2/all_data.json
@@ -45,13 +45,20 @@
       "mode": "auto",
       "model": "ThermoTouch",
       "name": "Anna",
-      "preset_modes": ["away", "no_frost", "vacation", "home", "asleep"],
+      "preset_modes": [
+        "away",
+        "no_frost",
+        "vacation",
+        "home",
+        "asleep"
+      ],
       "select_schedule": "Thermostat schedule",
       "sensors": {
         "cooling_activation_outdoor_temperature": 26.0,
         "cooling_deactivation_threshold": 3.0,
         "illuminance": 0.5,
-        "setpoint": 19.5,
+        "setpoint_high": 30.0,
+        "setpoint_low": 19.5,
         "temperature": 20.9
       },
       "temperature_offset": {

--- a/fixtures/anna_elga_2_schedule_off/all_data.json
+++ b/fixtures/anna_elga_2_schedule_off/all_data.json
@@ -37,21 +37,30 @@
     },
     "ebd90df1ab334565b5895f37590ccff4": {
       "active_preset": "home",
-      "available_schedules": ["Thermostat schedule"],
+      "available_schedules": [
+        "Thermostat schedule"
+      ],
       "dev_class": "thermostat",
       "firmware": "2018-02-08T11:15:53+01:00",
       "hardware": "6539-1301-5002",
       "location": "d3ce834534114348be628b61b26d9220",
-      "mode": "heat",
+      "mode": "heat_cool",
       "model": "ThermoTouch",
       "name": "Anna",
-      "preset_modes": ["away", "no_frost", "vacation", "home", "asleep"],
+      "preset_modes": [
+        "away",
+        "no_frost",
+        "vacation",
+        "home",
+        "asleep"
+      ],
       "select_schedule": "None",
       "sensors": {
         "cooling_activation_outdoor_temperature": 26.0,
         "cooling_deactivation_threshold": 3.0,
         "illuminance": 0.5,
-        "setpoint": 19.5,
+        "setpoint_high": 30.0,
+        "setpoint_low": 19.5,
         "temperature": 20.9
       },
       "temperature_offset": {

--- a/fixtures/anna_elga_2_schedule_off/all_data.json
+++ b/fixtures/anna_elga_2_schedule_off/all_data.json
@@ -37,9 +37,7 @@
     },
     "ebd90df1ab334565b5895f37590ccff4": {
       "active_preset": "home",
-      "available_schedules": [
-        "Thermostat schedule"
-      ],
+      "available_schedules": ["Thermostat schedule"],
       "dev_class": "thermostat",
       "firmware": "2018-02-08T11:15:53+01:00",
       "hardware": "6539-1301-5002",
@@ -47,13 +45,7 @@
       "mode": "heat_cool",
       "model": "ThermoTouch",
       "name": "Anna",
-      "preset_modes": [
-        "away",
-        "no_frost",
-        "vacation",
-        "home",
-        "asleep"
-      ],
+      "preset_modes": ["away", "no_frost", "vacation", "home", "asleep"],
       "select_schedule": "None",
       "sensors": {
         "cooling_activation_outdoor_temperature": 26.0,

--- a/fixtures/anna_elga_2_schedule_off/all_data.json
+++ b/fixtures/anna_elga_2_schedule_off/all_data.json
@@ -5,6 +5,7 @@
       "binary_sensors": {
         "compressor_state": false,
         "cooling_enabled": false,
+        "cooling_state": false,
         "dhw_state": false,
         "flame_state": false,
         "heating_state": false,
@@ -18,7 +19,7 @@
         "setpoint": 60.0,
         "upper_bound": 100.0
       },
-      "model": "Generic heater",
+      "model": "Generic heater/cooler",
       "name": "OpenTherm",
       "sensors": {
         "domestic_hot_water_setpoint": 60.0,
@@ -62,7 +63,8 @@
       "thermostat": {
         "lower_bound": 4.0,
         "resolution": 0.1,
-        "setpoint": 19.5,
+        "setpoint_high": 30.0,
+        "setpoint_low": 19.5,
         "upper_bound": 30.0
       },
       "vendor": "Plugwise"
@@ -85,10 +87,10 @@
     }
   },
   "gateway": {
-    "cooling_present": false,
+    "cooling_present": true,
     "gateway_id": "fb49af122f6e4b0f91267e1cf7666d6f",
     "heater_id": "573c152e7d4f4720878222bd75638f5b",
-    "item_count": 59,
+    "item_count": 62,
     "notifications": {},
     "smile_name": "Smile Anna"
   }

--- a/fixtures/anna_heatpump_heating/all_data.json
+++ b/fixtures/anna_heatpump_heating/all_data.json
@@ -67,13 +67,20 @@
       "mode": "auto",
       "model": "ThermoTouch",
       "name": "Anna",
-      "preset_modes": ["no_frost", "home", "away", "asleep", "vacation"],
+      "preset_modes": [
+        "no_frost",
+        "home",
+        "away",
+        "asleep",
+        "vacation"
+      ],
       "select_schedule": "standaard",
       "sensors": {
         "cooling_activation_outdoor_temperature": 21.0,
         "cooling_deactivation_threshold": 4.0,
         "illuminance": 86.0,
-        "setpoint": 20.5,
+        "setpoint_high": 30.0,
+        "setpoint_low": 20.5,
         "temperature": 19.3
       },
       "temperature_offset": {

--- a/fixtures/anna_heatpump_heating/all_data.json
+++ b/fixtures/anna_heatpump_heating/all_data.json
@@ -21,6 +21,7 @@
       "binary_sensors": {
         "compressor_state": true,
         "cooling_enabled": false,
+        "cooling_state": false,
         "dhw_state": false,
         "flame_state": false,
         "heating_state": true,
@@ -40,7 +41,7 @@
         "setpoint": 60.0,
         "upper_bound": 100.0
       },
-      "model": "Generic heater",
+      "model": "Generic heater/cooler",
       "name": "OpenTherm",
       "sensors": {
         "dhw_temperature": 46.3,
@@ -84,17 +85,18 @@
       "thermostat": {
         "lower_bound": 4.0,
         "resolution": 0.1,
-        "setpoint": 20.5,
+        "setpoint_high": 30.0,
+        "setpoint_low": 20.5,
         "upper_bound": 30.0
       },
       "vendor": "Plugwise"
     }
   },
   "gateway": {
-    "cooling_present": false,
+    "cooling_present": true,
     "gateway_id": "015ae9ea3f964e668e490fa39da3870b",
     "heater_id": "1cbf783bb11e4a7c8a6843dee3a86927",
-    "item_count": 63,
+    "item_count": 66,
     "notifications": {},
     "smile_name": "Smile Anna"
   }

--- a/fixtures/anna_heatpump_heating/all_data.json
+++ b/fixtures/anna_heatpump_heating/all_data.json
@@ -67,13 +67,7 @@
       "mode": "auto",
       "model": "ThermoTouch",
       "name": "Anna",
-      "preset_modes": [
-        "no_frost",
-        "home",
-        "away",
-        "asleep",
-        "vacation"
-      ],
+      "preset_modes": ["no_frost", "home", "away", "asleep", "vacation"],
       "select_schedule": "standaard",
       "sensors": {
         "cooling_activation_outdoor_temperature": 21.0,

--- a/fixtures/m_anna_heatpump_cooling/all_data.json
+++ b/fixtures/m_anna_heatpump_cooling/all_data.json
@@ -73,7 +73,7 @@
         "cooling_activation_outdoor_temperature": 21.0,
         "cooling_deactivation_threshold": 4.0,
         "illuminance": 86.0,
-        "setpoint_high": 24.0,
+        "setpoint_high": 30.0,
         "setpoint_low": 20.5,
         "temperature": 26.3
       },
@@ -86,7 +86,7 @@
       "thermostat": {
         "lower_bound": 4.0,
         "resolution": 0.1,
-        "setpoint_high": 24.0,
+        "setpoint_high": 30.0,
         "setpoint_low": 20.5,
         "upper_bound": 30.0
       },

--- a/fixtures/m_anna_heatpump_cooling/all_data.json
+++ b/fixtures/m_anna_heatpump_cooling/all_data.json
@@ -97,7 +97,7 @@
     "cooling_present": true,
     "gateway_id": "015ae9ea3f964e668e490fa39da3870b",
     "heater_id": "1cbf783bb11e4a7c8a6843dee3a86927",
-    "item_count": 63,
+    "item_count": 66,
     "notifications": {},
     "smile_name": "Smile Anna"
   }

--- a/fixtures/m_anna_heatpump_idle/all_data.json
+++ b/fixtures/m_anna_heatpump_idle/all_data.json
@@ -97,7 +97,7 @@
     "cooling_present": true,
     "gateway_id": "015ae9ea3f964e668e490fa39da3870b",
     "heater_id": "1cbf783bb11e4a7c8a6843dee3a86927",
-    "item_count": 63,
+    "item_count": 66,
     "notifications": {},
     "smile_name": "Smile Anna"
   }

--- a/fixtures/m_anna_heatpump_idle/all_data.json
+++ b/fixtures/m_anna_heatpump_idle/all_data.json
@@ -73,7 +73,7 @@
         "cooling_activation_outdoor_temperature": 25.0,
         "cooling_deactivation_threshold": 4.0,
         "illuminance": 86.0,
-        "setpoint_high": 24.0,
+        "setpoint_high": 30.0,
         "setpoint_low": 20.5,
         "temperature": 23.0
       },
@@ -86,7 +86,7 @@
       "thermostat": {
         "lower_bound": 4.0,
         "resolution": 0.1,
-        "setpoint_high": 24.0,
+        "setpoint_high": 30.0,
         "setpoint_low": 20.5,
         "upper_bound": 30.0
       },

--- a/plugwise/helper.py
+++ b/plugwise/helper.py
@@ -1028,12 +1028,13 @@ class SmileHelper:
             # Anna+Elga: base cooling_state on the elga-status-code
             if "elga_status_code" in data:
                 # Determine _cooling_present and _cooling_enabled
-                if (
-                    "cooling_enabled" in data["binary_sensors"]
-                    and data["binary_sensors"]["cooling_enabled"]
-                ):
-                    self._cooling_present = self._cooling_enabled = True
+                  if "cooling_enabled" in data["binary_sensors"]:
+                    self._cooling_present = True
                     data["model"] = "Generic heater/cooler"
+                    self._cooling_enabled = False
+                    if data["binary_sensors"]["cooling_enabled"]:
+                        self._cooling_enabled = True
+                    
                     data["binary_sensors"]["cooling_state"] = self._cooling_active = (
                         data["elga_status_code"] == 8
                     )

--- a/plugwise/helper.py
+++ b/plugwise/helper.py
@@ -1028,7 +1028,7 @@ class SmileHelper:
             # Anna+Elga: base cooling_state on the elga-status-code
             if "elga_status_code" in data:
                 # Determine _cooling_present and _cooling_enabled
-                  if "cooling_enabled" in data["binary_sensors"]:
+                if "cooling_enabled" in data["binary_sensors"]:
                     self._cooling_present = True
                     data["model"] = "Generic heater/cooler"
                     self._cooling_enabled = False

--- a/plugwise/helper.py
+++ b/plugwise/helper.py
@@ -1034,7 +1034,7 @@ class SmileHelper:
                     self._cooling_enabled = False
                     if data["binary_sensors"]["cooling_enabled"]:
                         self._cooling_enabled = True
-                    
+
                     data["binary_sensors"]["cooling_state"] = self._cooling_active = (
                         data["elga_status_code"] == 8
                     )

--- a/plugwise/helper.py
+++ b/plugwise/helper.py
@@ -1027,17 +1027,13 @@ class SmileHelper:
         if self._is_thermostat and self.smile(ANNA) and dev_id == self._heater_id:
             # Anna+Elga: base cooling_state on the elga-status-code
             if "elga_status_code" in data:
-                # Determine _cooling_present and _cooling_enabled
-                if "cooling_enabled" in data["binary_sensors"]:
-                    self._cooling_present = True
-                    data["model"] = "Generic heater/cooler"
-                    self._cooling_enabled = False
-                    if data["binary_sensors"]["cooling_enabled"]:
-                        self._cooling_enabled = True
-
-                    data["binary_sensors"]["cooling_state"] = self._cooling_active = (
-                        data["elga_status_code"] == 8
-                    )
+                #Techneco Elga has cooling-capability
+                self._cooling_present = True
+                data["model"] = "Generic heater/cooler"
+                self._cooling_enabled = data["elga_status_code"] in [8, 9]
+                data["binary_sensors"]["cooling_state"] = self._cooling_active = (
+                    data["elga_status_code"] == 8
+                )
                 data.pop("elga_status_code", None)
                 self._count -= 1
                 # Elga has no cooling-switch

--- a/plugwise/helper.py
+++ b/plugwise/helper.py
@@ -1027,7 +1027,7 @@ class SmileHelper:
         if self._is_thermostat and self.smile(ANNA) and dev_id == self._heater_id:
             # Anna+Elga: base cooling_state on the elga-status-code
             if "elga_status_code" in data:
-                #Techneco Elga has cooling-capability
+                # Techneco Elga has cooling-capability
                 self._cooling_present = True
                 data["model"] = "Generic heater/cooler"
                 self._cooling_enabled = data["elga_status_code"] in [8, 9]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name            = "plugwise"
-version         = "0.34.0"
+version         = "0.34.1a0"
 license         = {file = "LICENSE"}
 description     = "Plugwise Smile (Adam/Anna/P1) and Stretch module for Python 3."
 readme          = "README.md"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name            = "plugwise"
-version         = "0.34.1a0"
+version         = "0.34.1"
 license         = {file = "LICENSE"}
 description     = "Plugwise Smile (Adam/Anna/P1) and Stretch module for Python 3."
 readme          = "README.md"

--- a/scripts/manual_fixtures.py
+++ b/scripts/manual_fixtures.py
@@ -282,9 +282,6 @@ m_anna_heatpump_cooling["devices"]["015ae9ea3f964e668e490fa39da3870b"]["sensors"
 ] = 28.2
 
 # Go for 3cb7
-m_anna_heatpump_cooling["devices"]["3cb70739631c4d17a86b8b12e8a5161b"][
-    "thermostat"
-].pop("setpoint")
 m_anna_heatpump_cooling["devices"]["3cb70739631c4d17a86b8b12e8a5161b"]["thermostat"][
     "setpoint_low"
 ] = 20.5
@@ -292,9 +289,6 @@ m_anna_heatpump_cooling["devices"]["3cb70739631c4d17a86b8b12e8a5161b"]["thermost
     "setpoint_high"
 ] = 24.0
 
-m_anna_heatpump_cooling["devices"]["3cb70739631c4d17a86b8b12e8a5161b"]["sensors"].pop(
-    "setpoint"
-)
 m_anna_heatpump_cooling["devices"]["3cb70739631c4d17a86b8b12e8a5161b"]["sensors"][
     "temperature"
 ] = 26.3

--- a/scripts/manual_fixtures.py
+++ b/scripts/manual_fixtures.py
@@ -287,7 +287,7 @@ m_anna_heatpump_cooling["devices"]["3cb70739631c4d17a86b8b12e8a5161b"]["thermost
 ] = 20.5
 m_anna_heatpump_cooling["devices"]["3cb70739631c4d17a86b8b12e8a5161b"]["thermostat"][
     "setpoint_high"
-] = 24.0
+] = 30.0
 
 m_anna_heatpump_cooling["devices"]["3cb70739631c4d17a86b8b12e8a5161b"]["sensors"][
     "temperature"
@@ -297,7 +297,7 @@ m_anna_heatpump_cooling["devices"]["3cb70739631c4d17a86b8b12e8a5161b"]["sensors"
 ] = 20.5
 m_anna_heatpump_cooling["devices"]["3cb70739631c4d17a86b8b12e8a5161b"]["sensors"][
     "setpoint_high"
-] = 24.0
+] = 30.0
 
 json_writer("m_anna_heatpump_cooling", m_anna_heatpump_cooling, base_n)
 

--- a/tests/test_smile.py
+++ b/tests/test_smile.py
@@ -490,7 +490,7 @@ class TestPlugwise:  # pylint: disable=attribute-defined-outside-init
         _LOGGER.info("Asserting modifying settings in location (%s):", loc_id)
         test_temp = {"setpoint": 22.9}
         if smile._cooling_present and not block_cooling:
-            test_temp = {"setpoint_low": 19.5, "setpoint_high": 23.5}
+            test_temp = {"setpoint_low": 19.5, "setpoint_high": 30.0}
         _LOGGER.info("- Adjusting temperature to %s", test_temp)
         try:
             await smile.set_temperature(loc_id, test_temp)
@@ -3902,6 +3902,7 @@ class TestPlugwise:  # pylint: disable=attribute-defined-outside-init
                     "dhw_state": False,
                     "heating_state": True,
                     "compressor_state": True,
+                    "cooling_state": False,
                     "cooling_enabled": False,
                     "slave_boiler_state": False,
                     "flame_state": False,
@@ -3932,7 +3933,8 @@ class TestPlugwise:  # pylint: disable=attribute-defined-outside-init
                     "setpoint": -0.5,
                 },
                 "thermostat": {
-                    "setpoint": 20.5,
+                    "setpoint_low": 20.5,
+                    "setpoint_high": 30.0,
                     "lower_bound": 4.0,
                     "upper_bound": 30.0,
                     "resolution": 0.1,
@@ -3944,10 +3946,11 @@ class TestPlugwise:  # pylint: disable=attribute-defined-outside-init
                 "mode": "auto",
                 "sensors": {
                     "temperature": 19.3,
-                    "setpoint": 20.5,
                     "illuminance": 86.0,
                     "cooling_activation_outdoor_temperature": 21.0,
                     "cooling_deactivation_threshold": 4.0,
+                    "setpoint_low": 20.5,
+                    "setpoint_high": 30.0,
                 },
             },
         }
@@ -3955,7 +3958,7 @@ class TestPlugwise:  # pylint: disable=attribute-defined-outside-init
             "1cbf783bb11e4a7c8a6843dee3a86927": {
                 "dev_class": "heater_central",
                 "location": "a57efe5f145f498c9be62a9b63626fbf",
-                "model": "Generic heater",
+                "model": "Generic heater/cooler",
                 "name": "OpenTherm",
                 "vendor": "Techneco",
                 "maximum_boiler_temperature": {
@@ -3969,6 +3972,7 @@ class TestPlugwise:  # pylint: disable=attribute-defined-outside-init
                     "dhw_state": False,
                     "heating_state": True,
                     "compressor_state": True,
+                    "cooling_state": False,
                     "cooling_enabled": False,
                     "slave_boiler_state": False,
                     "flame_state": False,
@@ -4002,7 +4006,7 @@ class TestPlugwise:  # pylint: disable=attribute-defined-outside-init
         await self.device_test(smile, "2020-04-12 00:00:01", testdata)
         assert smile.gateway_id == "015ae9ea3f964e668e490fa39da3870b"
         assert smile._last_active["c784ee9fdab44e1395b8dee7d7a497d5"] == "standaard"
-        assert smile.device_items == 63
+        assert smile.device_items == 66
         assert not self.notifications
         assert self.cooling_present
         assert not smile._cooling_enabled
@@ -4024,7 +4028,7 @@ class TestPlugwise:  # pylint: disable=attribute-defined-outside-init
         await self.device_test(
             smile, "2020-04-13 00:00:01", testdata_updated, initialize=False
         )
-        assert smile.device_items == 60
+        assert smile.device_items == 63
         await smile.close_connection()
         await self.disconnect(server, client)
 

--- a/tests/test_smile.py
+++ b/tests/test_smile.py
@@ -3882,7 +3882,7 @@ class TestPlugwise:  # pylint: disable=attribute-defined-outside-init
             "1cbf783bb11e4a7c8a6843dee3a86927": {
                 "dev_class": "heater_central",
                 "location": "a57efe5f145f498c9be62a9b63626fbf",
-                "model": "Generic heater",
+                "model": "Generic heater/cooler",
                 "name": "OpenTherm",
                 "vendor": "Techneco",
                 "maximum_boiler_temperature": {
@@ -4003,9 +4003,8 @@ class TestPlugwise:  # pylint: disable=attribute-defined-outside-init
         assert smile.gateway_id == "015ae9ea3f964e668e490fa39da3870b"
         assert smile._last_active["c784ee9fdab44e1395b8dee7d7a497d5"] == "standaard"
         assert smile.device_items == 63
-        assert not self.cooling_present
         assert not self.notifications
-
+        assert self.cooling_present
         assert not smile._cooling_enabled
         assert not smile._cooling_active
 

--- a/tests/test_smile.py
+++ b/tests/test_smile.py
@@ -4012,14 +4012,15 @@ class TestPlugwise:  # pylint: disable=attribute-defined-outside-init
         assert not smile._cooling_enabled
         assert not smile._cooling_active
 
-        result = await self.tinker_thermostat(
-            smile,
-            "c784ee9fdab44e1395b8dee7d7a497d5",
-            good_schedules=[
-                "standaard",
-            ],
-        )
-        assert result
+        with pytest.raises(pw_exceptions.PlugwiseError) as exc:
+            result = await self.tinker_thermostat(
+                smile,
+                "c784ee9fdab44e1395b8dee7d7a497d5",
+                good_schedules=[
+                    "standaard",
+                ],
+            )
+        _LOGGER.debug("ERROR raised: %s", exc.value)
 
         # Now change some data and change directory reading xml from
         # emulating reading newer dataset after an update_interval,

--- a/tests/test_smile.py
+++ b/tests/test_smile.py
@@ -4603,15 +4603,13 @@ class TestPlugwise:  # pylint: disable=attribute-defined-outside-init
         )
         assert switch_change
 
-        with pytest.raises(pw_exceptions.PlugwiseError) as exc:
-            await self.tinker_thermostat(
+        await self.tinker_thermostat(
                 smile,
                 "15da035090b847e7a21f93e08c015ebc",
                 good_schedules=[
                     "Winter",
                 ],
             )
-        _LOGGER.debug("ERROR raised: %s", exc.value)
 
         with pytest.raises(pw_exceptions.PlugwiseError) as exc:
             await self.tinker_thermostat_temp(

--- a/tests/test_smile.py
+++ b/tests/test_smile.py
@@ -4604,12 +4604,12 @@ class TestPlugwise:  # pylint: disable=attribute-defined-outside-init
         assert switch_change
 
         await self.tinker_thermostat(
-                smile,
-                "15da035090b847e7a21f93e08c015ebc",
-                good_schedules=[
-                    "Winter",
-                ],
-            )
+            smile,
+            "15da035090b847e7a21f93e08c015ebc",
+            good_schedules=[
+                "Winter",
+            ],
+        )
 
         with pytest.raises(pw_exceptions.PlugwiseError) as exc:
             await self.tinker_thermostat_temp(

--- a/tests/test_smile.py
+++ b/tests/test_smile.py
@@ -4604,13 +4604,15 @@ class TestPlugwise:  # pylint: disable=attribute-defined-outside-init
         )
         assert switch_change
 
-        await self.tinker_thermostat(
-            smile,
-            "15da035090b847e7a21f93e08c015ebc",
-            good_schedules=[
-                "Winter",
-            ],
-        )
+        with pytest.raises(pw_exceptions.PlugwiseError) as exc:
+            await self.tinker_thermostat(
+                smile,
+                "15da035090b847e7a21f93e08c015ebc",
+                good_schedules=[
+                    "Winter",
+                ],
+            )
+        _LOGGER.debug("ERROR raised: %s", exc.value)
 
         with pytest.raises(pw_exceptions.PlugwiseError) as exc:
             await self.tinker_thermostat_temp(

--- a/tests/test_smile.py
+++ b/tests/test_smile.py
@@ -490,7 +490,7 @@ class TestPlugwise:  # pylint: disable=attribute-defined-outside-init
         _LOGGER.info("Asserting modifying settings in location (%s):", loc_id)
         test_temp = {"setpoint": 22.9}
         if smile._cooling_present and not block_cooling:
-            test_temp = {"setpoint_low": 19.5, "setpoint_high": 30.0}
+            test_temp = {"setpoint_low": 19.5, "setpoint_high": 23.5}
         _LOGGER.info("- Adjusting temperature to %s", test_temp)
         try:
             await smile.set_temperature(loc_id, test_temp)

--- a/tests/test_smile.py
+++ b/tests/test_smile.py
@@ -4236,37 +4236,22 @@ class TestPlugwise:  # pylint: disable=attribute-defined-outside-init
     async def test_connect_anna_elga_2(self):
         """Test a 2nd Anna with Elga setup, cooling off, in idle mode (with missing outdoor temperature - solved)."""
         testdata = {
-            "ebd90df1ab334565b5895f37590ccff4": {
-                "dev_class": "thermostat",
-                "firmware": "2018-02-08T11:15:53+01:00",
-                "hardware": "6539-1301-5002",
-                "location": "d3ce834534114348be628b61b26d9220",
-                "model": "ThermoTouch",
-                "name": "Anna",
+            "fb49af122f6e4b0f91267e1cf7666d6f": {
+                "dev_class": "gateway",
+                "firmware": "4.2.1",
+                "hardware": "AME Smile 2.0 board",
+                "location": "d34dfe6ab90b410c98068e75de3eb631",
+                "mac_address": "C4930002FE76",
+                "model": "Gateway",
+                "name": "Smile Anna",
                 "vendor": "Plugwise",
-                "thermostat": {
-                    "setpoint": 19.5,
-                    "lower_bound": 4.0,
-                    "upper_bound": 30.0,
-                    "resolution": 0.1,
-                },
-                "preset_modes": ["away", "no_frost", "vacation", "home", "asleep"],
-                "active_preset": "home",
-                "available_schedules": ["Thermostat schedule"],
-                "select_schedule": "Thermostat schedule",
-                "mode": "auto",
-                "sensors": {
-                    "temperature": 20.9,
-                    "setpoint": 19.5,
-                    "illuminance": 0.5,
-                    "cooling_activation_outdoor_temperature": 26.0,
-                    "cooling_deactivation_threshold": 3.0,
-                },
+                "binary_sensors": {"plugwise_notification": False},
+                "sensors": {"outdoor_temperature": 13.0},
             },
             "573c152e7d4f4720878222bd75638f5b": {
                 "dev_class": "heater_central",
                 "location": "d34dfe6ab90b410c98068e75de3eb631",
-                "model": "Generic heater",
+                "model": "Generic heater/cooler",
                 "name": "OpenTherm",
                 "vendor": "Techneco",
                 "maximum_boiler_temperature": {
@@ -4280,6 +4265,7 @@ class TestPlugwise:  # pylint: disable=attribute-defined-outside-init
                     "dhw_state": False,
                     "heating_state": False,
                     "compressor_state": False,
+                    "cooling_state": False,
                     "cooling_enabled": False,
                     "slave_boiler_state": False,
                     "flame_state": False,
@@ -4295,17 +4281,34 @@ class TestPlugwise:  # pylint: disable=attribute-defined-outside-init
                 },
                 "switches": {"dhw_cm_switch": True},
             },
-            "fb49af122f6e4b0f91267e1cf7666d6f": {
-                "dev_class": "gateway",
-                "firmware": "4.2.1",
-                "hardware": "AME Smile 2.0 board",
-                "location": "d34dfe6ab90b410c98068e75de3eb631",
-                "mac_address": "C4930002FE76",
-                "model": "Gateway",
-                "name": "Smile Anna",
+            "ebd90df1ab334565b5895f37590ccff4": {
+                "dev_class": "thermostat",
+                "firmware": "2018-02-08T11:15:53+01:00",
+                "hardware": "6539-1301-5002",
+                "location": "d3ce834534114348be628b61b26d9220",
+                "model": "ThermoTouch",
+                "name": "Anna",
                 "vendor": "Plugwise",
-                "binary_sensors": {"plugwise_notification": False},
-                "sensors": {"outdoor_temperature": 13.0},
+                "thermostat": {
+                    "setpoint_low": 19.5,
+                    "setpoint_high": 30.0,
+                    "lower_bound": 4.0,
+                    "upper_bound": 30.0,
+                    "resolution": 0.1,
+                },
+                "preset_modes": ["away", "no_frost", "vacation", "home", "asleep"],
+                "active_preset": "home",
+                "available_schedules": ["Thermostat schedule"],
+                "select_schedule": "Thermostat schedule",
+                "mode": "auto",
+                "sensors": {
+                    "temperature": 20.9,
+                    "illuminance": 0.5,
+                    "cooling_activation_outdoor_temperature": 26.0,
+                    "cooling_deactivation_threshold": 3.0,
+                    "setpoint_low": 19.5,
+                    "setpoint_high": 30.0,
+                },
             },
         }
 
@@ -4326,9 +4329,10 @@ class TestPlugwise:  # pylint: disable=attribute-defined-outside-init
             smile._last_active["d3ce834534114348be628b61b26d9220"]
             == "Thermostat schedule"
         )
-        assert smile.device_items == 59
+        assert smile.device_items == 62
         assert smile.gateway_id == "fb49af122f6e4b0f91267e1cf7666d6f"
-        assert not self.cooling_present
+        assert self.cooling_present
+        assert not smile._cooling_enabled
         assert not self.notifications
 
         await smile.close_connection()
@@ -4347,7 +4351,8 @@ class TestPlugwise:  # pylint: disable=attribute-defined-outside-init
                 "name": "Anna",
                 "vendor": "Plugwise",
                 "thermostat": {
-                    "setpoint": 19.5,
+                    "setpoint_low": 19.5,
+                    "setpoint_high": 30.0,
                     "lower_bound": 4.0,
                     "upper_bound": 30.0,
                     "resolution": 0.1,
@@ -4356,13 +4361,14 @@ class TestPlugwise:  # pylint: disable=attribute-defined-outside-init
                 "active_preset": "home",
                 "available_schedules": ["Thermostat schedule"],
                 "select_schedule": "None",
-                "mode": "heat",
+                "mode": "heat_cool",
                 "sensors": {
                     "temperature": 20.9,
-                    "setpoint": 19.5,
                     "illuminance": 0.5,
                     "cooling_activation_outdoor_temperature": 26.0,
                     "cooling_deactivation_threshold": 3.0,
+                    "setpoint_low": 19.5,
+                    "setpoint_high": 30.0,
                 },
             }
         }
@@ -4376,8 +4382,9 @@ class TestPlugwise:  # pylint: disable=attribute-defined-outside-init
             smile._last_active["d3ce834534114348be628b61b26d9220"]
             == "Thermostat schedule"
         )
-        assert not smile._cooling_present
-        assert smile.device_items == 59
+        assert smile._cooling_present
+        assert not smile._cooling_enabled
+        assert smile.device_items == 62
 
         await smile.close_connection()
         await self.disconnect(server, client)
@@ -4484,9 +4491,9 @@ class TestPlugwise:  # pylint: disable=attribute-defined-outside-init
             == "Thermostat schedule"
         )
         assert smile.device_items == 62
-        assert self.cooling_present
         assert not self.notifications
 
+        assert self.cooling_present
         assert smile._cooling_enabled
         assert smile._cooling_active
 

--- a/tests/test_smile.py
+++ b/tests/test_smile.py
@@ -4013,7 +4013,7 @@ class TestPlugwise:  # pylint: disable=attribute-defined-outside-init
         assert not smile._cooling_active
 
         with pytest.raises(pw_exceptions.PlugwiseError) as exc:
-            result = await self.tinker_thermostat(
+            await self.tinker_thermostat(
                 smile,
                 "c784ee9fdab44e1395b8dee7d7a497d5",
                 good_schedules=[


### PR DESCRIPTION
The present determination of cooling-enabled for the Anna + Elga system does not work, see https://github.com/plugwise/plugwise-beta/issues/512

Changes:
- Anna+Elga now always has `cooling_present` set to `True`: the Elga (always) has cooling-capability.
- Cooling-mode on/off is determined from specific Elga status-codes
