### PR TITLE
Set flame_state to false in relevant fixtures

### DIFF
--- a/fixtures/m_adam_cooling/all_data.json
+++ b/fixtures/m_adam_cooling/all_data.json
@@ -5,7 +5,7 @@
       "binary_sensors": {
         "cooling_state": true,
         "dhw_state": false,
-        "flame_state": true,
+        "flame_state": false,
         "heating_state": false
       },
       "dev_class": "heater_central",

--- a/fixtures/m_adam_heating/all_data.json
+++ b/fixtures/m_adam_heating/all_data.json
@@ -4,7 +4,7 @@
       "available": true,
       "binary_sensors": {
         "dhw_state": false,
-        "flame_state": true,
+        "flame_state": false,
         "heating_state": true
       },
       "dev_class": "heater_central",

--- a/scripts/manual_fixtures.py
+++ b/scripts/manual_fixtures.py
@@ -164,6 +164,9 @@ m_adam_cooling["devices"]["056ee145a816487eaa69243c3280f8bf"]["binary_sensors"][
 m_adam_cooling["devices"]["056ee145a816487eaa69243c3280f8bf"]["binary_sensors"][
     "heating_state"
 ] = False
+m_adam_cooling["devices"]["056ee145a816487eaa69243c3280f8bf"]["binary_sensors"][
+    "flame_state"
+] = False
 m_adam_cooling["devices"]["056ee145a816487eaa69243c3280f8bf"]["sensors"][
     "water_temperature"
 ] = 19.0
@@ -238,6 +241,9 @@ m_adam_heating["devices"]["056ee145a816487eaa69243c3280f8bf"]["binary_sensors"].
 m_adam_heating["devices"]["056ee145a816487eaa69243c3280f8bf"]["binary_sensors"][
     "heating_state"
 ] = True
+m_adam_cooling["devices"]["056ee145a816487eaa69243c3280f8bf"]["binary_sensors"][
+    "flame_state"
+] = False
 m_adam_heating["devices"]["056ee145a816487eaa69243c3280f8bf"]["sensors"][
     "water_temperature"
 ] = 37.0


### PR DESCRIPTION
Revert a change caused by the recent update in the base data.