### PR TITLE
Typing clean-up

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## Ongoing
+
+- Typing-constants clean-up
+
 ## v0.35.1
 
 - Update OFF-constant, removal capital begin-letter

--- a/plugwise/constants.py
+++ b/plugwise/constants.py
@@ -257,12 +257,6 @@ BinarySensorType = Literal[
 ]
 BINARY_SENSORS: Final[tuple[str, ...]] = get_args(BinarySensorType)
 
-NumberType = Literal[
-    "maximum_boiler_temperature",
-    "max_dhw_temperature",
-    "temperature_offset",
-]
-
 LIMITS: Final[tuple[str, ...]] = (
     "offset",
     "setpoint",
@@ -270,17 +264,6 @@ LIMITS: Final[tuple[str, ...]] = (
     "lower_bound",
     "upper_bound",
 )
-
-SelectType = Literal[
-    "select_dhw_mode",
-    "select_regulation_mode",
-    "select_schedule",
-]
-SelectOptionsType = Literal[
-    "dhw_modes",
-    "regulation_modes",
-    "available_schedules",
-]
 
 SensorType = Literal[
     "battery",


### PR DESCRIPTION
The removed constants were moved to the integration where they are used, They were not used in the backend.
Also, save the updated fixtures. They were accidentally overwritten.