### PR TITLE
Clean up timeout-related, pass _request-function as an argument

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## v1.4.3
+
+- Clean up timeout-related, pass _request-function as an argument.
+
 ## v1.4.2
 
 - Bugfix: implement solution for issue reported in [#739](https://github.com/plugwise/plugwise-beta/issues/739)

--- a/plugwise/__init__.py
+++ b/plugwise/__init__.py
@@ -60,7 +60,6 @@ class Smile(SmileComm):
         self._host = host
         self._passwd = password
         self._port = port
-        self._timeout = timeout
         self._user = username
         self._websession = websession
 
@@ -128,7 +127,6 @@ class Smile(SmileComm):
             self._host,
             self._passwd,
             self._request,
-            self._timeout,
             self._websession,
             self._cooling_present,
             self._elga,
@@ -153,7 +151,6 @@ class Smile(SmileComm):
             self._host,
             self._passwd,
             self._request,
-            self._timeout,
             self._websession,
             self._is_thermostat,
             self._on_off_device,

--- a/plugwise/__init__.py
+++ b/plugwise/__init__.py
@@ -127,6 +127,7 @@ class Smile(SmileComm):
         self._smile_api = SmileAPI(
             self._host,
             self._passwd,
+            self._request,
             self._timeout,
             self._websession,
             self._cooling_present,
@@ -151,6 +152,7 @@ class Smile(SmileComm):
          ) if not self.smile_legacy else SmileLegacyAPI(
             self._host,
             self._passwd,
+            self._request,
             self._timeout,
             self._websession,
             self._is_thermostat,

--- a/plugwise/__init__.py
+++ b/plugwise/__init__.py
@@ -6,7 +6,6 @@ from __future__ import annotations
 
 from plugwise.constants import (
     DEFAULT_PORT,
-    DEFAULT_TIMEOUT,
     DEFAULT_USERNAME,
     DOMAIN_OBJECTS,
     LOGGER,
@@ -193,9 +192,6 @@ class Smile(SmileComm):
             self.smile_model_id = gateway.find("vendor_model").text
         else:
             model = await self._smile_detect_legacy(result, dsmrmain, model)
-
-        if not self.smile_legacy:
-            self._timeout = DEFAULT_TIMEOUT
 
         if model == "Unknown" or self.smile_fw_version is None:  # pragma: no cover
             # Corner case check

--- a/plugwise/legacy/smile.py
+++ b/plugwise/legacy/smile.py
@@ -5,7 +5,7 @@ Plugwise backend module for Home Assistant Core - covering the legacy P1, Anna, 
 from __future__ import annotations
 
 import datetime as dt
-from typing import Any
+from typing import Any, Awaitable, Callable
 
 from plugwise.constants import (
     APPLIANCES,
@@ -40,7 +40,7 @@ class SmileLegacyAPI(SmileLegacyData):
         self,
         host: str,
         password: str,
-        request: etree,
+        request: Callable[..., Awaitable[Any]],
         timeout: int,
         websession: aiohttp.ClientSession,
         _is_thermostat: bool,

--- a/plugwise/legacy/smile.py
+++ b/plugwise/legacy/smile.py
@@ -76,7 +76,6 @@ class SmileLegacyAPI(SmileComm, SmileLegacyData):
         self._opentherm_device = _opentherm_device
         self._stretch_v2 = _stretch_v2
         self._target_smile = _target_smile
-        self._timeout = timeout
         self.loc_data = loc_data
         self.smile_fw_version = smile_fw_version
         self.smile_hostname = smile_hostname

--- a/plugwise/legacy/smile.py
+++ b/plugwise/legacy/smile.py
@@ -24,14 +24,13 @@ from plugwise.constants import (
     ThermoLoc,
 )
 from plugwise.exceptions import ConnectionFailedError, PlugwiseError
-from plugwise.helper import SmileComm
 from plugwise.legacy.data import SmileLegacyData
 
 import aiohttp
 from munch import Munch
 
 
-class SmileLegacyAPI(SmileComm, SmileLegacyData):
+class SmileLegacyAPI(SmileLegacyData):
     """The Plugwise SmileLegacyAPI class."""
 
     # pylint: disable=too-many-instance-attributes, too-many-public-methods
@@ -40,6 +39,7 @@ class SmileLegacyAPI(SmileComm, SmileLegacyData):
         self,
         host: str,
         password: str,
+        request,
         timeout: int,
         websession: aiohttp.ClientSession,
         _is_thermostat: bool,
@@ -60,14 +60,6 @@ class SmileLegacyAPI(SmileComm, SmileLegacyData):
         username: str = DEFAULT_USERNAME,
     ) -> None:
         """Set the constructor for this class."""
-        super().__init__(
-            host,
-            password,
-            port,
-            timeout,
-            username,
-            websession,
-         )
         SmileLegacyData.__init__(self)
 
         self._cooling_present = False
@@ -77,6 +69,7 @@ class SmileLegacyAPI(SmileComm, SmileLegacyData):
         self._stretch_v2 = _stretch_v2
         self._target_smile = _target_smile
         self.loc_data = loc_data
+        self.request = request
         self.smile_fw_version = smile_fw_version
         self.smile_hostname = smile_hostname
         self.smile_hw_version = smile_hw_version
@@ -90,12 +83,12 @@ class SmileLegacyAPI(SmileComm, SmileLegacyData):
 
     async def full_update_device(self) -> None:
         """Perform a first fetch of all XML data, needed for initialization."""
-        self._domain_objects = await self._request(DOMAIN_OBJECTS)
-        self._locations = await self._request(LOCATIONS)
-        self._modules = await self._request(MODULES)
+        self._domain_objects = await self.request(DOMAIN_OBJECTS)
+        self._locations = await self.request(LOCATIONS)
+        self._modules = await self.request(MODULES)
         # P1 legacy has no appliances
         if self.smile_type != "power":
-            self._appliances = await self._request(APPLIANCES)
+            self._appliances = await self.request(APPLIANCES)
 
     def get_all_devices(self) -> None:
         """Determine the evices present from the obtained XML-data.
@@ -130,12 +123,12 @@ class SmileLegacyAPI(SmileComm, SmileLegacyData):
             self.get_all_devices()
         # Otherwise perform an incremental update
         else:
-            self._domain_objects = await self._request(DOMAIN_OBJECTS)
+            self._domain_objects = await self.request(DOMAIN_OBJECTS)
             match self._target_smile:
                 case "smile_v2":
-                    self._modules = await self._request(MODULES)
+                    self._modules = await self.request(MODULES)
                 case self._target_smile if self._target_smile in REQUIRE_APPLIANCES:
-                    self._appliances = await self._request(APPLIANCES)
+                    self._appliances = await self.request(APPLIANCES)
 
             self._update_gw_devices()
 
@@ -290,10 +283,10 @@ class SmileLegacyAPI(SmileComm, SmileLegacyData):
         await self.call_request(uri, method="put", data=data)
 
     async def call_request(self, uri: str, **kwargs: Any) -> None:
-        """ConnectionFailedError wrapper for calling _request()."""
+        """ConnectionFailedError wrapper for calling request()."""
         method: str = kwargs["method"]
         data: str | None = kwargs.get("data")
         try:
-            await self._request(uri, method=method, data=data)
+            await self.request(uri, method=method, data=data)
         except ConnectionFailedError as exc:
             raise ConnectionFailedError from exc

--- a/plugwise/legacy/smile.py
+++ b/plugwise/legacy/smile.py
@@ -27,6 +27,7 @@ from plugwise.exceptions import ConnectionFailedError, PlugwiseError
 from plugwise.legacy.data import SmileLegacyData
 
 import aiohttp
+from defusedxml import ElementTree as etree
 from munch import Munch
 
 
@@ -39,7 +40,7 @@ class SmileLegacyAPI(SmileLegacyData):
         self,
         host: str,
         password: str,
-        request,
+        request: etree,
         timeout: int,
         websession: aiohttp.ClientSession,
         _is_thermostat: bool,

--- a/plugwise/legacy/smile.py
+++ b/plugwise/legacy/smile.py
@@ -4,8 +4,9 @@ Plugwise backend module for Home Assistant Core - covering the legacy P1, Anna, 
 """
 from __future__ import annotations
 
+from collections.abc import Awaitable, Callable
 import datetime as dt
-from typing import Any, Awaitable, Callable
+from typing import Any
 
 from plugwise.constants import (
     APPLIANCES,
@@ -27,7 +28,6 @@ from plugwise.exceptions import ConnectionFailedError, PlugwiseError
 from plugwise.legacy.data import SmileLegacyData
 
 import aiohttp
-from defusedxml import ElementTree as etree
 from munch import Munch
 
 

--- a/plugwise/legacy/smile.py
+++ b/plugwise/legacy/smile.py
@@ -41,7 +41,6 @@ class SmileLegacyAPI(SmileLegacyData):
         host: str,
         password: str,
         request: Callable[..., Awaitable[Any]],
-        timeout: int,
         websession: aiohttp.ClientSession,
         _is_thermostat: bool,
         _on_off_device: bool,

--- a/plugwise/smile.py
+++ b/plugwise/smile.py
@@ -45,7 +45,7 @@ class SmileAPI(SmileData):
         self,
         host: str,
         password: str,
-        request,
+        request: etree,
         timeout: int,
         websession: aiohttp.ClientSession,
         _cooling_present: bool,

--- a/plugwise/smile.py
+++ b/plugwise/smile.py
@@ -4,8 +4,9 @@ Plugwise backend module for Home Assistant Core.
 """
 from __future__ import annotations
 
+from collections.abc import Awaitable, Callable
 import datetime as dt
-from typing import Any, Awaitable, Callable
+from typing import Any
 
 from plugwise.constants import (
     ADAM,

--- a/plugwise/smile.py
+++ b/plugwise/smile.py
@@ -86,7 +86,6 @@ class SmileAPI(SmileComm, SmileData):
         self._on_off_device = _on_off_device
         self._opentherm_device = _opentherm_device
         self._schedule_old_states = _schedule_old_states
-        self._timeout = timeout
         self.gateway_id = gateway_id
         self.loc_data = loc_data
         self.smile_fw_version = smile_fw_version

--- a/plugwise/smile.py
+++ b/plugwise/smile.py
@@ -47,7 +47,6 @@ class SmileAPI(SmileData):
         host: str,
         password: str,
         request: Callable[..., Awaitable[Any]],
-        timeout: int,
         websession: aiohttp.ClientSession,
         _cooling_present: bool,
         _elga: bool,

--- a/plugwise/smile.py
+++ b/plugwise/smile.py
@@ -5,7 +5,7 @@ Plugwise backend module for Home Assistant Core.
 from __future__ import annotations
 
 import datetime as dt
-from typing import Any
+from typing import Any, Awaitable, Callable
 
 from plugwise.constants import (
     ADAM,
@@ -45,7 +45,7 @@ class SmileAPI(SmileData):
         self,
         host: str,
         password: str,
-        request: etree,
+        request: Callable[..., Awaitable[Any]],
         timeout: int,
         websession: aiohttp.ClientSession,
         _cooling_present: bool,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name            = "plugwise"
-version         = "1.4.3a0"
+version         = "1.4.3a1"
 license         = {file = "LICENSE"}
 description     = "Plugwise Smile (Adam/Anna/P1) and Stretch module for Python 3."
 readme          = "README.md"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name            = "plugwise"
-version         = "1.4.3a1"
+version         = "1.4.3"
 license         = {file = "LICENSE"}
 description     = "Plugwise Smile (Adam/Anna/P1) and Stretch module for Python 3."
 readme          = "README.md"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name            = "plugwise"
-version         = "1.4.2"
+version         = "1.4.3a0"
 license         = {file = "LICENSE"}
 description     = "Plugwise Smile (Adam/Anna/P1) and Stretch module for Python 3."
 readme          = "README.md"


### PR DESCRIPTION
I just realized I forgot to clean up some timeout -related stuff.
While doing this I wondered, can I avoid the double-linking of SmileComm? Turns out it can be avoided :)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Updated project version to 1.4.3.

- **Improvements**
	- Enhanced request handling in the `Smile` and `SmileLegacyAPI` classes for better performance and clarity.
	- Simplified class structures by removing unnecessary inheritance.

- **Bug Fixes**
	- Cleanup of timeout-related code to improve stability and functionality.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->