### PR TITLE
Change key to low_battery

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## v1.1.0
 
-- New Feature: add a battery_state binary_sensor for battery-powered devices and block the related battery-low notifications.
+- New Feature: add a low_battery binary_sensor for battery-powered devices and block the related battery-low notifications.
 
 ## v1.0.0
 

--- a/fixtures/adam_heatpump_cooling/all_data.json
+++ b/fixtures/adam_heatpump_cooling/all_data.json
@@ -48,7 +48,7 @@
         "off"
       ],
       "binary_sensors": {
-        "battery_state": false
+        "low_battery": false
       },
       "control_state": "off",
       "dev_class": "zone_thermostat",
@@ -525,7 +525,7 @@
         "off"
       ],
       "binary_sensors": {
-        "battery_state": false
+        "low_battery": false
       },
       "control_state": "off",
       "dev_class": "zone_thermostat",

--- a/fixtures/adam_jip/all_data.json
+++ b/fixtures/adam_jip/all_data.json
@@ -4,7 +4,7 @@
       "active_preset": "no_frost",
       "available": true,
       "binary_sensors": {
-        "battery_state": false
+        "low_battery": false
       },
       "control_state": "off",
       "dev_class": "zone_thermostat",
@@ -101,7 +101,7 @@
       "active_preset": "home",
       "available": true,
       "binary_sensors": {
-        "battery_state": false
+        "low_battery": false
       },
       "control_state": "off",
       "dev_class": "zone_thermostat",
@@ -159,7 +159,7 @@
       "active_preset": "home",
       "available": true,
       "binary_sensors": {
-        "battery_state": false
+        "low_battery": false
       },
       "control_state": "off",
       "dev_class": "zone_thermostat",
@@ -273,7 +273,7 @@
       "active_preset": "home",
       "available": true,
       "binary_sensors": {
-        "battery_state": false
+        "low_battery": false
       },
       "control_state": "off",
       "dev_class": "zone_thermometer",

--- a/fixtures/adam_multiple_devices_per_zone/all_data.json
+++ b/fixtures/adam_multiple_devices_per_zone/all_data.json
@@ -83,7 +83,7 @@
     "680423ff840043738f42cc7f1ff97a36": {
       "available": true,
       "binary_sensors": {
-        "battery_state": false
+        "low_battery": false
       },
       "dev_class": "thermo_sensor",
       "firmware": "2019-03-27T01:00:00+01:00",
@@ -119,7 +119,7 @@
         "off"
       ],
       "binary_sensors": {
-        "battery_state": false
+        "low_battery": false
       },
       "dev_class": "zone_thermostat",
       "firmware": "2016-10-27T02:00:00+02:00",
@@ -206,7 +206,7 @@
     "a2c3583e0a6349358998b760cea82d2a": {
       "available": true,
       "binary_sensors": {
-        "battery_state": false
+        "low_battery": false
       },
       "dev_class": "thermo_sensor",
       "firmware": "2019-03-27T01:00:00+01:00",
@@ -265,7 +265,7 @@
         "off"
       ],
       "binary_sensors": {
-        "battery_state": false
+        "low_battery": false
       },
       "dev_class": "zone_thermostat",
       "firmware": "2016-08-02T02:00:00+02:00",
@@ -319,7 +319,7 @@
     "d3da73bde12a47d5a6b8f9dad971f2ec": {
       "available": true,
       "binary_sensors": {
-        "battery_state": false
+        "low_battery": false
       },
       "dev_class": "thermo_sensor",
       "firmware": "2019-03-27T01:00:00+01:00",
@@ -355,7 +355,7 @@
         "off"
       ],
       "binary_sensors": {
-        "battery_state": false
+        "low_battery": false
       },
       "dev_class": "zone_thermostat",
       "firmware": "2016-10-27T02:00:00+02:00",
@@ -398,7 +398,7 @@
         "off"
       ],
       "binary_sensors": {
-        "battery_state": false
+        "low_battery": false
       },
       "dev_class": "thermostatic_radiator_valve",
       "firmware": "2019-03-27T01:00:00+01:00",
