### PR TITLE
Add/correct typing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## v1.3.1
+
+- Add missing typing for model_id.
+
 ## v1.3.0
 
 - New Feature: add device model_id's to the API output (not for legacy devices).

--- a/plugwise/constants.py
+++ b/plugwise/constants.py
@@ -512,16 +512,16 @@ class DeviceData(TypedDict, total=False):
 
     # Appliance base data
     dev_class: str
-    firmware: str | None
+    firmware: str
     hardware: str
     location: str
-    mac_address: str | None
+    mac_address: str
     members: list[str]
     model: str
     model_id: str
     name: str
     vendor: str
-    zigbee_mac_address: str | None
+    zigbee_mac_address: str
 
     # For temporary use
     cooling_enabled: bool

--- a/plugwise/constants.py
+++ b/plugwise/constants.py
@@ -252,6 +252,7 @@ ApplianceType = Literal[
     "mac_address",
     "members",
     "model",
+    "model_id",
     "name",
     "vendor",
     "zigbee_mac_address",
@@ -517,6 +518,7 @@ class DeviceData(TypedDict, total=False):
     mac_address: str | None
     members: list[str]
     model: str
+    model_id: str
     name: str
     vendor: str
     zigbee_mac_address: str | None

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name            = "plugwise"
-version         = "1.3.0"
+version         = "1.3.1"
 license         = {file = "LICENSE"}
 description     = "Plugwise Smile (Adam/Anna/P1) and Stretch module for Python 3."
 readme          = "README.md"


### PR DESCRIPTION
Typing for `model_id` was missing.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Added mandatory `model_id` to the API output for improved clarity.
  
- **Improvements**
	- Updated `firmware` and `mac_address` fields to be mandatory, enhancing data integrity.
  
- **Documentation**
	- Updated changelog to reflect the new version and changes made in v1.3.1. 

- **Chores**
	- Incremented project version from 1.3.0 to 1.3.1 in project configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->