### PR TITLE
Add control_state to Anna output

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,12 +1,13 @@
 # Changelog
 
-## Ongoing
+## v1.6.4
 
 - Continuous improvements [#662](https://github.com/plugwise/python-plugwise/pull/662)
 - Rework tooling [#664](https://github.com/plugwise/python-plugwise/pull/664)
 - Archive p1v4 userdata [#666](https://github.com/plugwise/python-plugwise/pull/666)
 - Correct manual_fixtures script [#668](https://github.com/plugwise/python-plugwise/pull/668)
 - Improve P1 fault-handling, continuous improvements [#670](https://github.com/plugwise/python-plugwise/pull/670)
+- Add control_state to Anna output [#671](https://github.com/plugwise/python-plugwise/pull/671)
 
 ## v1.6.3
 

--- a/fixtures/anna_elga_2/all_data.json
+++ b/fixtures/anna_elga_2/all_data.json
@@ -39,6 +39,7 @@
       "active_preset": "home",
       "available_schedules": ["Thermostat schedule", "off"],
       "climate_mode": "auto",
+      "control_state": "idle",
       "dev_class": "thermostat",
       "firmware": "2018-02-08T11:15:53+01:00",
       "hardware": "6539-1301-5002",

--- a/fixtures/anna_elga_2_cooling/all_data.json
+++ b/fixtures/anna_elga_2_cooling/all_data.json
@@ -39,6 +39,7 @@
       "active_preset": "home",
       "available_schedules": ["Thermostat schedule", "off"],
       "climate_mode": "auto",
+      "control_state": "cooling",
       "dev_class": "thermostat",
       "firmware": "2018-02-08T11:15:53+01:00",
       "hardware": "6539-1301-5002",

--- a/fixtures/anna_elga_2_schedule_off/all_data.json
+++ b/fixtures/anna_elga_2_schedule_off/all_data.json
@@ -39,6 +39,7 @@
       "active_preset": "home",
       "available_schedules": ["Thermostat schedule", "off"],
       "climate_mode": "heat_cool",
+      "control_state": "idle",
       "dev_class": "thermostat",
       "firmware": "2018-02-08T11:15:53+01:00",
       "hardware": "6539-1301-5002",

--- a/fixtures/anna_elga_no_cooling/all_data.json
+++ b/fixtures/anna_elga_no_cooling/all_data.json
@@ -60,6 +60,7 @@
       "active_preset": "home",
       "available_schedules": ["standaard", "off"],
       "climate_mode": "auto",
+      "control_state": "heating",
       "dev_class": "thermostat",
       "firmware": "2018-02-08T11:15:53+01:00",
       "hardware": "6539-1301-5002",

--- a/fixtures/anna_heatpump_cooling/all_data.json
+++ b/fixtures/anna_heatpump_cooling/all_data.json
@@ -57,6 +57,7 @@
       "active_preset": "home",
       "available_schedules": ["standaard", "off"],
       "climate_mode": "heat_cool",
+      "control_state": "cooling",
       "dev_class": "thermostat",
       "firmware": "2018-02-08T11:15:53+01:00",
       "hardware": "6539-1301-5002",

--- a/fixtures/anna_heatpump_cooling_fake_firmware/all_data.json
+++ b/fixtures/anna_heatpump_cooling_fake_firmware/all_data.json
@@ -57,6 +57,7 @@
       "active_preset": "home",
       "available_schedules": ["standaard", "off"],
       "climate_mode": "heat_cool",
+      "control_state": "cooling",
       "dev_class": "thermostat",
       "firmware": "2018-02-08T11:15:53+01:00",
       "hardware": "6539-1301-5002",

--- a/fixtures/anna_heatpump_heating/all_data.json
+++ b/fixtures/anna_heatpump_heating/all_data.json
@@ -62,6 +62,7 @@
       "active_preset": "home",
       "available_schedules": ["standaard", "off"],
       "climate_mode": "auto",
+      "control_state": "heating",
       "dev_class": "thermostat",
       "firmware": "2018-02-08T11:15:53+01:00",
       "hardware": "6539-1301-5002",

--- a/fixtures/anna_loria_cooling_active/all_data.json
+++ b/fixtures/anna_loria_cooling_active/all_data.json
@@ -4,6 +4,7 @@
       "active_preset": "home",
       "available_schedules": ["Winter", "Test ", "off"],
       "climate_mode": "auto",
+      "control_state": "cooling",
       "dev_class": "thermostat",
       "firmware": "2018-02-08T11:15:53+01:00",
       "hardware": "6539-1301-5002",

--- a/fixtures/anna_loria_driessens/all_data.json
+++ b/fixtures/anna_loria_driessens/all_data.json
@@ -27,6 +27,7 @@
         "off"
       ],
       "climate_mode": "auto",
+      "control_state": "idle",
       "dev_class": "thermostat",
       "firmware": "2018-02-08T11:15:53+01:00",
       "hardware": "6539-1301-5002",

--- a/fixtures/anna_loria_heating_idle/all_data.json
+++ b/fixtures/anna_loria_heating_idle/all_data.json
@@ -4,6 +4,7 @@
       "active_preset": "home",
       "available_schedules": ["Winter", "Test ", "off"],
       "climate_mode": "auto",
+      "control_state": "idle",
       "dev_class": "thermostat",
       "firmware": "2018-02-08T11:15:53+01:00",
       "hardware": "6539-1301-5002",

--- a/fixtures/anna_v4/all_data.json
+++ b/fixtures/anna_v4/all_data.json
@@ -4,6 +4,7 @@
       "active_preset": "home",
       "available_schedules": ["Standaard", "Thuiswerken", "off"],
       "climate_mode": "heat",
+      "control_state": "heating",
       "dev_class": "thermostat",
       "firmware": "2018-02-08T11:15:53+01:00",
       "hardware": "6539-1301-5002",

--- a/fixtures/anna_v4_dhw/all_data.json
+++ b/fixtures/anna_v4_dhw/all_data.json
@@ -4,6 +4,7 @@
       "active_preset": "home",
       "available_schedules": ["Standaard", "Thuiswerken", "off"],
       "climate_mode": "heat",
+      "control_state": "idle",
       "dev_class": "thermostat",
       "firmware": "2018-02-08T11:15:53+01:00",
       "hardware": "6539-1301-5002",

--- a/fixtures/anna_v4_no_tag/all_data.json
+++ b/fixtures/anna_v4_no_tag/all_data.json
@@ -4,6 +4,7 @@
       "active_preset": "home",
       "available_schedules": ["Standaard", "Thuiswerken", "off"],
       "climate_mode": "auto",
+      "control_state": "heating",
       "dev_class": "thermostat",
       "firmware": "2018-02-08T11:15:53+01:00",
       "hardware": "6539-1301-5002",

--- a/fixtures/anna_without_boiler_fw441/all_data.json
+++ b/fixtures/anna_without_boiler_fw441/all_data.json
@@ -4,6 +4,7 @@
       "active_preset": "home",
       "available_schedules": ["Test", "Normaal", "off"],
       "climate_mode": "auto",
+      "control_state": "idle",
       "dev_class": "thermostat",
       "firmware": "2018-02-08T11:15:53+01:00",
       "hardware": "6539-1301-5002",

--- a/fixtures/legacy_anna/all_data.json
+++ b/fixtures/legacy_anna/all_data.json
@@ -37,6 +37,7 @@
     "0d266432d64443e283b5d708ae98b455": {
       "active_preset": "home",
       "climate_mode": "heat",
+      "control_state": "heating",
       "dev_class": "thermostat",
       "firmware": "2017-03-13T11:54:58+01:00",
       "hardware": "6539-1301-500",

--- a/fixtures/legacy_anna_2/all_data.json
+++ b/fixtures/legacy_anna_2/all_data.json
@@ -4,6 +4,7 @@
       "active_preset": null,
       "available_schedules": ["Thermostat schedule", "off"],
       "climate_mode": "heat",
+      "control_state": "idle",
       "dev_class": "thermostat",
       "firmware": "2017-03-13T11:54:58+01:00",
       "hardware": "6539-1301-5002",

--- a/fixtures/m_adam_jip/all_data.json
+++ b/fixtures/m_adam_jip/all_data.json
@@ -3,7 +3,6 @@
     "06aecb3d00354375924f50c47af36bd2": {
       "active_preset": "no_frost",
       "climate_mode": "off",
-      "control_state": "idle",
       "dev_class": "climate",
       "model": "ThermoZone",
       "name": "Slaapkamer",

--- a/fixtures/m_anna_heatpump_cooling/all_data.json
+++ b/fixtures/m_anna_heatpump_cooling/all_data.json
@@ -62,6 +62,7 @@
       "active_preset": "home",
       "available_schedules": ["standaard", "off"],
       "climate_mode": "auto",
+      "control_state": "heating",
       "dev_class": "thermostat",
       "firmware": "2018-02-08T11:15:53+01:00",
       "hardware": "6539-1301-5002",

--- a/fixtures/m_anna_heatpump_cooling/all_data.json
+++ b/fixtures/m_anna_heatpump_cooling/all_data.json
@@ -62,7 +62,7 @@
       "active_preset": "home",
       "available_schedules": ["standaard", "off"],
       "climate_mode": "auto",
-      "control_state": "heating",
+      "control_state": "cooling",
       "dev_class": "thermostat",
       "firmware": "2018-02-08T11:15:53+01:00",
       "hardware": "6539-1301-5002",

--- a/fixtures/m_anna_heatpump_idle/all_data.json
+++ b/fixtures/m_anna_heatpump_idle/all_data.json
@@ -62,6 +62,7 @@
       "active_preset": "home",
       "available_schedules": ["standaard", "off"],
       "climate_mode": "auto",
+      "control_state": "heating",
       "dev_class": "thermostat",
       "firmware": "2018-02-08T11:15:53+01:00",
       "hardware": "6539-1301-5002",

--- a/fixtures/m_anna_heatpump_idle/all_data.json
+++ b/fixtures/m_anna_heatpump_idle/all_data.json
@@ -62,7 +62,7 @@
       "active_preset": "home",
       "available_schedules": ["standaard", "off"],
       "climate_mode": "auto",
-      "control_state": "heating",
+      "control_state": "idle",
       "dev_class": "thermostat",
       "firmware": "2018-02-08T11:15:53+01:00",
       "hardware": "6539-1301-5002",

--- a/plugwise/data.py
+++ b/plugwise/data.py
@@ -167,13 +167,14 @@ class SmileData(SmileHelper):
         """
         zone = self._zones[loc_id]
         data = self._get_zone_data(loc_id)
-        if ctrl_state := self._control_state(data, loc_id):
-            if str(ctrl_state) in ("cooling", "heating", "preheating"):
-                data["control_state"] = str(ctrl_state)
-                self._count += 1
-            if str(ctrl_state) == "off":
-                data["control_state"] = "idle"
-                self._count += 1
+        data["control_state"] = "idle"
+        self._count += 1
+        if (ctrl_state := self._control_state(data, loc_id)) and str(ctrl_state) in (
+            "cooling",
+            "heating",
+            "preheating",
+        ):
+            data["control_state"] = str(ctrl_state)
 
         data["sensors"].pop("setpoint")  # remove, only used in _control_state()
         self._count -= 1

--- a/plugwise/data.py
+++ b/plugwise/data.py
@@ -211,6 +211,7 @@ class SmileData(SmileHelper):
         # Thermostat data for Anna (presets, temperatures etc)
         if self.smile(ANNA) and entity["dev_class"] == "thermostat":
             self._climate_data(entity_id, entity, data)
+            self._get_anna_control_state(data)
 
         return data
 
@@ -307,6 +308,18 @@ class SmileData(SmileHelper):
         return (
             "regulation_modes" in gateway and gateway["select_regulation_mode"] == mode
         )
+
+    def _get_anna_control_state(self, data: GwEntityData) -> None:
+        """Set the thermostat control_state based on the opentherm/onoff device state."""
+        data["control_state"] = "idle"
+        for entity_id in self.gw_entities:
+            if self.gw_entities[entity_id]["dev_class"] != "heater_central":
+                continue
+
+            if self.gw_entities[entity_id]["binary_sensors"]["heating_state"]:
+                data["control_state"] = "heating"
+            if self.gw_entities[entity_id]["binary_sensors"].get("cooling_state"):
+                data["control_state"] = "cooling"
 
     def _get_schedule_states_with_off(
         self, location: str, schedules: list[str], selected: str, data: GwEntityData

--- a/plugwise/data.py
+++ b/plugwise/data.py
@@ -313,12 +313,14 @@ class SmileData(SmileHelper):
         """Set the thermostat control_state based on the opentherm/onoff device state."""
         data["control_state"] = "idle"
         for entity_id in self.gw_entities:
-            if self.gw_entities[entity_id]["dev_class"] != "heater_central":
+            entity = self.gw_entities[entity_id]
+            if entity["dev_class"] != "heater_central":
                 continue
 
-            if self.gw_entities[entity_id]["binary_sensors"]["heating_state"]:
+            binary_sensors = entity["binary_sensors"]
+            if binary_sensors["heating_state"]:
                 data["control_state"] = "heating"
-            if self.gw_entities[entity_id]["binary_sensors"].get("cooling_state"):
+            if binary_sensors.get("cooling_state"):
                 data["control_state"] = "cooling"
 
     def _get_schedule_states_with_off(

--- a/plugwise/data.py
+++ b/plugwise/data.py
@@ -312,8 +312,7 @@ class SmileData(SmileHelper):
     def _get_anna_control_state(self, data: GwEntityData) -> None:
         """Set the thermostat control_state based on the opentherm/onoff device state."""
         data["control_state"] = "idle"
-        for entity_id in self.gw_entities:
-            entity = self.gw_entities[entity_id]
+        for entity in self.gw_entities.values():
             if entity["dev_class"] != "heater_central":
                 continue
 

--- a/plugwise/legacy/data.py
+++ b/plugwise/legacy/data.py
@@ -64,6 +64,7 @@ class SmileLegacyData(SmileLegacyHelper):
 
         # Thermostat data (presets, temperatures etc)
         self._climate_data(entity, data)
+        self._get_anna_control_state(data)
 
         return data
 
@@ -92,3 +93,15 @@ class SmileLegacyData(SmileLegacyHelper):
         self._count += 1
         if sel_schedule in (NONE, OFF):
             data["climate_mode"] = "heat"
+
+    def _get_anna_control_state(self, data: GwEntityData) -> None:
+        """Set the thermostat control_state based on the opentherm/onoff device state."""
+        data["control_state"] = "idle"
+        for entity in self.gw_entities.values():
+            if entity["dev_class"] != "heater_central":
+                continue
+
+            binary_sensors = entity["binary_sensors"]
+            if binary_sensors["heating_state"]:
+                data["control_state"] = "heating"
+

--- a/plugwise/legacy/data.py
+++ b/plugwise/legacy/data.py
@@ -104,4 +104,3 @@ class SmileLegacyData(SmileLegacyHelper):
             binary_sensors = entity["binary_sensors"]
             if binary_sensors["heating_state"]:
                 data["control_state"] = "heating"
-

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name            = "plugwise"
-version         = "1.6.3"
+version         = "1.6.4a0"
 license         = {file = "LICENSE"}
 description     = "Plugwise Smile (Adam/Anna/P1) and Stretch module for Python 3."
 readme          = "README.md"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name            = "plugwise"
-version         = "1.6.4a0"
+version         = "1.6.4"
 license         = {file = "LICENSE"}
 description     = "Plugwise Smile (Adam/Anna/P1) and Stretch module for Python 3."
 readme          = "README.md"

--- a/scripts/manual_fixtures.py
+++ b/scripts/manual_fixtures.py
@@ -49,8 +49,9 @@ base = json.load(io)
 
 adam_jip = base.copy()
 
-# Change mode to off for "06aecb3d00354375924f50c47af36bd2"
+# Change mode to off for "06aecb3d00354375924f50c47af36bd2" for testcoverage in HA Core
 adam_jip["devices"]["06aecb3d00354375924f50c47af36bd2"]["climate_mode"] = "off"
+# Remove control_state for testcoverage of missing control_state in HA Core
 adam_jip["devices"]["06aecb3d00354375924f50c47af36bd2"].pop("control_state")
 
 json_writer("m_adam_jip", adam_jip)

--- a/scripts/manual_fixtures.py
+++ b/scripts/manual_fixtures.py
@@ -51,6 +51,7 @@ adam_jip = base.copy()
 
 # Change mode to off for "06aecb3d00354375924f50c47af36bd2"
 adam_jip["devices"]["06aecb3d00354375924f50c47af36bd2"]["climate_mode"] = "off"
+adam_jip["devices"]["06aecb3d00354375924f50c47af36bd2"].pop("control_state")
 
 json_writer("m_adam_jip", adam_jip)
 

--- a/scripts/manual_fixtures.py
+++ b/scripts/manual_fixtures.py
@@ -298,6 +298,7 @@ m_anna_heatpump_cooling["devices"]["015ae9ea3f964e668e490fa39da3870b"]["sensors"
 ] = 28.2
 
 # Go for 3cb7
+m_anna_heatpump_cooling["devices"]["3cb70739631c4d17a86b8b12e8a5161b"]["control_state"] = "cooling"
 m_anna_heatpump_cooling["devices"]["3cb70739631c4d17a86b8b12e8a5161b"]["thermostat"][
     "setpoint_low"
 ] = 20.5
@@ -350,7 +351,7 @@ m_anna_heatpump_idle["devices"]["1cbf783bb11e4a7c8a6843dee3a86927"]["sensors"][
 
 
 # Go for 3cb7
-
+m_anna_heatpump_cooling["devices"]["3cb70739631c4d17a86b8b12e8a5161b"]["control_state"] = "idle"
 m_anna_heatpump_idle["devices"]["3cb70739631c4d17a86b8b12e8a5161b"]["sensors"][
     "temperature"
 ] = 23.0

--- a/scripts/manual_fixtures.py
+++ b/scripts/manual_fixtures.py
@@ -352,7 +352,7 @@ m_anna_heatpump_idle["devices"]["1cbf783bb11e4a7c8a6843dee3a86927"]["sensors"][
 
 
 # Go for 3cb7
-m_anna_heatpump_cooling["devices"]["3cb70739631c4d17a86b8b12e8a5161b"]["control_state"] = "idle"
+m_anna_heatpump_idle["devices"]["3cb70739631c4d17a86b8b12e8a5161b"]["control_state"] = "idle"
 m_anna_heatpump_idle["devices"]["3cb70739631c4d17a86b8b12e8a5161b"]["sensors"][
     "temperature"
 ] = 23.0

--- a/tests/data/anna/anna_elga_2.json
+++ b/tests/data/anna/anna_elga_2.json
@@ -39,6 +39,7 @@
       "active_preset": "home",
       "available_schedules": ["Thermostat schedule", "off"],
       "climate_mode": "auto",
+      "control_state": "idle",
       "dev_class": "thermostat",
       "firmware": "2018-02-08T11:15:53+01:00",
       "hardware": "6539-1301-5002",

--- a/tests/data/anna/anna_elga_2_cooling.json
+++ b/tests/data/anna/anna_elga_2_cooling.json
@@ -39,6 +39,7 @@
       "active_preset": "home",
       "available_schedules": ["Thermostat schedule", "off"],
       "climate_mode": "auto",
+      "control_state": "cooling",
       "dev_class": "thermostat",
       "firmware": "2018-02-08T11:15:53+01:00",
       "hardware": "6539-1301-5002",

--- a/tests/data/anna/anna_elga_2_cooling_UPDATED_DATA.json
+++ b/tests/data/anna/anna_elga_2_cooling_UPDATED_DATA.json
@@ -39,6 +39,7 @@
       "active_preset": "home",
       "available_schedules": ["Thermostat schedule", "off"],
       "climate_mode": "auto",
+      "control_state": "heating",
       "dev_class": "thermostat",
       "firmware": "2018-02-08T11:15:53+01:00",
       "hardware": "6539-1301-5002",

--- a/tests/data/anna/anna_elga_2_schedule_off.json
+++ b/tests/data/anna/anna_elga_2_schedule_off.json
@@ -39,6 +39,7 @@
       "active_preset": "home",
       "available_schedules": ["Thermostat schedule", "off"],
       "climate_mode": "heat_cool",
+      "control_state": "idle",
       "dev_class": "thermostat",
       "firmware": "2018-02-08T11:15:53+01:00",
       "hardware": "6539-1301-5002",

--- a/tests/data/anna/anna_elga_no_cooling.json
+++ b/tests/data/anna/anna_elga_no_cooling.json
@@ -60,6 +60,7 @@
       "active_preset": "home",
       "available_schedules": ["standaard", "off"],
       "climate_mode": "auto",
+      "control_state": "heating",
       "dev_class": "thermostat",
       "firmware": "2018-02-08T11:15:53+01:00",
       "hardware": "6539-1301-5002",

--- a/tests/data/anna/anna_heatpump_cooling.json
+++ b/tests/data/anna/anna_heatpump_cooling.json
@@ -57,6 +57,7 @@
       "active_preset": "home",
       "available_schedules": ["standaard", "off"],
       "climate_mode": "heat_cool",
+      "control_state": "cooling",
       "dev_class": "thermostat",
       "firmware": "2018-02-08T11:15:53+01:00",
       "hardware": "6539-1301-5002",

--- a/tests/data/anna/anna_heatpump_cooling_fake_firmware.json
+++ b/tests/data/anna/anna_heatpump_cooling_fake_firmware.json
@@ -57,6 +57,7 @@
       "active_preset": "home",
       "available_schedules": ["standaard", "off"],
       "climate_mode": "heat_cool",
+      "control_state": "cooling",
       "dev_class": "thermostat",
       "firmware": "2018-02-08T11:15:53+01:00",
       "hardware": "6539-1301-5002",

--- a/tests/data/anna/anna_heatpump_heating.json
+++ b/tests/data/anna/anna_heatpump_heating.json
@@ -62,6 +62,7 @@
       "active_preset": "home",
       "available_schedules": ["standaard", "off"],
       "climate_mode": "auto",
+      "control_state": "heating",
       "dev_class": "thermostat",
       "firmware": "2018-02-08T11:15:53+01:00",
       "hardware": "6539-1301-5002",

--- a/tests/data/anna/anna_loria_cooling_active.json
+++ b/tests/data/anna/anna_loria_cooling_active.json
@@ -4,6 +4,7 @@
       "active_preset": "home",
       "available_schedules": ["Winter", "Test ", "off"],
       "climate_mode": "auto",
+      "control_state": "cooling",
       "dev_class": "thermostat",
       "firmware": "2018-02-08T11:15:53+01:00",
       "hardware": "6539-1301-5002",

--- a/tests/data/anna/anna_loria_driessens.json
+++ b/tests/data/anna/anna_loria_driessens.json
@@ -27,6 +27,7 @@
         "off"
       ],
       "climate_mode": "auto",
+      "control_state": "idle",
       "dev_class": "thermostat",
       "firmware": "2018-02-08T11:15:53+01:00",
       "hardware": "6539-1301-5002",

--- a/tests/data/anna/anna_loria_heating_idle.json
+++ b/tests/data/anna/anna_loria_heating_idle.json
@@ -4,6 +4,7 @@
       "active_preset": "home",
       "available_schedules": ["Winter", "Test ", "off"],
       "climate_mode": "auto",
+      "control_state": "idle",
       "dev_class": "thermostat",
       "firmware": "2018-02-08T11:15:53+01:00",
       "hardware": "6539-1301-5002",

--- a/tests/data/anna/anna_v4.json
+++ b/tests/data/anna/anna_v4.json
@@ -4,6 +4,7 @@
       "active_preset": "home",
       "available_schedules": ["Standaard", "Thuiswerken", "off"],
       "climate_mode": "heat",
+      "control_state": "heating",
       "dev_class": "thermostat",
       "firmware": "2018-02-08T11:15:53+01:00",
       "hardware": "6539-1301-5002",

--- a/tests/data/anna/anna_v4_UPDATED_DATA.json
+++ b/tests/data/anna/anna_v4_UPDATED_DATA.json
@@ -39,7 +39,7 @@
       "active_preset": "away",
       "select_schedule": "Standaard",
       "climate_mode": "auto",
-      "control_state": "heating",
+      "control_state": "idle",
       "sensors": {
         "temperature": 19.5,
         "setpoint": 19.5,

--- a/tests/data/anna/anna_v4_UPDATED_DATA.json
+++ b/tests/data/anna/anna_v4_UPDATED_DATA.json
@@ -39,6 +39,7 @@
       "active_preset": "away",
       "select_schedule": "Standaard",
       "climate_mode": "auto",
+      "control_state": "heating",
       "sensors": {
         "temperature": 19.5,
         "setpoint": 19.5,

--- a/tests/data/anna/anna_v4_dhw.json
+++ b/tests/data/anna/anna_v4_dhw.json
@@ -4,6 +4,7 @@
       "active_preset": "home",
       "available_schedules": ["Standaard", "Thuiswerken", "off"],
       "climate_mode": "heat",
+      "control_state": "idle",
       "dev_class": "thermostat",
       "firmware": "2018-02-08T11:15:53+01:00",
       "hardware": "6539-1301-5002",

--- a/tests/data/anna/anna_v4_no_tag.json
+++ b/tests/data/anna/anna_v4_no_tag.json
@@ -4,6 +4,7 @@
       "active_preset": "home",
       "available_schedules": ["Standaard", "Thuiswerken", "off"],
       "climate_mode": "auto",
+      "control_state": "heating",
       "dev_class": "thermostat",
       "firmware": "2018-02-08T11:15:53+01:00",
       "hardware": "6539-1301-5002",

--- a/tests/data/anna/anna_without_boiler_fw441.json
+++ b/tests/data/anna/anna_without_boiler_fw441.json
@@ -4,6 +4,7 @@
       "active_preset": "home",
       "available_schedules": ["Test", "Normaal", "off"],
       "climate_mode": "auto",
+      "control_state": "idle",
       "dev_class": "thermostat",
       "firmware": "2018-02-08T11:15:53+01:00",
       "hardware": "6539-1301-5002",

--- a/tests/data/anna/legacy_anna.json
+++ b/tests/data/anna/legacy_anna.json
@@ -37,6 +37,7 @@
     "0d266432d64443e283b5d708ae98b455": {
       "active_preset": "home",
       "climate_mode": "heat",
+      "control_state": "heating",
       "dev_class": "thermostat",
       "firmware": "2017-03-13T11:54:58+01:00",
       "hardware": "6539-1301-500",

--- a/tests/data/anna/legacy_anna_2.json
+++ b/tests/data/anna/legacy_anna_2.json
@@ -4,6 +4,7 @@
       "active_preset": null,
       "available_schedules": ["Thermostat schedule", "off"],
       "climate_mode": "heat",
+      "control_state": "idle",
       "dev_class": "thermostat",
       "firmware": "2017-03-13T11:54:58+01:00",
       "hardware": "6539-1301-5002",


### PR DESCRIPTION
This will allow us to simplify the climate-code in the Integration

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Added `control_state` field to multiple thermostat entities, indicating their current operational states such as "idle", "cooling", and "heating".

- **Bug Fixes**
	- Enhanced state representation for thermostats to ensure accurate tracking of their operational modes.

- **Tests**
	- Updated test data to include the new `control_state` field for various thermostat entities, improving test coverage for state management.

- **Chores**
	- Updated changelog to reflect the release of version 1.6.4 and included improvements related to `control_state`.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->