@@ -443,7 +443,7 @@
         "off"
       ],
       "binary_sensors": {
-        "battery_state": false
+        "low_battery": false
       },
       "dev_class": "zone_thermostat",
       "firmware": "2016-10-27T02:00:00+02:00",

--- a/fixtures/adam_plus_anna_new/all_data.json
+++ b/fixtures/adam_plus_anna_new/all_data.json
@@ -28,7 +28,7 @@
     "1772a4ea304041adb83f357b751341ff": {
       "available": true,
       "binary_sensors": {
-        "battery_state": false
+        "low_battery": false
       },
       "dev_class": "thermo_sensor",
       "firmware": "2020-11-04T01:00:00+01:00",
@@ -188,7 +188,7 @@
         "off"
       ],
       "binary_sensors": {
-        "battery_state": true
+        "low_battery": true
       },
       "control_state": "preheating",
       "dev_class": "zone_thermostat",

--- a/fixtures/adam_zone_per_device/all_data.json
+++ b/fixtures/adam_zone_per_device/all_data.json
@@ -83,7 +83,7 @@
     "680423ff840043738f42cc7f1ff97a36": {
       "available": true,
       "binary_sensors": {
-        "battery_state": false
+        "low_battery": false
       },
       "dev_class": "thermo_sensor",
       "firmware": "2019-03-27T01:00:00+01:00",
@@ -119,7 +119,7 @@
         "off"
       ],
       "binary_sensors": {
-        "battery_state": false
+        "low_battery": false
       },
       "dev_class": "zone_thermostat",
       "firmware": "2016-10-27T02:00:00+02:00",
@@ -206,7 +206,7 @@
     "a2c3583e0a6349358998b760cea82d2a": {
       "available": true,
       "binary_sensors": {
-        "battery_state": false
+        "low_battery": false
       },
       "dev_class": "thermo_sensor",
       "firmware": "2019-03-27T01:00:00+01:00",
@@ -265,7 +265,7 @@
         "off"
       ],
       "binary_sensors": {
-        "battery_state": false
+        "low_battery": false
       },
       "dev_class": "zone_thermostat",
       "firmware": "2016-08-02T02:00:00+02:00",
@@ -319,7 +319,7 @@
     "d3da73bde12a47d5a6b8f9dad971f2ec": {
       "available": true,
       "binary_sensors": {
-        "battery_state": false
+        "low_battery": false
       },
       "dev_class": "thermo_sensor",
       "firmware": "2019-03-27T01:00:00+01:00",
@@ -355,7 +355,7 @@
         "off"
       ],
       "binary_sensors": {
-        "battery_state": false
+        "low_battery": false
       },
       "dev_class": "zone_thermostat",
       "firmware": "2016-10-27T02:00:00+02:00",
@@ -398,7 +398,7 @@
         "off"
       ],
       "binary_sensors": {
-        "battery_state": false
+        "low_battery": false
       },
       "dev_class": "thermostatic_radiator_valve",
       "firmware": "2019-03-27T01:00:00+01:00",
@@ -443,7 +443,7 @@
         "off"
       ],
       "binary_sensors": {
-        "battery_state": false
+        "low_battery": false
       },
       "dev_class": "zone_thermostat",
       "firmware": "2016-10-27T02:00:00+02:00",

--- a/fixtures/m_adam_cooling/all_data.json
+++ b/fixtures/m_adam_cooling/all_data.json
@@ -29,7 +29,7 @@
     "1772a4ea304041adb83f357b751341ff": {
       "available": true,
       "binary_sensors": {
-        "battery_state": false
+        "low_battery": false
       },
       "dev_class": "thermo_sensor",
       "firmware": "2020-11-04T01:00:00+01:00",
@@ -120,7 +120,7 @@
         "off"
       ],
       "binary_sensors": {
-        "battery_state": true
+        "low_battery": true
       },
       "control_state": "preheating",
       "dev_class": "zone_thermostat",

--- a/fixtures/m_adam_heating/all_data.json
+++ b/fixtures/m_adam_heating/all_data.json
@@ -34,7 +34,7 @@
     "1772a4ea304041adb83f357b751341ff": {
       "available": true,
       "binary_sensors": {
-        "battery_state": false
+        "low_battery": false
       },
       "dev_class": "thermo_sensor",
       "firmware": "2020-11-04T01:00:00+01:00",
@@ -119,7 +119,7 @@
         "off"
       ],
       "binary_sensors": {
-        "battery_state": true
+        "low_battery": true
       },
       "control_state": "off",
       "dev_class": "zone_thermostat",

