### PR TITLE
Change the output of the connect() function

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## v1.4.4
+
+- Change connect() output to gateway firmware version.
+
 ## v1.4.3
 
 - Clean up timeout-related, pass _request-function as an argument.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## v1.4.4
 
-- Change connect() output to gateway firmware version.
+- Change connect() function to output the gateway firmware-version.
 
 ## v1.4.3
 

--- a/plugwise/__init__.py
+++ b/plugwise/__init__.py
@@ -76,7 +76,7 @@ class Smile(SmileComm):
         self._target_smile: str = NONE
         self.gateway_id: str = NONE
         self.loc_data: dict[str, ThermoLoc] = {}
-        self.smile_fw_version: Version | None
+        self.smile_fw_version: Version | None = None
         self.smile_hostname: str = NONE
         self.smile_hw_version: str | None = None
         self.smile_legacy = False
@@ -88,7 +88,7 @@ class Smile(SmileComm):
         self.smile_version: Version | None = None
         self.smile_zigbee_mac_address: str | None = None
 
-    async def connect(self) -> str | None:
+    async def connect(self) -> Version | None:
         """Connect to Plugwise device and determine its name, type and version."""
         result = await self._request(DOMAIN_OBJECTS)
         # Work-around for Stretch fw 2.7.18

--- a/plugwise/__init__.py
+++ b/plugwise/__init__.py
@@ -87,7 +87,7 @@ class Smile(SmileComm):
         self.smile_version: str = NONE
         self.smile_zigbee_mac_address: str | None = None
 
-    async def connect(self) -> bool:
+    async def connect(self) -> str:
         """Connect to Plugwise device and determine its name, type and version."""
         result = await self._request(DOMAIN_OBJECTS)
         # Work-around for Stretch fw 2.7.18
@@ -173,7 +173,7 @@ class Smile(SmileComm):
         # Update all endpoints on first connect
         await self._smile_api.full_update_device()
 
