### PR TITLE
Implement fix for Core Issue #119686

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## v0.38.3
+
+- Implement fix for Core Issue #119686
+
 ## v0.38.2
 
 - Lower connection-timeout for actual devices after initial connect

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## v0.38.3
 
-- Implement fix for Core Issue #119686
+- Implement fix for Core Issue [#119686](https://github.com/home-assistant/core/issues/119686)
 
 ## v0.38.2
 

--- a/plugwise/smile.py
+++ b/plugwise/smile.py
@@ -163,9 +163,12 @@ class SmileAPI(SmileComm, SmileData):
         temperature: float,
     ) -> None:
         """Set the maximum boiler- or DHW-setpoint on the Central Heating boiler or the temperature-offset on a Thermostat."""
-        if key == "temperature_offset":
-            await self.set_offset(dev_id, temperature)
-            return
+        match key:
+            case "temperature_offset":
+                await self.set_offset(dev_id, temperature)
+                return
+            case "max_dhw_temperature":
+                key = "domestic_hot_water_setpoint"
 
         temp = str(temperature)
         thermostat_id: str | None = None

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name            = "plugwise"
-version         = "0.38.2"
+version         = "0.38.3"
 license         = {file = "LICENSE"}
 description     = "Plugwise Smile (Adam/Anna/P1) and Stretch module for Python 3."
 readme          = "README.md"

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -916,7 +916,7 @@ class TestPlugwise:  # pylint: disable=attribute-defined-outside-init
         tinker_max_boiler_temp_passed = False
         new_temp = 60.0
         _LOGGER.info("- Adjusting temperature to %s", new_temp)
-        for test in ["maximum_boiler_temperature", "bogus_temperature"]:
+        for test in ["maximum_boiler_temperature", "max_dhw_temperature", "bogus_temperature"]:
             _LOGGER.info("  + for %s", test)
             try:
                 await smile.set_number("dummy", test, new_temp)


### PR DESCRIPTION
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added renaming of the incoming key `max_dhw_temperature` (back) to `domestic_hot_water_setpoint`, fixing Core Issue #119686.

- **Tests**
  - Included "max_dhw_temperature" in the test loops to ensure new functionality works as expected.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->