--- a/fixtures/m_adam_jip/all_data.json
+++ b/fixtures/m_adam_jip/all_data.json
@@ -4,7 +4,7 @@
       "active_preset": "no_frost",
       "available": true,
       "binary_sensors": {
-        "battery_state": false
+        "low_battery": false
       },
       "control_state": "off",
       "dev_class": "zone_thermostat",
@@ -101,7 +101,7 @@
       "active_preset": "home",
       "available": true,
       "binary_sensors": {
-        "battery_state": false
+        "low_battery": false
       },
       "control_state": "off",
       "dev_class": "zone_thermostat",
@@ -159,7 +159,7 @@
       "active_preset": "home",
       "available": true,
       "binary_sensors": {
-        "battery_state": false
+        "low_battery": false
       },
       "control_state": "off",
       "dev_class": "zone_thermostat",
@@ -273,7 +273,7 @@
       "active_preset": "home",
       "available": true,
       "binary_sensors": {
-        "battery_state": false
+        "low_battery": false
       },
       "control_state": "off",
       "dev_class": "zone_thermometer",

--- a/fixtures/m_adam_multiple_devices_per_zone/all_data.json
+++ b/fixtures/m_adam_multiple_devices_per_zone/all_data.json
@@ -83,7 +83,7 @@
     "680423ff840043738f42cc7f1ff97a36": {
       "available": true,
       "binary_sensors": {
-        "battery_state": false
+        "low_battery": false
       },
       "dev_class": "thermo_sensor",
       "firmware": "2019-03-27T01:00:00+01:00",
@@ -119,7 +119,7 @@
         "off"
       ],
       "binary_sensors": {
-        "battery_state": false
+        "low_battery": false
       },
       "dev_class": "zone_thermostat",
       "firmware": "2016-10-27T02:00:00+02:00",
@@ -206,7 +206,7 @@
     "a2c3583e0a6349358998b760cea82d2a": {
       "available": true,
       "binary_sensors": {
-        "battery_state": false
+        "low_battery": false
       },
       "dev_class": "thermo_sensor",
       "firmware": "2019-03-27T01:00:00+01:00",
@@ -265,7 +265,7 @@
         "off"
       ],
       "binary_sensors": {
-        "battery_state": false
+        "low_battery": false
       },
       "dev_class": "zone_thermostat",
       "firmware": "2016-08-02T02:00:00+02:00",
@@ -319,7 +319,7 @@
     "d3da73bde12a47d5a6b8f9dad971f2ec": {
       "available": true,
       "binary_sensors": {
-        "battery_state": false
+        "low_battery": false
       },
       "dev_class": "thermo_sensor",
       "firmware": "2019-03-27T01:00:00+01:00",
@@ -355,7 +355,7 @@
         "off"
       ],
       "binary_sensors": {
-        "battery_state": false
+        "low_battery": false
       },
       "dev_class": "zone_thermostat",
       "firmware": "2016-10-27T02:00:00+02:00",
@@ -390,7 +390,7 @@
       "active_preset": "no_frost",
       "available": true,
       "binary_sensors": {
-        "battery_state": false
+        "low_battery": false
       },
       "dev_class": "thermostatic_radiator_valve",
       "firmware": "2019-03-27T01:00:00+01:00",
@@ -434,7 +434,7 @@
         "off"
       ],
       "binary_sensors": {
-        "battery_state": false
+        "low_battery": false
       },
       "dev_class": "zone_thermostat",
       "firmware": "2016-10-27T02:00:00+02:00",

--- a/plugwise/constants.py
+++ b/plugwise/constants.py
@@ -258,13 +258,13 @@ ApplianceType = Literal[
 ]
 
 BinarySensorType = Literal[
-    "battery_state",
     "compressor_state",
     "cooling_enabled",
     "cooling_state",
     "dhw_state",
     "flame_state",
     "heating_state",
+    "low_battery",
     "plugwise_notification",
     "secondary_boiler_state",
 ]