-        return True
+        return self.smile_version
 
     async def _smile_detect(self, result: etree, dsmrmain: etree) -> None:
         """Helper-function for connect().

--- a/plugwise/__init__.py
+++ b/plugwise/__init__.py
@@ -84,10 +84,10 @@ class Smile(SmileComm):
         self.smile_model_id: str | None = None
         self.smile_name: str = NONE
         self.smile_type: str = NONE
-        self.smile_version: str = NONE
+        self.smile_version: str | None = None
         self.smile_zigbee_mac_address: str | None = None
 
-    async def connect(self) -> str:
+    async def connect(self) -> str | None:
         """Connect to Plugwise device and determine its name, type and version."""
         result = await self._request(DOMAIN_OBJECTS)
         # Work-around for Stretch fw 2.7.18

--- a/plugwise/helper.py
+++ b/plugwise/helper.py
@@ -62,6 +62,7 @@ from dateutil import tz
 from dateutil.parser import parse
 from defusedxml import ElementTree as etree
 from munch import Munch
+from packaging.version import Version
 
 
 class SmileComm:
@@ -250,7 +251,7 @@ class SmileHelper(SmileCommon):
         self.gw_data: GatewayData = {}
         self.gw_devices: dict[str, DeviceData] = {}
         self.loc_data: dict[str, ThermoLoc]
-        self.smile_fw_version: str | None
+        self.smile_fw_version: Version | None
         self.smile_hw_version: str | None
         self.smile_mac_address: str | None
         self.smile_model: str
@@ -425,7 +426,7 @@ class SmileHelper(SmileCommon):
     def _appl_gateway_info(self, appl: Munch, appliance: etree) -> Munch:
         """Helper-function for _appliance_info_finder()."""
         self.gateway_id = appliance.attrib["id"]
-        appl.firmware = self.smile_fw_version
+        appl.firmware = str(self.smile_fw_version)
         appl.hardware = self.smile_hw_version
         appl.mac = self.smile_mac_address
         appl.model = self.smile_model

--- a/plugwise/legacy/helper.py
+++ b/plugwise/legacy/helper.py
@@ -44,6 +44,7 @@ from plugwise.util import (
 # This way of importing aiohttp is because of patch/mocking in testing (aiohttp timeouts)
 from defusedxml import ElementTree as etree
 from munch import Munch
+from packaging.version import Version
 
 
 def etree_to_dict(element: etree) -> dict[str, str]:
@@ -81,7 +82,7 @@ class SmileLegacyHelper(SmileCommon):
         self.gw_data: GatewayData = {}
         self.gw_devices: dict[str, DeviceData] = {}
         self.loc_data: dict[str, ThermoLoc]
-        self.smile_fw_version: str | None
+        self.smile_fw_version: Version | None
         self.smile_hw_version: str | None
         self.smile_mac_address: str | None
         self.smile_model: str
@@ -194,7 +195,7 @@ class SmileLegacyHelper(SmileCommon):
         self.gw_devices[self.gateway_id] = {"dev_class": "gateway"}
         self._count += 1
         for key, value in {
-            "firmware": self.smile_fw_version,
+            "firmware": str(self.smile_fw_version),
             "location": self._home_location,
             "mac_address": self.smile_mac_address,
             "model": self.smile_model,

--- a/plugwise/legacy/smile.py
+++ b/plugwise/legacy/smile.py
@@ -29,6 +29,7 @@ from plugwise.legacy.data import SmileLegacyData
 
 import aiohttp
 from munch import Munch
+from packaging.version import Version
 
 
 class SmileLegacyAPI(SmileLegacyData):
@@ -48,7 +49,7 @@ class SmileLegacyAPI(SmileLegacyData):
         _stretch_v2: bool,
         _target_smile: str,
         loc_data: dict[str, ThermoLoc],
-        smile_fw_version: str | None,
+        smile_fw_version: Version | None,
         smile_hostname: str,
         smile_hw_version: str | None,
         smile_mac_address: str | None,

--- a/plugwise/smile.py
+++ b/plugwise/smile.py
@@ -35,6 +35,7 @@ from defusedxml import ElementTree as etree
 
 # Dict as class
 from munch import Munch
+from packaging.version import Version
 
 
 class SmileAPI(SmileData):
@@ -57,7 +58,7 @@ class SmileAPI(SmileData):
         _schedule_old_states: dict[str, dict[str, str]],
         gateway_id: str,
         loc_data: dict[str, ThermoLoc],
-        smile_fw_version: str | None,
+        smile_fw_version: Version | None,
         smile_hostname: str | None,
         smile_hw_version: str | None,
         smile_mac_address: str | None,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name            = "plugwise"
-version         = "1.4.3"
+version         = "1.4.4a0"
 license         = {file = "LICENSE"}
 description     = "Plugwise Smile (Adam/Anna/P1) and Stretch module for Python 3."
 readme          = "README.md"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name            = "plugwise"
-version         = "1.4.4a1"
+version         = "1.4.4"
 license         = {file = "LICENSE"}
 description     = "Plugwise Smile (Adam/Anna/P1) and Stretch module for Python 3."
 readme          = "README.md"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name            = "plugwise"
-version         = "1.4.4a0"
+version         = "1.4.4a1"
 license         = {file = "LICENSE"}
 description     = "Plugwise Smile (Adam/Anna/P1) and Stretch module for Python 3."
 readme          = "README.md"

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -2,7 +2,6 @@
 """Test Plugwise Home Assistant module and generate test JSON fixtures."""
 import importlib
 import json
-from packaging import version
 
 # Fixture writing
 import logging
@@ -18,6 +17,7 @@ import pytest
 # Testing
 import aiohttp
 from freezegun import freeze_time
+from packaging import version
 
 pw_constants = importlib.import_module("plugwise.constants")
 pw_exceptions = importlib.import_module("plugwise.exceptions")

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -345,8 +345,8 @@ class TestPlugwise:  # pylint: disable=attribute-defined-outside-init
 
         # Connect to the smile
         try:
-            connection_state = await smile.connect()
-            assert connection_state
+            version = await smile.connect()
+            assert version != pw_constants.NONE
             return server, smile, client
         except (
             pw_exceptions.ConnectionFailedError,
@@ -428,8 +428,8 @@ class TestPlugwise:  # pylint: disable=attribute-defined-outside-init
 
         # Connect to the smile
         try:
-            connection_state = await smile.connect()
-            assert connection_state
+            version = await smile.connect()
+            assert version != pw_constants.NONE
             return server, smile, client
         except (
             pw_exceptions.ConnectionFailedError,

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -346,7 +346,7 @@ class TestPlugwise:  # pylint: disable=attribute-defined-outside-init
         # Connect to the smile
         try:
             version = await smile.connect()
-            assert version != pw_constants.NONE
+            assert version is not None
             return server, smile, client
         except (
             pw_exceptions.ConnectionFailedError,
@@ -429,7 +429,7 @@ class TestPlugwise:  # pylint: disable=attribute-defined-outside-init
         # Connect to the smile
         try:
             version = await smile.connect()
-            assert version != pw_constants.NONE
+            assert version is not None
             return server, smile, client
         except (
             pw_exceptions.ConnectionFailedError,

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -344,6 +344,7 @@ class TestPlugwise:  # pylint: disable=attribute-defined-outside-init
             assert smile._timeout == 10
 
         # Connect to the smile
+        version = None
         try:
             version = await smile.connect()
             assert version is not None
@@ -353,6 +354,7 @@ class TestPlugwise:  # pylint: disable=attribute-defined-outside-init
             pw_exceptions.InvalidXMLError,
             pw_exceptions.InvalidAuthentication,
         ) as exception:
+            assert version is None
             await self.disconnect(server, client)
             raise exception
 
@@ -427,6 +429,7 @@ class TestPlugwise:  # pylint: disable=attribute-defined-outside-init
             assert smile._timeout == 30
 
         # Connect to the smile
+        version = None
         try:
             version = await smile.connect()
             assert version is not None
@@ -436,6 +439,7 @@ class TestPlugwise:  # pylint: disable=attribute-defined-outside-init
             pw_exceptions.InvalidXMLError,
             pw_exceptions.InvalidAuthentication,
         ) as exception:
+            assert version is None
             await self.disconnect(server, client)
             raise exception
 

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -2,6 +2,7 @@
 """Test Plugwise Home Assistant module and generate test JSON fixtures."""
 import importlib
 import json
+from packaging import version
 
 # Fixture writing
 import logging
@@ -1008,7 +1009,7 @@ class TestPlugwise:  # pylint: disable=attribute-defined-outside-init
         if smile_version:
             log_msg = f" # Assert version matching '{smile_version}"
             parent_logger.info(log_msg)
-            assert smile.smile_version == smile_version
+            assert smile.smile_version == version.parse(smile_version)
         log_msg = f" # Assert legacy {smile_legacy}"
         parent_logger.info(log_msg)
         if smile_legacy:


### PR DESCRIPTION
Let it output the gateway firmware-version so it can be used for config_entry migration in HA.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes for Version 1.4.4

- **New Features**
  - The `connect()` function now outputs the gateway firmware version, providing enhanced information during the connection process.

- **Improvements**
  - Enhanced type handling for firmware version attributes across various classes, ensuring consistency and clarity in version representation.
  - Updated tests to improve error handling and version validation, contributing to better reliability.

- **Chores**
  - Changelog updated to reflect the new version and summarize changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->