### PR TITLE
Don't output schedule-related data when no valid schedule(s) found

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## v0.37.7
+
+- Don't output schedule-related data when no valid schedule(s) found.
+- Various corrections to impacted test- and data-files/fixtures.
+
 ## v0.37.6
 
 - Schedule-related improvements.

--- a/fixtures/adam_jip/all_data.json
+++ b/fixtures/adam_jip/all_data.json
@@ -3,7 +3,6 @@
     "1346fbd8498d4dbcab7e18d51b771f3d": {
       "active_preset": "no_frost",
       "available": true,
-      "available_schedules": ["None"],
       "control_state": "off",
       "dev_class": "zone_thermostat",
       "firmware": "2016-10-27T02:00:00+02:00",
@@ -13,7 +12,6 @@
       "model": "Lisa",
       "name": "Slaapkamer",
       "preset_modes": ["home", "asleep", "away", "vacation", "no_frost"],
-      "select_schedule": "None",
       "sensors": {
         "battery": 92,
         "setpoint": 13.0,
@@ -99,7 +97,6 @@
     "6f3e9d7084214c21b9dfa46f6eeb8700": {
       "active_preset": "home",
       "available": true,
-      "available_schedules": ["None"],
       "control_state": "off",
       "dev_class": "zone_thermostat",
       "firmware": "2016-10-27T02:00:00+02:00",
@@ -109,7 +106,6 @@
       "model": "Lisa",
       "name": "Kinderkamer",
       "preset_modes": ["home", "asleep", "away", "vacation", "no_frost"],
-      "select_schedule": "None",
       "sensors": {
         "battery": 79,
         "setpoint": 13.0,
@@ -156,7 +152,6 @@
     "a6abc6a129ee499c88a4d420cc413b47": {
       "active_preset": "home",
       "available": true,
-      "available_schedules": ["None"],
       "control_state": "off",
       "dev_class": "zone_thermostat",
       "firmware": "2016-10-27T02:00:00+02:00",
@@ -166,7 +161,6 @@
       "model": "Lisa",
       "name": "Logeerkamer",
       "preset_modes": ["home", "asleep", "away", "vacation", "no_frost"],
-      "select_schedule": "None",
       "sensors": {
         "battery": 80,
         "setpoint": 13.0,
@@ -269,7 +263,6 @@
     "f61f1a2535f54f52ad006a3d18e459ca": {
       "active_preset": "home",
       "available": true,
-      "available_schedules": ["None"],
       "control_state": "off",
       "dev_class": "zone_thermometer",
       "firmware": "2020-09-01T02:00:00+02:00",
@@ -279,7 +272,6 @@
       "model": "Jip",
       "name": "Woonkamer",
       "preset_modes": ["home", "asleep", "away", "vacation", "no_frost"],
-      "select_schedule": "None",
       "sensors": {
         "battery": 100,
         "humidity": 56.2,
@@ -306,7 +298,7 @@
     "cooling_present": false,
     "gateway_id": "b5c2386c6f6342669e50fe49dd05b188",
     "heater_id": "e4684553153b44afbef2200885f379dc",
-    "item_count": 221,
+    "item_count": 213,
     "notifications": {},
     "smile_name": "Adam"
   }

--- a/fixtures/legacy_anna/all_data.json
+++ b/fixtures/legacy_anna/all_data.json
@@ -36,7 +36,6 @@
     },
     "0d266432d64443e283b5d708ae98b455": {
       "active_preset": "home",
-      "available_schedules": ["None"],
       "dev_class": "thermostat",
       "firmware": "2017-03-13T11:54:58+01:00",
       "hardware": "6539-1301-500",
@@ -45,7 +44,6 @@
       "model": "ThermoTouch",
       "name": "Anna",
       "preset_modes": ["away", "vacation", "asleep", "home", "no_frost"],
-      "select_schedule": "None",
       "sensors": {
         "illuminance": 151,
         "setpoint": 20.5,
@@ -64,7 +62,7 @@
     "cooling_present": false,
     "gateway_id": "0000aaaa0000aaaa0000aaaa0000aa00",
     "heater_id": "04e4cbfe7f4340f090f85ec3b9e6a950",
-    "item_count": 43,
+    "item_count": 41,
     "smile_name": "Smile Anna"
   }
 }

--- a/fixtures/m_adam_cooling/all_data.json
+++ b/fixtures/m_adam_cooling/all_data.json
@@ -66,7 +66,7 @@
       "model": "ThermoTouch",
       "name": "Anna",
       "preset_modes": ["no_frost", "asleep", "vacation", "home", "away"],
-      "select_schedule": "None",
+      "select_schedule": "off",
       "sensors": {
         "setpoint": 23.5,
         "temperature": 25.8

--- a/fixtures/m_adam_heating/all_data.json
+++ b/fixtures/m_adam_heating/all_data.json
@@ -71,7 +71,7 @@
       "model": "ThermoTouch",
       "name": "Anna",
       "preset_modes": ["no_frost", "asleep", "vacation", "home", "away"],
-      "select_schedule": "None",
+      "select_schedule": "off",
       "sensors": {
         "setpoint": 20.0,
         "temperature": 19.1

--- a/fixtures/m_adam_jip/all_data.json
+++ b/fixtures/m_adam_jip/all_data.json
@@ -3,7 +3,6 @@
     "1346fbd8498d4dbcab7e18d51b771f3d": {
       "active_preset": "no_frost",
       "available": true,
-      "available_schedules": ["None"],
       "control_state": "off",
       "dev_class": "zone_thermostat",
       "firmware": "2016-10-27T02:00:00+02:00",
@@ -13,7 +12,6 @@
       "model": "Lisa",
       "name": "Slaapkamer",
       "preset_modes": ["home", "asleep", "away", "vacation", "no_frost"],
-      "select_schedule": "None",
       "sensors": {
         "battery": 92,
         "setpoint": 13.0,
@@ -99,7 +97,6 @@
     "6f3e9d7084214c21b9dfa46f6eeb8700": {
       "active_preset": "home",
       "available": true,
-      "available_schedules": ["None"],
       "control_state": "off",
       "dev_class": "zone_thermostat",
       "firmware": "2016-10-27T02:00:00+02:00",
@@ -109,7 +106,6 @@
       "model": "Lisa",
       "name": "Kinderkamer",
       "preset_modes": ["home", "asleep", "away", "vacation", "no_frost"],
-      "select_schedule": "None",
       "sensors": {
         "battery": 79,
         "setpoint": 13.0,
@@ -156,7 +152,6 @@
     "a6abc6a129ee499c88a4d420cc413b47": {
       "active_preset": "home",
       "available": true,
-      "available_schedules": ["None"],
       "control_state": "off",
       "dev_class": "zone_thermostat",
       "firmware": "2016-10-27T02:00:00+02:00",
@@ -166,7 +161,6 @@
       "model": "Lisa",
       "name": "Logeerkamer",
       "preset_modes": ["home", "asleep", "away", "vacation", "no_frost"],
-      "select_schedule": "None",
       "sensors": {
         "battery": 80,
         "setpoint": 13.0,
@@ -269,7 +263,6 @@
     "f61f1a2535f54f52ad006a3d18e459ca": {
       "active_preset": "home",
       "available": true,
-      "available_schedules": ["None"],
       "control_state": "off",
       "dev_class": "zone_thermometer",
       "firmware": "2020-09-01T02:00:00+02:00",
@@ -279,7 +272,6 @@
       "model": "Jip",
       "name": "Woonkamer",
       "preset_modes": ["home", "asleep", "away", "vacation", "no_frost"],
-      "select_schedule": "None",
       "sensors": {
         "battery": 100,
         "humidity": 56.2,
@@ -306,7 +298,7 @@
     "cooling_present": false,
     "gateway_id": "b5c2386c6f6342669e50fe49dd05b188",
     "heater_id": "e4684553153b44afbef2200885f379dc",
-    "item_count": 221,
+    "item_count": 213,
     "notifications": {},
     "smile_name": "Adam"
   }

--- a/fixtures/m_adam_multiple_devices_per_zone/all_data.json
+++ b/fixtures/m_adam_multiple_devices_per_zone/all_data.json
@@ -1,0 +1,475 @@
+{
+  "devices": {
+    "02cf28bfec924855854c544690a609ef": {
+      "available": true,
+      "dev_class": "vcr",
+      "firmware": "2019-06-21T02:00:00+02:00",
+      "location": "cd143c07248f491493cea0533bc3d669",
+      "model": "Plug",
+      "name": "NVR",
+      "sensors": {
+        "electricity_consumed": 34.0,
+        "electricity_consumed_interval": 9.15,
+        "electricity_produced": 0.0,
+        "electricity_produced_interval": 0.0
+      },
+      "switches": {
+        "lock": true,
+        "relay": true
+      },
+      "vendor": "Plugwise",
+      "zigbee_mac_address": "ABCD012345670A15"
+    },
+    "21f2b542c49845e6bb416884c55778d6": {
+      "available": true,
+      "dev_class": "game_console",
+      "firmware": "2019-06-21T02:00:00+02:00",
+      "location": "cd143c07248f491493cea0533bc3d669",
+      "model": "Plug",
+      "name": "Playstation Smart Plug",
+      "sensors": {
+        "electricity_consumed": 84.1,
+        "electricity_consumed_interval": 8.6,
+        "electricity_produced": 0.0,
+        "electricity_produced_interval": 0.0
+      },
+      "switches": {
+        "lock": false,
+        "relay": true
+      },
+      "vendor": "Plugwise",
+      "zigbee_mac_address": "ABCD012345670A12"
+    },
+    "4a810418d5394b3f82727340b91ba740": {
+      "available": true,
+      "dev_class": "router",
+      "firmware": "2019-06-21T02:00:00+02:00",
+      "location": "cd143c07248f491493cea0533bc3d669",
+      "model": "Plug",
+      "name": "USG Smart Plug",
+      "sensors": {
+        "electricity_consumed": 8.5,
+        "electricity_consumed_interval": 0.0,
+        "electricity_produced": 0.0,
+        "electricity_produced_interval": 0.0
+      },
+      "switches": {
+        "lock": true,
+        "relay": true
+      },
+      "vendor": "Plugwise",
+      "zigbee_mac_address": "ABCD012345670A16"
+    },
+    "675416a629f343c495449970e2ca37b5": {
+      "available": true,
+      "dev_class": "router",
+      "firmware": "2019-06-21T02:00:00+02:00",
+      "location": "cd143c07248f491493cea0533bc3d669",
+      "model": "Plug",
+      "name": "Ziggo Modem",
+      "sensors": {
+        "electricity_consumed": 12.2,
+        "electricity_consumed_interval": 2.97,
+        "electricity_produced": 0.0,
+        "electricity_produced_interval": 0.0
+      },
+      "switches": {
+        "lock": true,
+        "relay": true
+      },
+      "vendor": "Plugwise",
+      "zigbee_mac_address": "ABCD012345670A01"
+    },
+    "680423ff840043738f42cc7f1ff97a36": {
+      "available": true,
+      "dev_class": "thermo_sensor",
+      "firmware": "2019-03-27T01:00:00+01:00",
+      "hardware": "1",
+      "location": "08963fec7c53423ca5680aa4cb502c63",
+      "model": "Tom/Floor",
+      "name": "Thermostatic Radiator Badkamer",
+      "sensors": {
+        "battery": 51,
+        "setpoint": 14.0,
+        "temperature": 19.1,
+        "temperature_difference": -0.4,
+        "valve_position": 0.0
+      },
+      "temperature_offset": {
+        "lower_bound": -2.0,
+        "resolution": 0.1,
+        "setpoint": 0.0,
+        "upper_bound": 2.0
+      },
+      "vendor": "Plugwise",
+      "zigbee_mac_address": "ABCD012345670A17"
+    },
+    "6a3bf693d05e48e0b460c815a4fdd09d": {
+      "active_preset": "asleep",
+      "available": true,
+      "available_schedules": [
+        "CV Roan",
+        "Bios Schema met Film Avond",
+        "GF7  Woonkamer",
+        "Badkamer Schema",
+        "CV Jessie",
+        "off"
+      ],
+      "dev_class": "zone_thermostat",
+      "firmware": "2016-10-27T02:00:00+02:00",
+      "hardware": "255",
+      "location": "82fa13f017d240daa0d0ea1775420f24",
+      "mode": "auto",
+      "model": "Lisa",
+      "name": "Zone Thermostat Jessie",
+      "preset_modes": ["home", "asleep", "away", "vacation", "no_frost"],
+      "select_schedule": "CV Jessie",
+      "sensors": {
+        "battery": 37,
+        "setpoint": 15.0,
+        "temperature": 17.2
+      },
+      "temperature_offset": {
+        "lower_bound": -2.0,
+        "resolution": 0.1,
+        "setpoint": 0.0,
+        "upper_bound": 2.0
+      },
+      "thermostat": {
+        "lower_bound": 0.0,
+        "resolution": 0.01,
+        "setpoint": 15.0,
+        "upper_bound": 99.9
+      },
+      "vendor": "Plugwise",
+      "zigbee_mac_address": "ABCD012345670A03"
+    },
+    "78d1126fc4c743db81b61c20e88342a7": {
+      "available": true,
+      "dev_class": "central_heating_pump",
+      "firmware": "2019-06-21T02:00:00+02:00",
+      "location": "c50f167537524366a5af7aa3942feb1e",
+      "model": "Plug",
+      "name": "CV Pomp",
+      "sensors": {
+        "electricity_consumed": 35.6,
+        "electricity_consumed_interval": 7.37,
+        "electricity_produced": 0.0,
+        "electricity_produced_interval": 0.0
+      },
+      "switches": {
+        "relay": true
+      },
+      "vendor": "Plugwise",
+      "zigbee_mac_address": "ABCD012345670A05"
+    },
+    "90986d591dcd426cae3ec3e8111ff730": {
+      "binary_sensors": {
+        "heating_state": true
+      },
+      "dev_class": "heater_central",
+      "location": "1f9dcf83fd4e4b66b72ff787957bfe5d",
+      "model": "Unknown",
+      "name": "OnOff",
+      "sensors": {
+        "intended_boiler_temperature": 70.0,
+        "modulation_level": 1,
+        "water_temperature": 70.0
+      }
+    },
+    "a28f588dc4a049a483fd03a30361ad3a": {
+      "available": true,
+      "dev_class": "settop",
+      "firmware": "2019-06-21T02:00:00+02:00",
+      "location": "cd143c07248f491493cea0533bc3d669",
+      "model": "Plug",
+      "name": "Fibaro HC2",
+      "sensors": {
+        "electricity_consumed": 12.5,
+        "electricity_consumed_interval": 3.8,
+        "electricity_produced": 0.0,
+        "electricity_produced_interval": 0.0
+      },
+      "switches": {
+        "lock": true,
+        "relay": true
+      },
+      "vendor": "Plugwise",
+      "zigbee_mac_address": "ABCD012345670A13"
+    },
+    "a2c3583e0a6349358998b760cea82d2a": {
+      "available": true,
+      "dev_class": "thermo_sensor",
+      "firmware": "2019-03-27T01:00:00+01:00",
+      "hardware": "1",
+      "location": "12493538af164a409c6a1c79e38afe1c",
+      "model": "Tom/Floor",
+      "name": "Bios Cv Thermostatic Radiator ",
+      "sensors": {
+        "battery": 62,
+        "setpoint": 13.0,
+        "temperature": 17.2,
+        "temperature_difference": -0.2,
+        "valve_position": 0.0
+      },
+      "temperature_offset": {
+        "lower_bound": -2.0,
+        "resolution": 0.1,
+        "setpoint": 0.0,
+        "upper_bound": 2.0
+      },
+      "vendor": "Plugwise",
+      "zigbee_mac_address": "ABCD012345670A09"
+    },
+    "b310b72a0e354bfab43089919b9a88bf": {
+      "available": true,
+      "dev_class": "thermo_sensor",
+      "firmware": "2019-03-27T01:00:00+01:00",
+      "hardware": "1",
+      "location": "c50f167537524366a5af7aa3942feb1e",
+      "model": "Tom/Floor",
+      "name": "Floor kraan",
+      "sensors": {
+        "setpoint": 21.5,
+        "temperature": 26.0,
+        "temperature_difference": 3.5,
+        "valve_position": 100
+      },
+      "temperature_offset": {
+        "lower_bound": -2.0,
+        "resolution": 0.1,
+        "setpoint": 0.0,
+        "upper_bound": 2.0
+      },
+      "vendor": "Plugwise",
+      "zigbee_mac_address": "ABCD012345670A02"
+    },
+    "b59bcebaf94b499ea7d46e4a66fb62d8": {
+      "active_preset": "home",
+      "available": true,
+      "available_schedules": [
+        "CV Roan",
+        "Bios Schema met Film Avond",
+        "GF7  Woonkamer",
+        "Badkamer Schema",
+        "CV Jessie",
+        "off"
+      ],
+      "dev_class": "zone_thermostat",
+      "firmware": "2016-08-02T02:00:00+02:00",
+      "hardware": "255",
+      "location": "c50f167537524366a5af7aa3942feb1e",
+      "mode": "auto",
+      "model": "Lisa",
+      "name": "Zone Lisa WK",
+      "preset_modes": ["home", "asleep", "away", "vacation", "no_frost"],
+      "select_schedule": "GF7  Woonkamer",
+      "sensors": {
+        "battery": 34,
+        "setpoint": 21.5,
+        "temperature": 20.9
+      },
+      "temperature_offset": {
+        "lower_bound": -2.0,
+        "resolution": 0.1,
+        "setpoint": 0.0,
+        "upper_bound": 2.0
+      },
+      "thermostat": {
+        "lower_bound": 0.0,
+        "resolution": 0.01,
+        "setpoint": 21.5,
+        "upper_bound": 99.9
+      },
+      "vendor": "Plugwise",
+      "zigbee_mac_address": "ABCD012345670A07"
+    },
+    "cd0ddb54ef694e11ac18ed1cbce5dbbd": {
+      "available": true,
+      "dev_class": "vcr",
+      "firmware": "2019-06-21T02:00:00+02:00",
+      "location": "cd143c07248f491493cea0533bc3d669",
+      "model": "Plug",
+      "name": "NAS",
+      "sensors": {
+        "electricity_consumed": 16.5,
+        "electricity_consumed_interval": 0.5,
+        "electricity_produced": 0.0,
+        "electricity_produced_interval": 0.0
+      },
+      "switches": {
+        "lock": true,
+        "relay": true
+      },
+      "vendor": "Plugwise",
+      "zigbee_mac_address": "ABCD012345670A14"
+    },
+    "d3da73bde12a47d5a6b8f9dad971f2ec": {
+      "available": true,
+      "dev_class": "thermo_sensor",
+      "firmware": "2019-03-27T01:00:00+01:00",
+      "hardware": "1",
+      "location": "82fa13f017d240daa0d0ea1775420f24",
+      "model": "Tom/Floor",
+      "name": "Thermostatic Radiator Jessie",
+      "sensors": {
+        "battery": 62,
+        "setpoint": 15.0,
+        "temperature": 17.1,
+        "temperature_difference": 0.1,
+        "valve_position": 0.0
+      },
+      "temperature_offset": {
+        "lower_bound": -2.0,
+        "resolution": 0.1,
+        "setpoint": 0.0,
+        "upper_bound": 2.0
+      },
+      "vendor": "Plugwise",
+      "zigbee_mac_address": "ABCD012345670A10"
+    },
+    "df4a4a8169904cdb9c03d61a21f42140": {
+      "active_preset": "away",
+      "available": true,
+      "available_schedules": [
+        "CV Roan",
+        "Bios Schema met Film Avond",
+        "GF7  Woonkamer",
+        "Badkamer Schema",
+        "CV Jessie",
+        "off"
+      ],
+      "dev_class": "zone_thermostat",
+      "firmware": "2016-10-27T02:00:00+02:00",
+      "hardware": "255",
+      "location": "12493538af164a409c6a1c79e38afe1c",
+      "mode": "heat",
+      "model": "Lisa",
+      "name": "Zone Lisa Bios",
+      "preset_modes": ["home", "asleep", "away", "vacation", "no_frost"],
+      "select_schedule": "off",
+      "sensors": {
+        "battery": 67,
+        "setpoint": 13.0,
+        "temperature": 16.5
+      },
+      "temperature_offset": {
+        "lower_bound": -2.0,
+        "resolution": 0.1,
+        "setpoint": 0.0,
+        "upper_bound": 2.0
+      },
+      "thermostat": {
+        "lower_bound": 0.0,
+        "resolution": 0.01,
+        "setpoint": 13.0,
+        "upper_bound": 99.9
+      },
+      "vendor": "Plugwise",
+      "zigbee_mac_address": "ABCD012345670A06"
+    },
+    "e7693eb9582644e5b865dba8d4447cf1": {
+      "active_preset": "no_frost",
+      "available": true,
+      "dev_class": "thermostatic_radiator_valve",
+      "firmware": "2019-03-27T01:00:00+01:00",
+      "hardware": "1",
+      "location": "446ac08dd04d4eff8ac57489757b7314",
+      "mode": "heat",
+      "model": "Tom/Floor",
+      "name": "CV Kraan Garage",
+      "preset_modes": ["home", "asleep", "away", "vacation", "no_frost"],
+      "sensors": {
+        "battery": 68,
+        "setpoint": 5.5,
+        "temperature": 15.6,
+        "temperature_difference": 0.0,
+        "valve_position": 0.0
+      },
+      "temperature_offset": {
+        "lower_bound": -2.0,
+        "resolution": 0.1,
+        "setpoint": 0.0,
+        "upper_bound": 2.0
+      },
+      "thermostat": {
+        "lower_bound": 0.0,
+        "resolution": 0.01,
+        "setpoint": 5.5,
+        "upper_bound": 100.0
+      },
+      "vendor": "Plugwise",
+      "zigbee_mac_address": "ABCD012345670A11"
+    },
+    "f1fee6043d3642a9b0a65297455f008e": {
+      "active_preset": "away",
+      "available": true,
+      "available_schedules": [
+        "CV Roan",
+        "Bios Schema met Film Avond",
+        "GF7  Woonkamer",
+        "Badkamer Schema",
+        "CV Jessie",
+        "off"
+      ],
+      "dev_class": "zone_thermostat",
+      "firmware": "2016-10-27T02:00:00+02:00",
+      "hardware": "255",
+      "location": "08963fec7c53423ca5680aa4cb502c63",
+      "mode": "auto",
+      "model": "Lisa",
+      "name": "Zone Thermostat Badkamer",
+      "preset_modes": ["home", "asleep", "away", "vacation", "no_frost"],
+      "select_schedule": "Badkamer Schema",
+      "sensors": {
+        "battery": 92,
+        "setpoint": 14.0,
+        "temperature": 18.9
+      },
+      "temperature_offset": {
+        "lower_bound": -2.0,
+        "resolution": 0.1,
+        "setpoint": 0.0,
+        "upper_bound": 2.0
+      },
+      "thermostat": {
+        "lower_bound": 0.0,
+        "resolution": 0.01,
+        "setpoint": 14.0,
+        "upper_bound": 99.9
+      },
+      "vendor": "Plugwise",
+      "zigbee_mac_address": "ABCD012345670A08"
+    },
+    "fe799307f1624099878210aa0b9f1475": {
+      "binary_sensors": {
+        "plugwise_notification": true
+      },
+      "dev_class": "gateway",
+      "firmware": "3.0.15",
+      "hardware": "AME Smile 2.0 board",
+      "location": "1f9dcf83fd4e4b66b72ff787957bfe5d",
+      "mac_address": "012345670001",
+      "model": "Gateway",
+      "name": "Adam",
+      "select_regulation_mode": "heating",
+      "sensors": {
+        "outdoor_temperature": 7.81
+      },
+      "vendor": "Plugwise",
+      "zigbee_mac_address": "ABCD012345670101"
+    }
+  },
+  "gateway": {
+    "cooling_present": false,
+    "gateway_id": "fe799307f1624099878210aa0b9f1475",
+    "heater_id": "90986d591dcd426cae3ec3e8111ff730",
+    "item_count": 315,
+    "notifications": {
+      "af82e4ccf9c548528166d38e560662a4": {
+        "warning": "Node Plug (with MAC address 000D6F000D13CB01, in room 'n.a.') has been unreachable since 23:03 2020-01-18. Please check the connection and restart the device."
+      }
+    },
+    "smile_name": "Adam"
+  }
+}

--- a/plugwise/data.py
+++ b/plugwise/data.py
@@ -197,9 +197,10 @@ class SmileData(SmileHelper):
 
         # Schedule
         avail_schedules, sel_schedule = self._schedules(loc_id)
-        data["available_schedules"] = avail_schedules
-        data["select_schedule"] = sel_schedule
-        self._count += 2
+        if avail_schedules != [NONE]:
+            data["available_schedules"] = avail_schedules
+            data["select_schedule"] = sel_schedule
+            self._count += 2
 
         # Operation modes: auto, heat, heat_cool, cool and off
         data["mode"] = "auto"

--- a/plugwise/legacy/data.py
+++ b/plugwise/legacy/data.py
@@ -81,9 +81,10 @@ class SmileLegacyData(SmileLegacyHelper):
 
         # Schedule
         avail_schedules, sel_schedule = self._schedules()
-        data["available_schedules"] = avail_schedules
-        data["select_schedule"] = sel_schedule
-        self._count += 2
+        if avail_schedules != [NONE]:
+            data["available_schedules"] = avail_schedules
+            data["select_schedule"] = sel_schedule
+            self._count += 2
 
         # Operation modes: auto, heat
         data["mode"] = "auto"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name            = "plugwise"
-version         = "0.37.6"
+version         = "0.37.7"
 license         = {file = "LICENSE"}
 description     = "Plugwise Smile (Adam/Anna/P1) and Stretch module for Python 3."
 readme          = "README.md"

--- a/scripts/manual_fixtures.py
+++ b/scripts/manual_fixtures.py
@@ -63,7 +63,7 @@ m_adam_cooling["devices"]["ad4838d7d35c4d6ea796ee12ae5aedf8"]["available"] = Tru
 
 m_adam_cooling["devices"]["ad4838d7d35c4d6ea796ee12ae5aedf8"][
     "select_schedule"
-] = "None"
+] = "off"
 m_adam_cooling["devices"]["ad4838d7d35c4d6ea796ee12ae5aedf8"][
     "control_state"
 ] = "cooling"

--- a/scripts/manual_fixtures.py
+++ b/scripts/manual_fixtures.py
@@ -24,6 +24,23 @@ def json_writer(manual_name: str, all_data: dict) -> None:
 
 print("... Crafting m_* fixtures from userdata ...")  # noqa: T201
 
+
+# Modified Adam fixtures
+
+base_adam_manual = "adam_multiple_devices_per_zone"
+basefile = f"./fixtures/{base_adam_manual}/all_data.json"
+
+io = open(basefile)
+base = json.load(io)
+
+adam_multiple_devices_per_zone = base.copy()
+
+# Change schedule to not present for "e7693eb9582644e5b865dba8d4447cf1"
+adam_multiple_devices_per_zone["devices"]["e7693eb9582644e5b865dba8d4447cf1"].pop("available_schedules")
+adam_multiple_devices_per_zone["devices"]["e7693eb9582644e5b865dba8d4447cf1"].pop("select_schedule")
+
+json_writer("m_adam_multiple_devices_per_zone", adam_multiple_devices_per_zone)
+
 base_adam_manual = "adam_jip"
 basefile = f"./fixtures/{base_adam_manual}/all_data.json"
 
@@ -36,6 +53,7 @@ adam_jip = base.copy()
 adam_jip["devices"]["1346fbd8498d4dbcab7e18d51b771f3d"]["mode"] = "off"
 
 json_writer("m_adam_jip", adam_jip)
+
 
 ### Manual Adam fixtures
 
@@ -218,7 +236,7 @@ m_adam_heating["devices"]["056ee145a816487eaa69243c3280f8bf"]["max_dhw_temperatu
 
 json_writer("m_adam_heating", m_adam_heating)
 
-### ANNA
+### Manual Anna fixtures
 
 base_anna_manual = "anna_heatpump_heating"
 basefile = f"./fixtures/{base_anna_manual}/all_data.json"

--- a/tests/data/adam/adam_jip.json
+++ b/tests/data/adam/adam_jip.json
@@ -52,8 +52,6 @@
     "available": true,
     "preset_modes": ["home", "asleep", "away", "vacation", "no_frost"],
     "active_preset": "home",
-    "available_schedules": ["None"],
-    "select_schedule": "None",
     "control_state": "off",
     "mode": "heat",
     "sensors": {
@@ -80,8 +78,6 @@
     "available": true,
     "preset_modes": ["home", "asleep", "away", "vacation", "no_frost"],
     "active_preset": "no_frost",
-    "available_schedules": ["None"],
-    "select_schedule": "None",
     "control_state": "off",
     "mode": "heat",
     "sensors": {
@@ -125,8 +121,6 @@
     "available": true,
     "preset_modes": ["home", "asleep", "away", "vacation", "no_frost"],
     "active_preset": "home",
-    "available_schedules": ["None"],
-    "select_schedule": "None",
     "control_state": "off",
     "mode": "heat",
     "sensors": {
@@ -153,8 +147,6 @@
     "available": true,
     "preset_modes": ["home", "asleep", "away", "vacation", "no_frost"],
     "active_preset": "home",
-    "available_schedules": ["None"],
-    "select_schedule": "None",
     "control_state": "off",
     "mode": "heat",
     "sensors": {

--- a/tests/data/anna/legacy_anna.json
+++ b/tests/data/anna/legacy_anna.json
@@ -24,8 +24,6 @@
     },
     "preset_modes": ["away", "vacation", "asleep", "home", "no_frost"],
     "active_preset": "home",
-    "available_schedules": ["None"],
-    "select_schedule": "None",
     "mode": "heat",
     "sensors": {
       "temperature": 20.4,

--- a/tests/data/anna/legacy_anna.json
+++ b/tests/data/anna/legacy_anna.json
@@ -49,6 +49,7 @@
     },
     "sensors": {
       "water_temperature": 23.6,
+      "dhw_temperature": 51.2,
       "intended_boiler_temperature": 17,
       "modulation_level": 0,
       "return_temperature": 21.7,

--- a/tests/data/anna/legacy_anna_2.json
+++ b/tests/data/anna/legacy_anna_2.json
@@ -53,6 +53,7 @@
     },
     "sensors": {
       "water_temperature": 54,
+      "dhw_temperature": 0.0,
       "intended_boiler_temperature": 0,
       "modulation_level": 0,
       "return_temperature": 0,

--- a/tests/test_adam.py
+++ b/tests/test_adam.py
@@ -347,7 +347,7 @@ class TestPlugwiseAdam(TestPlugwise):  # pylint: disable=attribute-defined-outsi
         assert smile._last_active["06aecb3d00354375924f50c47af36bd2"] is None
         assert smile._last_active["d27aede973b54be484f6842d1b2802ad"] is None
         assert smile._last_active["13228dab8ce04617af318a2888b3c548"] is None
-        assert self.device_items == 221
+        assert self.device_items == 213
 
         # Negative test
         result = await self.tinker_thermostat(

--- a/tests/test_legacy_anna.py
+++ b/tests/test_legacy_anna.py
@@ -64,7 +64,7 @@ class TestPlugwiseAnna(TestPlugwise):  # pylint: disable=attribute-defined-outsi
         await self.device_test(smile, "2020-05-03 00:00:01", testdata)
 
         assert smile.gateway_id == "be81e3f8275b4129852c4d8d550ae2eb"
-        assert self.device_items == 42
+        assert self.device_items == 43
 
         result = await self.tinker_legacy_thermostat(smile)
         assert result

--- a/tests/test_legacy_anna.py
+++ b/tests/test_legacy_anna.py
@@ -30,7 +30,7 @@ class TestPlugwiseAnna(TestPlugwise):  # pylint: disable=attribute-defined-outsi
 
         await self.device_test(smile, "2020-03-22 00:00:01", testdata)
         assert smile.gateway_id == "0000aaaa0000aaaa0000aaaa0000aa00"
-        assert self.device_items == 40
+        assert self.device_items == 41
 
         result = await self.tinker_legacy_thermostat(smile, schedule_on=False)
         assert result

--- a/tests/test_legacy_anna.py
+++ b/tests/test_legacy_anna.py
@@ -30,7 +30,7 @@ class TestPlugwiseAnna(TestPlugwise):  # pylint: disable=attribute-defined-outsi
 
         await self.device_test(smile, "2020-03-22 00:00:01", testdata)
         assert smile.gateway_id == "0000aaaa0000aaaa0000aaaa0000aa00"
-        assert self.device_items == 43
+        assert self.device_items == 40
 
         result = await self.tinker_legacy_thermostat(smile, schedule_on=False)
         assert result
@@ -64,7 +64,7 @@ class TestPlugwiseAnna(TestPlugwise):  # pylint: disable=attribute-defined-outsi
         await self.device_test(smile, "2020-05-03 00:00:01", testdata)
 
         assert smile.gateway_id == "be81e3f8275b4129852c4d8d550ae2eb"
-        assert self.device_items == 43
+        assert self.device_items == 42
 
         result = await self.tinker_legacy_thermostat(smile)
         assert result


### PR DESCRIPTION
When trying to implement v0.37.6 into plugwise-beta (Select-platform) I ran into a problem.
I realized this was best fixed in the backend by not outputting the schedule(s) data when there is(are) no valid schedule(s) present. So this was implemented.

During this process I corrected the manual-fixture script, and some omissions in the legacy_anna data.

Please see https://github.com/plugwise/plugwise-beta/pull/644 for the corresponding changes in pw-beta.