@@ -410,13 +410,13 @@ class ModelData(TypedDict):
 class SmileBinarySensors(TypedDict, total=False):
     """Smile Binary Sensors class."""
 
-    battery_state: bool
     compressor_state: bool
     cooling_enabled: bool
     cooling_state: bool
     dhw_state: bool
     flame_state: bool
     heating_state: bool
+    low_battery: bool
     plugwise_notification: bool
     secondary_boiler_state: bool
 

--- a/plugwise/data.py
+++ b/plugwise/data.py
@@ -65,7 +65,7 @@ class SmileData(SmileHelper):
 
             is_battery_low = (
                 mac_list
-                and "battery_state" in device["binary_sensors"]
+                and "low_battery" in device["binary_sensors"]
                 and device["zigbee_mac_address"] in mac_list
                 and (
                     (device["dev_class"] in ("thermo_sensor", "thermostatic_radiator_valve") and device["sensors"]["battery"] < 30)
@@ -73,14 +73,14 @@ class SmileData(SmileHelper):
                 )
             )
             if is_battery_low:
-                device["binary_sensors"]["battery_state"] = True
+                device["binary_sensors"]["low_battery"] = True
 
             self._update_for_cooling(device)
 
             remove_empty_platform_dicts(device)
 
     def _detect_low_batteries(self) -> list[str]:
-        """Helper-function updating the battery_state binary_sensor status from a Battery-is-low message."""
+        """Helper-function updating the low-battery binary_sensor status from a Battery-is-low message."""
         mac_address_list: list[str] = []
         mac_pattern = re.compile(r"(?:[0-9A-F]{2}){8}")
         matches = ["Battery", "below"]

--- a/plugwise/util.py
+++ b/plugwise/util.py
@@ -139,7 +139,7 @@ def common_match_cases(
             data[sp_key] = value
 
     if "battery" in data["sensors"]:
-        data["binary_sensors"]["battery_state"] = False
+        data["binary_sensors"]["low_battery"] = False
 
 
 def escape_illegal_xml_characters(xmldata: str) -> str:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name            = "plugwise"
-version         = "1.1.0a0"
+version         = "1.1.0"
 license         = {file = "LICENSE"}
 description     = "Plugwise Smile (Adam/Anna/P1) and Stretch module for Python 3."
 readme          = "README.md"

--- a/tests/data/adam/adam_plus_anna_new.json
+++ b/tests/data/adam/adam_plus_anna_new.json
@@ -71,7 +71,7 @@
     "zigbee_mac_address": "000D6F000C869B61",
     "vendor": "Plugwise",
     "binary_sensors": {
-        "battery_state": true
+        "low_battery": true
       },
     "sensors": {
       "temperature": 16.5,
@@ -182,7 +182,7 @@
     "zigbee_mac_address": "000D6F000C8FF5EE",
     "vendor": "Plugwise",
     "binary_sensors": {
-        "battery_state": false
+        "low_battery": false
       },
     "sensors": {
       "temperature": 17.6,

--- a/tests/data/adam/adam_plus_anna_new_UPDATED_DATA.json
+++ b/tests/data/adam/adam_plus_anna_new_UPDATED_DATA.json
@@ -28,7 +28,7 @@
   },
   "e2f4322d57924fa090fbbc48b3a140dc": {
     "binary_sensors": {
-        "battery_state": false
+        "low_battery": false
       },
     "mode": "off"
   },


### PR DESCRIPTION
In the backend code `low_battery` being `True/False` "reads" better.

But in the Integration I think we should stick to `Battery State` now with the `device_class` added.
Not a big problem, we can use `BATTERY_STATE: Final = "low_battery"` as constant.

@CoMPaTech what's your opinion?

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **New Features**
	- Updated the battery status representation from `battery_state` to `low_battery` across multiple devices, enhancing clarity on low battery conditions.
  
- **Bug Fixes**
	- Ensured consistency of battery status naming across various JSON configurations to prevent potential confusion in device monitoring.
  
- **Tests**
	- Adjusted test data to reflect the new battery status naming convention, ensuring all tests align with the updated terminology.

- **Chores**
	- Updated the project version to 1.1.0, indicating a transition to a stable release.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->