### PR TITLE
Collect all weather data from the Gateway

### DIFF
--- a/fixtures/adam_heatpump_cooling/all_data.json
+++ b/fixtures/adam_heatpump_cooling/all_data.json
@@ -305,10 +305,15 @@
       ],
       "select_gateway_mode": "full",
       "select_regulation_mode": "cooling",
-      "sensors": {
-        "outdoor_temperature": 13.4
-      },
       "vendor": "Plugwise",
+      "weather": {
+        "humidity": 88,
+        "outdoor_temperature": 13.4,
+        "solar_irradiance": 208.2,
+        "weather_description": "clouded",
+        "wind_bearing": 228.0,
+        "wind_speed": 1.79
+      },
       "zigbee_mac_address": "ABCD012345670101"
     },
     "7fda9f84f01342f8afe9ebbbbff30c0f": {
@@ -809,7 +814,7 @@
     "cooling_present": true,
     "gateway_id": "7d97fc3117784cfdafe347bcedcbbbcb",
     "heater_id": "0ca13e8176204ca7bf6f09de59f81c83",
-    "item_count": 497,
+    "item_count": 502,
     "notifications": {},
     "reboot": true,
     "smile_name": "Adam"

--- a/fixtures/adam_heatpump_cooling/all_data.json
+++ b/fixtures/adam_heatpump_cooling/all_data.json
@@ -305,11 +305,13 @@
       ],
       "select_gateway_mode": "full",
       "select_regulation_mode": "cooling",
+      "sensors": {
+        "solar_irradiance": 208.2
+      },
       "vendor": "Plugwise",
       "weather": {
         "humidity": 88,
         "outdoor_temperature": 13.4,
-        "solar_irradiance": 208.2,
         "weather_description": "clouded",
         "wind_bearing": 228.0,
         "wind_speed": 1.79

--- a/fixtures/adam_jip/all_data.json
+++ b/fixtures/adam_jip/all_data.json
@@ -229,11 +229,13 @@
       "regulation_modes": ["heating", "off", "bleeding_cold", "bleeding_hot"],
       "select_gateway_mode": "full",
       "select_regulation_mode": "heating",
+      "sensors": {
+        "solar_irradiance": 449.2
+      },
       "vendor": "Plugwise",
       "weather": {
         "humidity": 68,
         "outdoor_temperature": 24.9,
-        "solar_irradiance": 449.2,
         "weather_description": "overcast",
         "wind_bearing": 216.0,
         "wind_speed": 2.68

--- a/fixtures/adam_jip/all_data.json
+++ b/fixtures/adam_jip/all_data.json
@@ -229,10 +229,15 @@
       "regulation_modes": ["heating", "off", "bleeding_cold", "bleeding_hot"],
       "select_gateway_mode": "full",
       "select_regulation_mode": "heating",
-      "sensors": {
-        "outdoor_temperature": 24.9
-      },
       "vendor": "Plugwise",
+      "weather": {
+        "humidity": 68,
+        "outdoor_temperature": 24.9,
+        "solar_irradiance": 449.2,
+        "weather_description": "overcast",
+        "wind_bearing": 216.0,
+        "wind_speed": 2.68
+      },
       "zigbee_mac_address": "ABCD012345670101"
     },
     "d27aede973b54be484f6842d1b2802ad": {
@@ -373,7 +378,7 @@
     "cooling_present": false,
     "gateway_id": "b5c2386c6f6342669e50fe49dd05b188",
     "heater_id": "e4684553153b44afbef2200885f379dc",
-    "item_count": 244,
+    "item_count": 249,
     "notifications": {},
     "reboot": true,
     "smile_name": "Adam"

--- a/fixtures/adam_multiple_devices_per_zone/all_data.json
+++ b/fixtures/adam_multiple_devices_per_zone/all_data.json
@@ -580,10 +580,15 @@
       "model_id": "smile_open_therm",
       "name": "Adam",
       "select_regulation_mode": "heating",
-      "sensors": {
-        "outdoor_temperature": 7.81
-      },
       "vendor": "Plugwise",
+      "weather": {
+        "humidity": 75,
+        "outdoor_temperature": 7.81,
+        "solar_irradiance": 157.5,
+        "weather_description": "cloudy",
+        "wind_bearing": 40.0,
+        "wind_speed": 8.2
+      },
       "zigbee_mac_address": "ABCD012345670101"
     }
   },
@@ -591,7 +596,7 @@
     "cooling_present": false,
     "gateway_id": "fe799307f1624099878210aa0b9f1475",
     "heater_id": "90986d591dcd426cae3ec3e8111ff730",
-    "item_count": 369,
+    "item_count": 374,
     "notifications": {
       "af82e4ccf9c548528166d38e560662a4": {
         "warning": "Node Plug (with MAC address 000D6F000D13CB01, in room 'n.a.') has been unreachable since 23:03 2020-01-18. Please check the connection and restart the device."

--- a/fixtures/adam_multiple_devices_per_zone/all_data.json
+++ b/fixtures/adam_multiple_devices_per_zone/all_data.json
@@ -580,11 +580,13 @@
       "model_id": "smile_open_therm",
       "name": "Adam",
       "select_regulation_mode": "heating",
+      "sensors": {
+        "solar_irradiance": 157.5
+      },
       "vendor": "Plugwise",
       "weather": {
         "humidity": 75,
         "outdoor_temperature": 7.81,
-        "solar_irradiance": 157.5,
         "weather_description": "cloudy",
         "wind_bearing": 40.0,
         "wind_speed": 8.2

--- a/fixtures/adam_onoff_cooling_fake_firmware/all_data.json
+++ b/fixtures/adam_onoff_cooling_fake_firmware/all_data.json
@@ -59,10 +59,15 @@
       ],
       "select_gateway_mode": "full",
       "select_regulation_mode": "cooling",
-      "sensors": {
-        "outdoor_temperature": 13.4
-      },
       "vendor": "Plugwise",
+      "weather": {
+        "humidity": 88,
+        "outdoor_temperature": 13.4,
+        "solar_irradiance": 208.2,
+        "weather_description": "clouded",
+        "wind_bearing": 228.0,
+        "wind_speed": 1.79
+      },
       "zigbee_mac_address": "ABCD012345670101"
     },
     "ca79d23ae0094120b877558734cff85c": {
@@ -114,7 +119,7 @@
     "cooling_present": true,
     "gateway_id": "7d97fc3117784cfdafe347bcedcbbbcb",
     "heater_id": "0ca13e8176204ca7bf6f09de59f81c83",
-    "item_count": 64,
+    "item_count": 69,
     "notifications": {},
     "reboot": true,
     "smile_name": "Adam"

--- a/fixtures/adam_onoff_cooling_fake_firmware/all_data.json
+++ b/fixtures/adam_onoff_cooling_fake_firmware/all_data.json
@@ -59,11 +59,13 @@
       ],
       "select_gateway_mode": "full",
       "select_regulation_mode": "cooling",
+      "sensors": {
+        "solar_irradiance": 208.2
+      },
       "vendor": "Plugwise",
       "weather": {
         "humidity": 88,
         "outdoor_temperature": 13.4,
-        "solar_irradiance": 208.2,
         "weather_description": "clouded",
         "wind_bearing": 228.0,
         "wind_speed": 1.79

--- a/fixtures/adam_plus_anna/all_data.json
+++ b/fixtures/adam_plus_anna/all_data.json
@@ -86,11 +86,13 @@
       "model_id": "smile_open_therm",
       "name": "Adam",
       "select_regulation_mode": "heating",
+      "sensors": {
+        "solar_irradiance": 53.8
+      },
       "vendor": "Plugwise",
       "weather": {
         "humidity": 58,
         "outdoor_temperature": 11.9,
-        "solar_irradiance": 53.8,
         "weather_description": "overcast",
         "wind_bearing": 220.0,
         "wind_speed": 2.6

--- a/fixtures/adam_plus_anna/all_data.json
+++ b/fixtures/adam_plus_anna/all_data.json
@@ -86,10 +86,15 @@
       "model_id": "smile_open_therm",
       "name": "Adam",
       "select_regulation_mode": "heating",
-      "sensors": {
-        "outdoor_temperature": 11.9
-      },
       "vendor": "Plugwise",
+      "weather": {
+        "humidity": 58,
+        "outdoor_temperature": 11.9,
+        "solar_irradiance": 53.8,
+        "weather_description": "overcast",
+        "wind_bearing": 220.0,
+        "wind_speed": 2.6
+      },
       "zigbee_mac_address": "ABCD012345670101"
     },
     "ee62cad889f94e8ca3d09021f03a660b": {
@@ -128,7 +133,7 @@
     "cooling_present": false,
     "gateway_id": "b128b4bbbd1f47e9bf4d756e8fb5ee94",
     "heater_id": "2743216f626f43948deec1f7ab3b3d70",
-    "item_count": 80,
+    "item_count": 85,
     "notifications": {
       "6fb89e35caeb4b1cb275184895202d84": {
         "error": "There is no OpenTherm communication with the boiler."

--- a/fixtures/adam_plus_anna_new/all_data.json
+++ b/fixtures/adam_plus_anna_new/all_data.json
@@ -172,11 +172,13 @@
       "regulation_modes": ["bleeding_hot", "bleeding_cold", "off", "heating"],
       "select_gateway_mode": "full",
       "select_regulation_mode": "heating",
+      "sensors": {
+        "solar_irradiance": 3.0
+      },
       "vendor": "Plugwise",
       "weather": {
         "humidity": 90,
         "outdoor_temperature": 9.19,
-        "solar_irradiance": 3.0,
         "weather_description": "rain",
         "wind_bearing": 291.0,
         "wind_speed": 6.26

--- a/fixtures/adam_plus_anna_new/all_data.json
+++ b/fixtures/adam_plus_anna_new/all_data.json
@@ -172,10 +172,15 @@
       "regulation_modes": ["bleeding_hot", "bleeding_cold", "off", "heating"],
       "select_gateway_mode": "full",
       "select_regulation_mode": "heating",
-      "sensors": {
-        "outdoor_temperature": 9.19
-      },
       "vendor": "Plugwise",
+      "weather": {
+        "humidity": 90,
+        "outdoor_temperature": 9.19,
+        "solar_irradiance": 3.0,
+        "weather_description": "rain",
+        "wind_bearing": 291.0,
+        "wind_speed": 6.26
+      },
       "zigbee_mac_address": "000D6F000D5A168D"
     },
     "e2f4322d57924fa090fbbc48b3a140dc": {
@@ -288,7 +293,7 @@
     "cooling_present": false,
     "gateway_id": "da224107914542988a88561b4452b0f6",
     "heater_id": "056ee145a816487eaa69243c3280f8bf",
-    "item_count": 177,
+    "item_count": 182,
     "notifications": {},
     "reboot": true,
     "smile_name": "Adam"

--- a/fixtures/adam_plus_anna_new_regulation_off/all_data.json
+++ b/fixtures/adam_plus_anna_new_regulation_off/all_data.json
@@ -172,11 +172,13 @@
       "regulation_modes": ["bleeding_hot", "bleeding_cold", "off", "heating"],
       "select_gateway_mode": "full",
       "select_regulation_mode": "off",
+      "sensors": {
+        "solar_irradiance": 3.0
+      },
       "vendor": "Plugwise",
       "weather": {
         "humidity": 90,
         "outdoor_temperature": 9.19,
-        "solar_irradiance": 3.0,
         "weather_description": "rain",
         "wind_bearing": 291.0,
         "wind_speed": 6.26

--- a/fixtures/adam_plus_anna_new_regulation_off/all_data.json
+++ b/fixtures/adam_plus_anna_new_regulation_off/all_data.json
@@ -172,10 +172,15 @@
       "regulation_modes": ["bleeding_hot", "bleeding_cold", "off", "heating"],
       "select_gateway_mode": "full",
       "select_regulation_mode": "off",
-      "sensors": {
-        "outdoor_temperature": 9.19
-      },
       "vendor": "Plugwise",
+      "weather": {
+        "humidity": 90,
+        "outdoor_temperature": 9.19,
+        "solar_irradiance": 3.0,
+        "weather_description": "rain",
+        "wind_bearing": 291.0,
+        "wind_speed": 6.26
+      },
       "zigbee_mac_address": "000D6F000D5A168D"
     },
     "e2f4322d57924fa090fbbc48b3a140dc": {
@@ -288,7 +293,7 @@
     "cooling_present": false,
     "gateway_id": "da224107914542988a88561b4452b0f6",
     "heater_id": "056ee145a816487eaa69243c3280f8bf",
-    "item_count": 177,
+    "item_count": 182,
     "notifications": {},
     "reboot": true,
     "smile_name": "Adam"

--- a/fixtures/adam_zone_per_device/all_data.json
+++ b/fixtures/adam_zone_per_device/all_data.json
@@ -577,10 +577,15 @@
       "model_id": "smile_open_therm",
       "name": "Adam",
       "select_regulation_mode": "heating",
-      "sensors": {
-        "outdoor_temperature": 7.69
-      },
       "vendor": "Plugwise",
+      "weather": {
+        "humidity": 70,
+        "outdoor_temperature": 7.69,
+        "solar_irradiance": 86.2,
+        "weather_description": "cloudy",
+        "wind_bearing": 40.0,
+        "wind_speed": 7.2
+      },
       "zigbee_mac_address": "ABCD012345670101"
     }
   },
@@ -588,7 +593,7 @@
     "cooling_present": false,
     "gateway_id": "fe799307f1624099878210aa0b9f1475",
     "heater_id": "90986d591dcd426cae3ec3e8111ff730",
-    "item_count": 369,
+    "item_count": 374,
     "notifications": {
       "af82e4ccf9c548528166d38e560662a4": {
         "warning": "Node Plug (with MAC address 000D6F000D13CB01, in room 'n.a.') has been unreachable since 23:03 2020-01-18. Please check the connection and restart the device."

--- a/fixtures/adam_zone_per_device/all_data.json
+++ b/fixtures/adam_zone_per_device/all_data.json
@@ -577,11 +577,13 @@
       "model_id": "smile_open_therm",
       "name": "Adam",
       "select_regulation_mode": "heating",
+      "sensors": {
+        "solar_irradiance": 86.2
+      },
       "vendor": "Plugwise",
       "weather": {
         "humidity": 70,
         "outdoor_temperature": 7.69,
-        "solar_irradiance": 86.2,
         "weather_description": "cloudy",
         "wind_bearing": 40.0,
         "wind_speed": 7.2

--- a/fixtures/anna_elga_2/all_data.json
+++ b/fixtures/anna_elga_2/all_data.json
@@ -83,11 +83,13 @@
       "model": "Gateway",
       "model_id": "smile_thermo",
       "name": "Smile Anna",
+      "sensors": {
+        "solar_irradiance": 0.0
+      },
       "vendor": "Plugwise",
       "weather": {
         "humidity": 42,
         "outdoor_temperature": 13.0,
-        "solar_irradiance": 0.0,
         "weather_description": "cloudy",
         "wind_bearing": 120.0,
         "wind_speed": 3.6

--- a/fixtures/anna_elga_2/all_data.json
+++ b/fixtures/anna_elga_2/all_data.json
@@ -83,17 +83,22 @@
       "model": "Gateway",
       "model_id": "smile_thermo",
       "name": "Smile Anna",
-      "sensors": {
-        "outdoor_temperature": 13.0
-      },
-      "vendor": "Plugwise"
+      "vendor": "Plugwise",
+      "weather": {
+        "humidity": 42,
+        "outdoor_temperature": 13.0,
+        "solar_irradiance": 0.0,
+        "weather_description": "cloudy",
+        "wind_bearing": 120.0,
+        "wind_speed": 3.6
+      }
     }
   },
   "gateway": {
     "cooling_present": true,
     "gateway_id": "fb49af122f6e4b0f91267e1cf7666d6f",
     "heater_id": "573c152e7d4f4720878222bd75638f5b",
-    "item_count": 63,
+    "item_count": 68,
     "notifications": {},
     "reboot": true,
     "smile_name": "Smile Anna"

--- a/fixtures/anna_elga_2_cooling/all_data.json
+++ b/fixtures/anna_elga_2_cooling/all_data.json
@@ -83,17 +83,22 @@
       "model": "Gateway",
       "model_id": "smile_thermo",
       "name": "Smile Anna",
-      "sensors": {
-        "outdoor_temperature": 31.0
-      },
-      "vendor": "Plugwise"
+      "vendor": "Plugwise",
+      "weather": {
+        "humidity": 42,
+        "outdoor_temperature": 31.0,
+        "solar_irradiance": 0.0,
+        "weather_description": "cloudy",
+        "wind_bearing": 120.0,
+        "wind_speed": 3.6
+      }
     }
   },
   "gateway": {
     "cooling_present": true,
     "gateway_id": "fb49af122f6e4b0f91267e1cf7666d6f",
     "heater_id": "573c152e7d4f4720878222bd75638f5b",
-    "item_count": 63,
+    "item_count": 68,
     "notifications": {},
     "reboot": true,
     "smile_name": "Smile Anna"

--- a/fixtures/anna_elga_2_cooling/all_data.json
+++ b/fixtures/anna_elga_2_cooling/all_data.json
@@ -83,11 +83,13 @@
       "model": "Gateway",
       "model_id": "smile_thermo",
       "name": "Smile Anna",
+      "sensors": {
+        "solar_irradiance": 0.0
+      },
       "vendor": "Plugwise",
       "weather": {
         "humidity": 42,
         "outdoor_temperature": 31.0,
-        "solar_irradiance": 0.0,
         "weather_description": "cloudy",
         "wind_bearing": 120.0,
         "wind_speed": 3.6

--- a/fixtures/anna_elga_2_schedule_off/all_data.json
+++ b/fixtures/anna_elga_2_schedule_off/all_data.json
@@ -83,11 +83,13 @@
       "model": "Gateway",
       "model_id": "smile_thermo",
       "name": "Smile Anna",
+      "sensors": {
+        "solar_irradiance": 0.0
+      },
       "vendor": "Plugwise",
       "weather": {
         "humidity": 42,
         "outdoor_temperature": 13.0,
-        "solar_irradiance": 0.0,
         "weather_description": "cloudy",
         "wind_bearing": 120.0,
         "wind_speed": 3.6

--- a/fixtures/anna_elga_2_schedule_off/all_data.json
+++ b/fixtures/anna_elga_2_schedule_off/all_data.json
@@ -83,17 +83,22 @@
       "model": "Gateway",
       "model_id": "smile_thermo",
       "name": "Smile Anna",
-      "sensors": {
-        "outdoor_temperature": 13.0
-      },
-      "vendor": "Plugwise"
+      "vendor": "Plugwise",
+      "weather": {
+        "humidity": 42,
+        "outdoor_temperature": 13.0,
+        "solar_irradiance": 0.0,
+        "weather_description": "cloudy",
+        "wind_bearing": 120.0,
+        "wind_speed": 3.6
+      }
     }
   },
   "gateway": {
     "cooling_present": true,
     "gateway_id": "fb49af122f6e4b0f91267e1cf7666d6f",
     "heater_id": "573c152e7d4f4720878222bd75638f5b",
-    "item_count": 63,
+    "item_count": 68,
     "notifications": {},
     "reboot": true,
     "smile_name": "Smile Anna"

--- a/fixtures/anna_elga_no_cooling/all_data.json
+++ b/fixtures/anna_elga_no_cooling/all_data.json
@@ -12,10 +12,15 @@
       "model": "Gateway",
       "model_id": "smile_thermo",
       "name": "Smile Anna",
-      "sensors": {
-        "outdoor_temperature": 20.2
-      },
-      "vendor": "Plugwise"
+      "vendor": "Plugwise",
+      "weather": {
+        "humidity": 42,
+        "outdoor_temperature": 20.2,
+        "solar_irradiance": 653.6,
+        "weather_description": "clear",
+        "wind_bearing": 50.0,
+        "wind_speed": 4.1
+      }
     },
     "1cbf783bb11e4a7c8a6843dee3a86927": {
       "available": true,
@@ -95,7 +100,7 @@
     "cooling_present": false,
     "gateway_id": "015ae9ea3f964e668e490fa39da3870b",
     "heater_id": "1cbf783bb11e4a7c8a6843dee3a86927",
-    "item_count": 63,
+    "item_count": 68,
     "notifications": {},
     "reboot": true,
     "smile_name": "Smile Anna"

--- a/fixtures/anna_elga_no_cooling/all_data.json
+++ b/fixtures/anna_elga_no_cooling/all_data.json
@@ -12,11 +12,13 @@
       "model": "Gateway",
       "model_id": "smile_thermo",
       "name": "Smile Anna",
+      "sensors": {
+        "solar_irradiance": 653.6
+      },
       "vendor": "Plugwise",
       "weather": {
         "humidity": 42,
         "outdoor_temperature": 20.2,
-        "solar_irradiance": 653.6,
         "weather_description": "clear",
         "wind_bearing": 50.0,
         "wind_speed": 4.1

--- a/fixtures/anna_heatpump_cooling/all_data.json
+++ b/fixtures/anna_heatpump_cooling/all_data.json
@@ -12,10 +12,15 @@
       "model": "Gateway",
       "model_id": "smile_thermo",
       "name": "Smile Anna",
-      "sensors": {
-        "outdoor_temperature": 22.0
-      },
-      "vendor": "Plugwise"
+      "vendor": "Plugwise",
+      "weather": {
+        "humidity": 35,
+        "outdoor_temperature": 22.0,
+        "solar_irradiance": 207.2,
+        "weather_description": "overcast",
+        "wind_bearing": 0.0,
+        "wind_speed": 2.1
+      }
     },
     "1cbf783bb11e4a7c8a6843dee3a86927": {
       "available": true,
@@ -94,7 +99,7 @@
     "cooling_present": true,
     "gateway_id": "015ae9ea3f964e668e490fa39da3870b",
     "heater_id": "1cbf783bb11e4a7c8a6843dee3a86927",
-    "item_count": 64,
+    "item_count": 69,
     "notifications": {},
     "reboot": true,
     "smile_name": "Smile Anna"

--- a/fixtures/anna_heatpump_cooling/all_data.json
+++ b/fixtures/anna_heatpump_cooling/all_data.json
@@ -12,11 +12,13 @@
       "model": "Gateway",
       "model_id": "smile_thermo",
       "name": "Smile Anna",
+      "sensors": {
+        "solar_irradiance": 207.2
+      },
       "vendor": "Plugwise",
       "weather": {
         "humidity": 35,
         "outdoor_temperature": 22.0,
-        "solar_irradiance": 207.2,
         "weather_description": "overcast",
         "wind_bearing": 0.0,
         "wind_speed": 2.1

--- a/fixtures/anna_heatpump_cooling_fake_firmware/all_data.json
+++ b/fixtures/anna_heatpump_cooling_fake_firmware/all_data.json
@@ -12,10 +12,15 @@
       "model": "Gateway",
       "model_id": "smile_thermo",
       "name": "Smile Anna",
-      "sensors": {
-        "outdoor_temperature": 22.0
-      },
-      "vendor": "Plugwise"
+      "vendor": "Plugwise",
+      "weather": {
+        "humidity": 35,
+        "outdoor_temperature": 22.0,
+        "solar_irradiance": 207.2,
+        "weather_description": "overcast",
+        "wind_bearing": 0.0,
+        "wind_speed": 2.1
+      }
     },
     "1cbf783bb11e4a7c8a6843dee3a86927": {
       "available": true,
@@ -94,7 +99,7 @@
     "cooling_present": true,
     "gateway_id": "015ae9ea3f964e668e490fa39da3870b",
     "heater_id": "1cbf783bb11e4a7c8a6843dee3a86927",
-    "item_count": 64,
+    "item_count": 69,
     "notifications": {},
     "reboot": true,
     "smile_name": "Smile Anna"

--- a/fixtures/anna_heatpump_cooling_fake_firmware/all_data.json
+++ b/fixtures/anna_heatpump_cooling_fake_firmware/all_data.json
@@ -12,11 +12,13 @@
       "model": "Gateway",
       "model_id": "smile_thermo",
       "name": "Smile Anna",
+      "sensors": {
+        "solar_irradiance": 207.2
+      },
       "vendor": "Plugwise",
       "weather": {
         "humidity": 35,
         "outdoor_temperature": 22.0,
-        "solar_irradiance": 207.2,
         "weather_description": "overcast",
         "wind_bearing": 0.0,
         "wind_speed": 2.1

--- a/fixtures/anna_heatpump_heating/all_data.json
+++ b/fixtures/anna_heatpump_heating/all_data.json
@@ -12,10 +12,15 @@
       "model": "Gateway",
       "model_id": "smile_thermo",
       "name": "Smile Anna",
-      "sensors": {
-        "outdoor_temperature": 20.2
-      },
-      "vendor": "Plugwise"
+      "vendor": "Plugwise",
+      "weather": {
+        "humidity": 42,
+        "outdoor_temperature": 20.2,
+        "solar_irradiance": 653.6,
+        "weather_description": "clear",
+        "wind_bearing": 50.0,
+        "wind_speed": 4.1
+      }
     },
     "1cbf783bb11e4a7c8a6843dee3a86927": {
       "available": true,
@@ -99,7 +104,7 @@
     "cooling_present": true,
     "gateway_id": "015ae9ea3f964e668e490fa39da3870b",
     "heater_id": "1cbf783bb11e4a7c8a6843dee3a86927",
-    "item_count": 67,
+    "item_count": 72,
     "notifications": {},
     "reboot": true,
     "smile_name": "Smile Anna"

--- a/fixtures/anna_heatpump_heating/all_data.json
+++ b/fixtures/anna_heatpump_heating/all_data.json
@@ -12,11 +12,13 @@
       "model": "Gateway",
       "model_id": "smile_thermo",
       "name": "Smile Anna",
+      "sensors": {
+        "solar_irradiance": 653.6
+      },
       "vendor": "Plugwise",
       "weather": {
         "humidity": 42,
         "outdoor_temperature": 20.2,
-        "solar_irradiance": 653.6,
         "weather_description": "clear",
         "wind_bearing": 50.0,
         "wind_speed": 4.1

--- a/fixtures/anna_loria_cooling_active/all_data.json
+++ b/fixtures/anna_loria_cooling_active/all_data.json
@@ -46,10 +46,15 @@
       "model": "Gateway",
       "model_id": "smile_thermo",
       "name": "Smile Anna",
-      "sensors": {
-        "outdoor_temperature": 15.5
-      },
-      "vendor": "Plugwise"
+      "vendor": "Plugwise",
+      "weather": {
+        "humidity": 65,
+        "outdoor_temperature": 15.5,
+        "solar_irradiance": 84.7,
+        "weather_description": "overcast",
+        "wind_bearing": 289.0,
+        "wind_speed": 2.2
+      }
     },
     "bfb5ee0a88e14e5f97bfa725a760cc49": {
       "available": true,
@@ -98,7 +103,7 @@
     "cooling_present": true,
     "gateway_id": "9ff0569b4984459fb243af64c0901894",
     "heater_id": "bfb5ee0a88e14e5f97bfa725a760cc49",
-    "item_count": 66,
+    "item_count": 71,
     "notifications": {},
     "reboot": true,
     "smile_name": "Smile Anna"

--- a/fixtures/anna_loria_cooling_active/all_data.json
+++ b/fixtures/anna_loria_cooling_active/all_data.json
@@ -46,11 +46,13 @@
       "model": "Gateway",
       "model_id": "smile_thermo",
       "name": "Smile Anna",
+      "sensors": {
+        "solar_irradiance": 84.7
+      },
       "vendor": "Plugwise",
       "weather": {
         "humidity": 65,
         "outdoor_temperature": 15.5,
-        "solar_irradiance": 84.7,
         "weather_description": "overcast",
         "wind_bearing": 289.0,
         "wind_speed": 2.2

--- a/fixtures/anna_loria_driessens/all_data.json
+++ b/fixtures/anna_loria_driessens/all_data.json
@@ -12,11 +12,13 @@
       "model": "Gateway",
       "model_id": "smile_thermo",
       "name": "Smile Anna",
+      "sensors": {
+        "solar_irradiance": 97.6
+      },
       "vendor": "Plugwise",
       "weather": {
         "humidity": 88,
         "outdoor_temperature": 6.81,
-        "solar_irradiance": 97.6,
         "weather_description": "clouded",
         "wind_bearing": 230.0,
         "wind_speed": 4.12

--- a/fixtures/anna_loria_driessens/all_data.json
+++ b/fixtures/anna_loria_driessens/all_data.json
@@ -12,10 +12,15 @@
       "model": "Gateway",
       "model_id": "smile_thermo",
       "name": "Smile Anna",
-      "sensors": {
-        "outdoor_temperature": 6.81
-      },
-      "vendor": "Plugwise"
+      "vendor": "Plugwise",
+      "weather": {
+        "humidity": 88,
+        "outdoor_temperature": 6.81,
+        "solar_irradiance": 97.6,
+        "weather_description": "clouded",
+        "wind_bearing": 230.0,
+        "wind_speed": 4.12
+      }
     },
     "9fb768d699e44c7fb5cc50309dc4e7d4": {
       "active_preset": "home",
@@ -104,7 +109,7 @@
     "cooling_present": true,
     "gateway_id": "5c118b1842e943c0a5b6ef88a60bb17a",
     "heater_id": "a449cbc334ae4a5bb7f89064984b2906",
-    "item_count": 66,
+    "item_count": 71,
     "notifications": {},
     "reboot": true,
     "smile_name": "Smile Anna"

--- a/fixtures/anna_loria_heating_idle/all_data.json
+++ b/fixtures/anna_loria_heating_idle/all_data.json
@@ -46,10 +46,15 @@
       "model": "Gateway",
       "model_id": "smile_thermo",
       "name": "Smile Anna",
-      "sensors": {
-        "outdoor_temperature": 15.5
-      },
-      "vendor": "Plugwise"
+      "vendor": "Plugwise",
+      "weather": {
+        "humidity": 65,
+        "outdoor_temperature": 15.5,
+        "solar_irradiance": 84.7,
+        "weather_description": "overcast",
+        "wind_bearing": 289.0,
+        "wind_speed": 2.2
+      }
     },
     "bfb5ee0a88e14e5f97bfa725a760cc49": {
       "available": true,
@@ -98,7 +103,7 @@
     "cooling_present": true,
     "gateway_id": "9ff0569b4984459fb243af64c0901894",
     "heater_id": "bfb5ee0a88e14e5f97bfa725a760cc49",
-    "item_count": 66,
+    "item_count": 71,
     "notifications": {},
     "reboot": true,
     "smile_name": "Smile Anna"

--- a/fixtures/anna_loria_heating_idle/all_data.json
+++ b/fixtures/anna_loria_heating_idle/all_data.json
@@ -46,11 +46,13 @@
       "model": "Gateway",
       "model_id": "smile_thermo",
       "name": "Smile Anna",
+      "sensors": {
+        "solar_irradiance": 84.7
+      },
       "vendor": "Plugwise",
       "weather": {
         "humidity": 65,
         "outdoor_temperature": 15.5,
-        "solar_irradiance": 84.7,
         "weather_description": "overcast",
         "wind_bearing": 289.0,
         "wind_speed": 2.2

--- a/fixtures/anna_v4/all_data.json
+++ b/fixtures/anna_v4/all_data.json
@@ -44,10 +44,15 @@
       "model": "Gateway",
       "model_id": "smile_thermo",
       "name": "Smile Anna",
-      "sensors": {
-        "outdoor_temperature": 7.44
-      },
-      "vendor": "Plugwise"
+      "vendor": "Plugwise",
+      "weather": {
+        "humidity": 81,
+        "outdoor_temperature": 7.44,
+        "solar_irradiance": 449.4,
+        "weather_description": "clear",
+        "wind_bearing": 240.0,
+        "wind_speed": 3.6
+      }
     },
     "cd0e6156b1f04d5f952349ffbe397481": {
       "available": true,
@@ -90,7 +95,7 @@
     "cooling_present": false,
     "gateway_id": "0466eae8520144c78afb29628384edeb",
     "heater_id": "cd0e6156b1f04d5f952349ffbe397481",
-    "item_count": 58,
+    "item_count": 63,
     "notifications": {},
     "reboot": true,
     "smile_name": "Smile Anna"

--- a/fixtures/anna_v4/all_data.json
+++ b/fixtures/anna_v4/all_data.json
@@ -44,11 +44,13 @@
       "model": "Gateway",
       "model_id": "smile_thermo",
       "name": "Smile Anna",
+      "sensors": {
+        "solar_irradiance": 449.4
+      },
       "vendor": "Plugwise",
       "weather": {
         "humidity": 81,
         "outdoor_temperature": 7.44,
-        "solar_irradiance": 449.4,
         "weather_description": "clear",
         "wind_bearing": 240.0,
         "wind_speed": 3.6

--- a/fixtures/anna_v4_dhw/all_data.json
+++ b/fixtures/anna_v4_dhw/all_data.json
@@ -44,10 +44,15 @@
       "model": "Gateway",
       "model_id": "smile_thermo",
       "name": "Smile Anna",
-      "sensors": {
-        "outdoor_temperature": 7.44
-      },
-      "vendor": "Plugwise"
+      "vendor": "Plugwise",
+      "weather": {
+        "humidity": 81,
+        "outdoor_temperature": 7.44,
+        "solar_irradiance": 449.4,
+        "weather_description": "clear",
+        "wind_bearing": 240.0,
+        "wind_speed": 3.6
+      }
     },
     "cd0e6156b1f04d5f952349ffbe397481": {
       "available": true,
@@ -90,7 +95,7 @@
     "cooling_present": false,
     "gateway_id": "0466eae8520144c78afb29628384edeb",
     "heater_id": "cd0e6156b1f04d5f952349ffbe397481",
-    "item_count": 58,
+    "item_count": 63,
     "notifications": {},
     "reboot": true,
     "smile_name": "Smile Anna"

--- a/fixtures/anna_v4_dhw/all_data.json
+++ b/fixtures/anna_v4_dhw/all_data.json
@@ -44,11 +44,13 @@
       "model": "Gateway",
       "model_id": "smile_thermo",
       "name": "Smile Anna",
+      "sensors": {
+        "solar_irradiance": 449.4
+      },
       "vendor": "Plugwise",
       "weather": {
         "humidity": 81,
         "outdoor_temperature": 7.44,
-        "solar_irradiance": 449.4,
         "weather_description": "clear",
         "wind_bearing": 240.0,
         "wind_speed": 3.6

--- a/fixtures/anna_v4_no_tag/all_data.json
+++ b/fixtures/anna_v4_no_tag/all_data.json
@@ -44,10 +44,15 @@
       "model": "Gateway",
       "model_id": "smile_thermo",
       "name": "Smile Anna",
-      "sensors": {
-        "outdoor_temperature": 7.44
-      },
-      "vendor": "Plugwise"
+      "vendor": "Plugwise",
+      "weather": {
+        "humidity": 81,
+        "outdoor_temperature": 7.44,
+        "solar_irradiance": 449.4,
+        "weather_description": "clear",
+        "wind_bearing": 240.0,
+        "wind_speed": 3.6
+      }
     },
     "cd0e6156b1f04d5f952349ffbe397481": {
       "available": true,
@@ -90,7 +95,7 @@
     "cooling_present": false,
     "gateway_id": "0466eae8520144c78afb29628384edeb",
     "heater_id": "cd0e6156b1f04d5f952349ffbe397481",
-    "item_count": 58,
+    "item_count": 63,
     "notifications": {},
     "reboot": true,
     "smile_name": "Smile Anna"

--- a/fixtures/anna_v4_no_tag/all_data.json
+++ b/fixtures/anna_v4_no_tag/all_data.json
@@ -44,11 +44,13 @@
       "model": "Gateway",
       "model_id": "smile_thermo",
       "name": "Smile Anna",
+      "sensors": {
+        "solar_irradiance": 449.4
+      },
       "vendor": "Plugwise",
       "weather": {
         "humidity": 81,
         "outdoor_temperature": 7.44,
-        "solar_irradiance": 449.4,
         "weather_description": "clear",
         "wind_bearing": 240.0,
         "wind_speed": 3.6

--- a/fixtures/anna_without_boiler_fw441/all_data.json
+++ b/fixtures/anna_without_boiler_fw441/all_data.json
@@ -44,11 +44,13 @@
       "model": "Gateway",
       "model_id": "smile_thermo",
       "name": "Smile Anna",
+      "sensors": {
+        "solar_irradiance": 0.0
+      },
       "vendor": "Plugwise",
       "weather": {
         "humidity": 91,
         "outdoor_temperature": 8.31,
-        "solar_irradiance": 0.0,
         "weather_description": "rain",
         "wind_bearing": 208.0,
         "wind_speed": 6.77

--- a/fixtures/anna_without_boiler_fw441/all_data.json
+++ b/fixtures/anna_without_boiler_fw441/all_data.json
@@ -44,10 +44,15 @@
       "model": "Gateway",
       "model_id": "smile_thermo",
       "name": "Smile Anna",
-      "sensors": {
-        "outdoor_temperature": 8.31
-      },
-      "vendor": "Plugwise"
+      "vendor": "Plugwise",
+      "weather": {
+        "humidity": 91,
+        "outdoor_temperature": 8.31,
+        "solar_irradiance": 0.0,
+        "weather_description": "rain",
+        "wind_bearing": 208.0,
+        "wind_speed": 6.77
+      }
     },
     "c46b4794d28149699eacf053deedd003": {
       "binary_sensors": {
@@ -63,7 +68,7 @@
     "cooling_present": false,
     "gateway_id": "a270735e4ccd45239424badc0578a2b1",
     "heater_id": "c46b4794d28149699eacf053deedd003",
-    "item_count": 39,
+    "item_count": 44,
     "notifications": {},
     "reboot": true,
     "smile_name": "Smile Anna"

--- a/fixtures/m_adam_cooling/all_data.json
+++ b/fixtures/m_adam_cooling/all_data.json
@@ -89,10 +89,15 @@
       ],
       "select_gateway_mode": "full",
       "select_regulation_mode": "cooling",
-      "sensors": {
-        "outdoor_temperature": 29.65
-      },
       "vendor": "Plugwise",
+      "weather": {
+        "humidity": 90,
+        "outdoor_temperature": 29.65,
+        "solar_irradiance": 3.0,
+        "weather_description": "rain",
+        "wind_bearing": 291.0,
+        "wind_speed": 6.26
+      },
       "zigbee_mac_address": "000D6F000D5A168D"
     },
     "e2f4322d57924fa090fbbc48b3a140dc": {

--- a/fixtures/m_adam_cooling/all_data.json
+++ b/fixtures/m_adam_cooling/all_data.json
@@ -89,11 +89,13 @@
       ],
       "select_gateway_mode": "full",
       "select_regulation_mode": "cooling",
+      "sensors": {
+        "solar_irradiance": 3.0
+      },
       "vendor": "Plugwise",
       "weather": {
         "humidity": 90,
         "outdoor_temperature": 29.65,
-        "solar_irradiance": 3.0,
         "weather_description": "rain",
         "wind_bearing": 291.0,
         "wind_speed": 6.26

--- a/fixtures/m_adam_heating/all_data.json
+++ b/fixtures/m_adam_heating/all_data.json
@@ -88,10 +88,15 @@
       "regulation_modes": ["bleeding_hot", "bleeding_cold", "off", "heating"],
       "select_gateway_mode": "full",
       "select_regulation_mode": "heating",
-      "sensors": {
-        "outdoor_temperature": -1.25
-      },
       "vendor": "Plugwise",
+      "weather": {
+        "humidity": 90,
+        "outdoor_temperature": -1.25,
+        "solar_irradiance": 3.0,
+        "weather_description": "rain",
+        "wind_bearing": 291.0,
+        "wind_speed": 6.26
+      },
       "zigbee_mac_address": "000D6F000D5A168D"
     },
     "e2f4322d57924fa090fbbc48b3a140dc": {

--- a/fixtures/m_adam_heating/all_data.json
+++ b/fixtures/m_adam_heating/all_data.json
@@ -88,11 +88,13 @@
       "regulation_modes": ["bleeding_hot", "bleeding_cold", "off", "heating"],
       "select_gateway_mode": "full",
       "select_regulation_mode": "heating",
+      "sensors": {
+        "solar_irradiance": 3.0
+      },
       "vendor": "Plugwise",
       "weather": {
         "humidity": 90,
         "outdoor_temperature": -1.25,
-        "solar_irradiance": 3.0,
         "weather_description": "rain",
         "wind_bearing": 291.0,
         "wind_speed": 6.26

--- a/fixtures/m_adam_jip/all_data.json
+++ b/fixtures/m_adam_jip/all_data.json
@@ -228,11 +228,13 @@
       "regulation_modes": ["heating", "off", "bleeding_cold", "bleeding_hot"],
       "select_gateway_mode": "full",
       "select_regulation_mode": "heating",
+      "sensors": {
+        "solar_irradiance": 449.2
+      },
       "vendor": "Plugwise",
       "weather": {
         "humidity": 68,
         "outdoor_temperature": 24.9,
-        "solar_irradiance": 449.2,
         "weather_description": "overcast",
         "wind_bearing": 216.0,
         "wind_speed": 2.68

--- a/fixtures/m_adam_jip/all_data.json
+++ b/fixtures/m_adam_jip/all_data.json
@@ -228,10 +228,15 @@
       "regulation_modes": ["heating", "off", "bleeding_cold", "bleeding_hot"],
       "select_gateway_mode": "full",
       "select_regulation_mode": "heating",
-      "sensors": {
-        "outdoor_temperature": 24.9
-      },
       "vendor": "Plugwise",
+      "weather": {
+        "humidity": 68,
+        "outdoor_temperature": 24.9,
+        "solar_irradiance": 449.2,
+        "weather_description": "overcast",
+        "wind_bearing": 216.0,
+        "wind_speed": 2.68
+      },
       "zigbee_mac_address": "ABCD012345670101"
     },
     "d27aede973b54be484f6842d1b2802ad": {
@@ -372,7 +377,7 @@
     "cooling_present": false,
     "gateway_id": "b5c2386c6f6342669e50fe49dd05b188",
     "heater_id": "e4684553153b44afbef2200885f379dc",
-    "item_count": 244,
+    "item_count": 249,
     "notifications": {},
     "reboot": true,
     "smile_name": "Adam"

--- a/fixtures/m_adam_multiple_devices_per_zone/all_data.json
+++ b/fixtures/m_adam_multiple_devices_per_zone/all_data.json
@@ -571,11 +571,13 @@
       "model_id": "smile_open_therm",
       "name": "Adam",
       "select_regulation_mode": "heating",
+      "sensors": {
+        "solar_irradiance": 157.5
+      },
       "vendor": "Plugwise",
       "weather": {
         "humidity": 75,
         "outdoor_temperature": 7.81,
-        "solar_irradiance": 157.5,
         "weather_description": "cloudy",
         "wind_bearing": 40.0,
         "wind_speed": 8.2

--- a/fixtures/m_adam_multiple_devices_per_zone/all_data.json
+++ b/fixtures/m_adam_multiple_devices_per_zone/all_data.json
@@ -571,10 +571,15 @@
       "model_id": "smile_open_therm",
       "name": "Adam",
       "select_regulation_mode": "heating",
-      "sensors": {
-        "outdoor_temperature": 7.81
-      },
       "vendor": "Plugwise",
+      "weather": {
+        "humidity": 75,
+        "outdoor_temperature": 7.81,
+        "solar_irradiance": 157.5,
+        "weather_description": "cloudy",
+        "wind_bearing": 40.0,
+        "wind_speed": 8.2
+      },
       "zigbee_mac_address": "ABCD012345670101"
     }
   },
@@ -582,7 +587,7 @@
     "cooling_present": false,
     "gateway_id": "fe799307f1624099878210aa0b9f1475",
     "heater_id": "90986d591dcd426cae3ec3e8111ff730",
-    "item_count": 369,
+    "item_count": 374,
     "notifications": {
       "af82e4ccf9c548528166d38e560662a4": {
         "warning": "Node Plug (with MAC address 000D6F000D13CB01, in room 'n.a.') has been unreachable since 23:03 2020-01-18. Please check the connection and restart the device."

--- a/fixtures/m_anna_heatpump_cooling/all_data.json
+++ b/fixtures/m_anna_heatpump_cooling/all_data.json
@@ -12,11 +12,13 @@
       "model": "Gateway",
       "model_id": "smile_thermo",
       "name": "Smile Anna",
+      "sensors": {
+        "solar_irradiance": 653.6
+      },
       "vendor": "Plugwise",
       "weather": {
         "humidity": 42,
         "outdoor_temperature": 28.2,
-        "solar_irradiance": 653.6,
         "weather_description": "clear",
         "wind_bearing": 50.0,
         "wind_speed": 4.1

--- a/fixtures/m_anna_heatpump_cooling/all_data.json
+++ b/fixtures/m_anna_heatpump_cooling/all_data.json
@@ -12,10 +12,15 @@
       "model": "Gateway",
       "model_id": "smile_thermo",
       "name": "Smile Anna",
-      "sensors": {
-        "outdoor_temperature": 28.2
-      },
-      "vendor": "Plugwise"
+      "vendor": "Plugwise",
+      "weather": {
+        "humidity": 42,
+        "outdoor_temperature": 28.2,
+        "solar_irradiance": 653.6,
+        "weather_description": "clear",
+        "wind_bearing": 50.0,
+        "wind_speed": 4.1
+      }
     },
     "1cbf783bb11e4a7c8a6843dee3a86927": {
       "available": true,
@@ -99,7 +104,7 @@
     "cooling_present": true,
     "gateway_id": "015ae9ea3f964e668e490fa39da3870b",
     "heater_id": "1cbf783bb11e4a7c8a6843dee3a86927",
-    "item_count": 67,
+    "item_count": 72,
     "notifications": {},
     "reboot": true,
     "smile_name": "Smile Anna"

--- a/fixtures/m_anna_heatpump_idle/all_data.json
+++ b/fixtures/m_anna_heatpump_idle/all_data.json
@@ -12,11 +12,13 @@
       "model": "Gateway",
       "model_id": "smile_thermo",
       "name": "Smile Anna",
+      "sensors": {
+        "solar_irradiance": 653.6
+      },
       "vendor": "Plugwise",
       "weather": {
         "humidity": 42,
         "outdoor_temperature": 28.2,
-        "solar_irradiance": 653.6,
         "weather_description": "clear",
         "wind_bearing": 50.0,
         "wind_speed": 4.1

--- a/fixtures/m_anna_heatpump_idle/all_data.json
+++ b/fixtures/m_anna_heatpump_idle/all_data.json
@@ -12,10 +12,15 @@
       "model": "Gateway",
       "model_id": "smile_thermo",
       "name": "Smile Anna",
-      "sensors": {
-        "outdoor_temperature": 28.2
-      },
-      "vendor": "Plugwise"
+      "vendor": "Plugwise",
+      "weather": {
+        "humidity": 42,
+        "outdoor_temperature": 28.2,
+        "solar_irradiance": 653.6,
+        "weather_description": "clear",
+        "wind_bearing": 50.0,
+        "wind_speed": 4.1
+      }
     },
     "1cbf783bb11e4a7c8a6843dee3a86927": {
       "available": true,
@@ -99,7 +104,7 @@
     "cooling_present": true,
     "gateway_id": "015ae9ea3f964e668e490fa39da3870b",
     "heater_id": "1cbf783bb11e4a7c8a6843dee3a86927",
-    "item_count": 67,
+    "item_count": 72,
     "notifications": {},
     "reboot": true,
     "smile_name": "Smile Anna"

--- a/plugwise/common.py
+++ b/plugwise/common.py
@@ -169,7 +169,7 @@ class SmileCommon:
         # --------------------------------------#
         loc.net_string = f"net_electricity_{log_found}"
         val = loc.logs.find(loc.locator).text
-        loc.f_val = power_data_local_format(loc.attr, loc.key_string, val)
+        loc.f_val = power_data_local_format(loc.attrs, loc.key_string, val)
 
         return loc
 

--- a/plugwise/common.py
+++ b/plugwise/common.py
@@ -169,7 +169,7 @@ class SmileCommon:
         # --------------------------------------#
         loc.net_string = f"net_electricity_{log_found}"
         val = loc.logs.find(loc.locator).text
-        loc.f_val = power_data_local_format(loc.attrs, loc.key_string, val)
+        loc.f_val = power_data_local_format(loc.attr, loc.key_string, val)
 
         return loc
 

--- a/plugwise/common.py
+++ b/plugwise/common.py
@@ -147,6 +147,8 @@ class SmileCommon:
             self._count += len(data["sensors"]) - 1
         if "switches" in data:
             self._count += len(data["switches"]) - 1
+        if "weather" in data:
+            self._count += len(data["weather"]) - 1
         self._count += len(data)
 
     def _power_data_peak_value(self, loc: Munch, legacy: bool) -> Munch:

--- a/plugwise/constants.py
+++ b/plugwise/constants.py
@@ -521,8 +521,7 @@ class ThermoLoc(TypedDict, total=False):
     secondary: list[str]
 
 
-@dataclass
-class WeatherData:
+class WeatherData(TypedDict, total=False):
     """Smile Weather data class."""
 
     humidity: int

--- a/plugwise/constants.py
+++ b/plugwise/constants.py
@@ -391,6 +391,15 @@ TOGGLES: Final[dict[str, ToggleNameType]] = {
     "cooling_enabled": "cooling_ena_switch",
     "domestic_hot_water_comfort_mode": "dhw_cm_switch",
 }
+WeatherType = Literal[
+    "humidity",
+    "outdoor_temperature",
+    "solar_irradiance",
+    "weather_description",
+    "wind_bearing",
+    "wind_speed",
+]
+WEATHER: Final[tuple[str, ...]] = get_args(WeatherType)
 
 ZONE_THERMOSTATS: Final[tuple[str, ...]] = (
     "thermostat",
@@ -512,6 +521,18 @@ class ThermoLoc(TypedDict, total=False):
     secondary: list[str]
 
 
+@dataclass
+class WeatherData:
+    """Smile Weather data class."""
+
+    humidity: int
+    outdoor_temperature: float
+    solar_irradiance: float
+    weather_description: str
+    wind_bearing: float
+    wind_speed: float
+
+
 class ActuatorData(TypedDict, total=False):
     """Actuator data for thermostat types."""
 
@@ -583,6 +604,7 @@ class GwEntityData(TypedDict, total=False):
     switches: SmileSwitches
     temperature_offset: ActuatorData
     thermostat: ActuatorData
+    weather: WeatherData
 
 
 @dataclass

--- a/plugwise/constants.py
+++ b/plugwise/constants.py
@@ -340,6 +340,7 @@ SensorType = Literal[
     "setpoint",
     "setpoint_high",
     "setpoint_low",
+    "solar_irradiance",
     "temperature_difference",
     "valve_position",
     "voltage_phase_one",
@@ -394,7 +395,6 @@ TOGGLES: Final[dict[str, ToggleNameType]] = {
 WeatherType = Literal[
     "humidity",
     "outdoor_temperature",
-    "solar_irradiance",
     "weather_description",
     "wind_bearing",
     "wind_speed",
@@ -493,6 +493,7 @@ class SmileSensors(TypedDict, total=False):
     return_temperature: float
     setpoint: float
     setpoint_high: float
+    solar_irradiance: float
     setpoint_low: float
     temperature_difference: float
     valve_position: int
@@ -526,7 +527,6 @@ class WeatherData(TypedDict, total=False):
 
     humidity: int
     outdoor_temperature: float
-    solar_irradiance: float
     weather_description: str
     wind_bearing: float
     wind_speed: float

--- a/plugwise/constants.py
+++ b/plugwise/constants.py
@@ -126,7 +126,6 @@ P1_LEGACY_MEASUREMENTS: Final[dict[str, UOM]] = {
 # radiator_valve: 'uncorrected_temperature', 'temperature_offset'
 
 DEVICE_MEASUREMENTS: Final[dict[str, DATA | UOM]] = {
-    "humidity": UOM(NONE),  # Specific for a Jip
     "illuminance": UOM(UNIT_LUMEN),  # Specific for an Anna
     "temperature": UOM(TEMP_CELSIUS),  # HA Core thermostat current_temperature
     "thermostat": DATA("setpoint", TEMP_CELSIUS),  # HA Core thermostat setpoint
@@ -144,6 +143,13 @@ DEVICE_MEASUREMENTS: Final[dict[str, DATA | UOM]] = {
     "electricity_consumed": UOM(POWER_WATT),
     "electricity_produced": UOM(POWER_WATT),
     "relay": UOM(NONE),
+    #####################
+    # Gateway weather related
+    "humidity": UOM(NONE),  # also present for a Jip
+    "outdoor_temperature": UOM(NONE),
+    "solar_irradiance": UOM(NONE),
+    "weather_description": UOM(NONE),
+    "wind_vector": UOM(NONE),
 }
 
 # Heater Central related measurements

--- a/plugwise/constants.py
+++ b/plugwise/constants.py
@@ -145,8 +145,8 @@ DEVICE_MEASUREMENTS: Final[dict[str, DATA | UOM]] = {
     "relay": UOM(NONE),
     #####################
     # Gateway weather related
-    "humidity": UOM(NONE),  # also present for a Jip
-    "outdoor_temperature": UOM(NONE),
+    "humidity": UOM(PERCENTAGE),  # also present for a Jip
+    "outdoor_temperature": UOM(TEMP_CELSIUS),
     "solar_irradiance": UOM(NONE),
     "weather_description": UOM(NONE),
     "wind_vector": UOM(NONE),

--- a/plugwise/helper.py
+++ b/plugwise/helper.py
@@ -783,13 +783,17 @@ class SmileHelper(SmileCommon):
 
         Obtain the value/state for the given object from a location in DOMAIN_OBJECTS
         """
-        val: float | int | None = None
+        val: float | int | str | None = None
         search = self._domain_objects
         locator = f'./location[@id="{obj_id}"]/logs/point_log[type="{measurement}"]/period/measurement'
         if (found := search.find(locator)) is not None:
-            val = format_measure(found.text, NONE)
+            value = found.text
+            if isinstance(value, str):
+                return val
 
-        return val
+            return format_measure(value, NONE)
+
+        return None
 
     def _process_c_heating_state(self, data: GwEntityData) -> None:
         """Helper-function for _get_measurement_data().

--- a/plugwise/helper.py
+++ b/plugwise/helper.py
@@ -785,21 +785,27 @@ class SmileHelper(SmileCommon):
             ) is None:
                 continue
 
-            if measurement == "wind_vector":
-                value_list: list[str] = str(value).split(",")
-                data["weather"]["wind_speed"] = format_measure(
-                    value_list[0].strip("("),
-                    getattr(attrs, ATTR_UNIT_OF_MEASUREMENT),
-                )
-                data["weather"]["wind_bearing"] = format_measure(
-                    value_list[1].strip(")"),
-                    getattr(attrs, ATTR_UNIT_OF_MEASUREMENT),
-                )
-                self._count += 2
-            else:
-                key = cast(WeatherType, measurement)
-                data["weather"][key] = value
-                self._count += 1
+            match measurement:
+                case "solar_irradiance":
+                    # Not available in HA weather platform -> sensor
+                    key = cast(SensorType, measurement)
+                    data["sensors"][key] = value
+                    self._count += 1
+                case "wind_vector":
+                    value_list: list[str] = str(value).split(",")
+                    data["weather"]["wind_speed"] = format_measure(
+                        value_list[0].strip("("),
+                        getattr(attrs, ATTR_UNIT_OF_MEASUREMENT),
+                    )
+                    data["weather"]["wind_bearing"] = format_measure(
+                        value_list[1].strip(")"),
+                        getattr(attrs, ATTR_UNIT_OF_MEASUREMENT),
+                    )
+                    self._count += 2
+                case _:
+                    key = cast(WeatherType, measurement)
+                    data["weather"][key] = value
+                    self._count += 1
 
     def _loc_value(
         self, loc_id: str, measurement: str, attrs: DATA | UOM

--- a/plugwise/helper.py
+++ b/plugwise/helper.py
@@ -791,13 +791,17 @@ class SmileHelper(SmileCommon):
         locator = f'./location[@id="{obj_id}"]/logs/point_log[type="{measurement}"]/period/measurement'
         if (found := search.find(locator)) is not None:
             value = found.text
-            if isinstance(value, str):
-                return value
-
-            if measurement == "humidity":
-                value = float(value/100)
-
-            return format_measure(value, attr)
+            match measurement:
+                case "humidity": 
+                    return format_measure(float(value)/100, attr)
+                case "outdoor_temperature":
+                    return format_measure(float(value), attr)
+                case "solar_irradiance":
+                    return format_measure(float(value), attr)
+                case "weather_description":
+                    return value
+                case "wind_vector":
+                    return value
 
     def _process_c_heating_state(self, data: GwEntityData) -> None:
         """Helper-function for _get_measurement_data().

--- a/plugwise/helper.py
+++ b/plugwise/helper.py
@@ -769,14 +769,17 @@ class SmileHelper(SmileCommon):
         Available under the Home location.
         """
         measurements = HEATER_CENTRAL_MEASUREMENTS
-        if entity_id != self.gateway_id:
-            return
+        if self._is_thermostat:
+            if entity_id != self.gateway_id:
+                return
 
-        location_id = self.gw_entities[entity_id]["location"]
-        if (
-            location := self._domain_objects.find(f'./location[@id="{location_id}"]')
-        ) is not None:
-            self._appliance_measurements(location, data, measurements)
+            location_id = self.gw_entities[entity_id]["location"]
+            if (
+                location := self._domain_objects.find(f'./location[@id="{location_id}"]')
+            ) is not None:
+                self._appliance_measurements(location, data, measurements)
+        
+        return
 
     def _object_value(self, obj_id: str, measurement: str) -> float | int | None:
         """Helper-function for smile.py: _get_entity_data().

--- a/plugwise/helper.py
+++ b/plugwise/helper.py
@@ -587,7 +587,7 @@ class SmileHelper(SmileCommon):
 
         search = self._domain_objects
         loc.logs = search.find(f'./location[@id="{loc_id}"]/logs')
-        for loc.measurement, loc.attr in P1_MEASUREMENTS.items():
+        for loc.measurement, loc.attrs in P1_MEASUREMENTS.items():
             for loc.log_type in log_list:
                 self._collect_power_values(data, loc, t_string)
 
@@ -601,13 +601,13 @@ class SmileHelper(SmileCommon):
         measurements: dict[str, DATA | UOM],
     ) -> None:
         """Helper-function for _get_measurement_data() - collect appliance measurement data."""
-        for measurement, attr in measurements.items():
+        for measurement, attrs in measurements.items():
             p_locator = f'.//logs/point_log[type="{measurement}"]/period/measurement'
             if (appl_p_loc := appliance.find(p_locator)) is not None:
                 if skip_obsolete_measurements(appliance, measurement):
                     continue
 
-                if new_name := getattr(attr, ATTR_NAME, None):
+                if new_name := getattr(attrs, ATTR_NAME, None):
                     measurement = new_name
 
                 match measurement:
@@ -616,7 +616,7 @@ class SmileHelper(SmileCommon):
                     case "select_dhw_mode":
                         data["select_dhw_mode"] = appl_p_loc.text
 
-                common_match_cases(measurement, attr, appl_p_loc, data)
+                common_match_cases(measurement, attrs, appl_p_loc, data)
 
             i_locator = f'.//logs/interval_log[type="{measurement}"]/period/measurement'
             if (appl_i_loc := appliance.find(i_locator)) is not None:
@@ -772,25 +772,25 @@ class SmileHelper(SmileCommon):
         measurements = DEVICE_MEASUREMENTS
         if self._is_thermostat and entity_id == self.gateway_id:
             data["weather"] =  {}
-            for measurement, attr in measurements.items():
+            for measurement, attrs in measurements.items():
                 LOGGER.debug("HOI meas: %s", measurement)
-                value = self._object_value(self._home_location, measurement, attr)
+                value = self._object_value(self._home_location, measurement, attrs)
                 LOGGER.debug("HOI value: %s", value)
                 if value is not None:
                     if measurement == "wind_vector":
                         value = value.split(",")
                         data["weather"]["wind_speed"] = format_measure(
-                            value[0].strip("("), getattr(attr, ATTR_UNIT_OF_MEASUREMENT)
+                            value[0].strip("("), getattr(attrs, ATTR_UNIT_OF_MEASUREMENT)
                         )
                         data["weather"]["wind_bearing"] = format_measure(
-                            value[1].strip(")"), getattr(attr, ATTR_UNIT_OF_MEASUREMENT)
+                            value[1].strip(")"), getattr(attrs, ATTR_UNIT_OF_MEASUREMENT)
                         )
                         self._count += 2
                     else:
                         data["weather"][measurement] = value
                         self._count += 1
 
-    def _object_value(self, obj_id: str, measurement: str, attr: str) -> float | int | str| None:
+    def _object_value(self, obj_id: str, measurement: str, attrs: str) -> float | int | str| None:
         """Helper-function for smile.py: _get_entity_data().
 
         Obtain the value/state for the given object from a location in DOMAIN_OBJECTS
@@ -804,9 +804,9 @@ class SmileHelper(SmileCommon):
                 case "humidity":
                     return int(float(value))
                 case "outdoor_temperature":
-                    return format_measure(value, getattr(attr, ATTR_UNIT_OF_MEASUREMENT))
+                    return format_measure(value, getattr(attrs, ATTR_UNIT_OF_MEASUREMENT))
                 case "solar_irradiance":
-                    return format_measure(value, getattr(attr, ATTR_UNIT_OF_MEASUREMENT))
+                    return format_measure(value, getattr(attrs, ATTR_UNIT_OF_MEASUREMENT))
                 case "weather_description":
                     return value
                 case "wind_vector":

--- a/plugwise/helper.py
+++ b/plugwise/helper.py
@@ -788,8 +788,8 @@ class SmileHelper(SmileCommon):
             match measurement:
                 case "solar_irradiance":
                     # Not available in HA weather platform -> sensor
-                    key = cast(SensorType, measurement)
-                    data["sensors"][key] = value
+                    sensor = cast(SensorType, measurement)
+                    data["sensors"][sensor] = float(value)
                     self._count += 1
                 case "wind_vector":
                     value_list: list[str] = str(value).split(",")

--- a/plugwise/helper.py
+++ b/plugwise/helper.py
@@ -771,14 +771,17 @@ class SmileHelper(SmileCommon):
         measurements = DEVICE_MEASUREMENTS
         if self._is_thermostat and entity_id == self.gateway_id:
             for measurement, attrs in measurements.items():
+                LOGGER.debug("HOI meas: %s", measurement)
+                LOGGER.debug("HOI loc: %s", self._home_location)
                 value = self._object_value(self._home_location, measurement)
+                LOGGER.debug("HOI value: %s", value)
                 if value is not None:
                     data[measurement] = value
                     self._count += 1
         
         return
 
-    def _object_value(self, obj_id: str, measurement: str) -> float | int | None:
+    def _object_value(self, obj_id: str, measurement: str) -> float | int | str| None:
         """Helper-function for smile.py: _get_entity_data().
 
         Obtain the value/state for the given object from a location in DOMAIN_OBJECTS
@@ -787,7 +790,9 @@ class SmileHelper(SmileCommon):
         search = self._domain_objects
         locator = f'./location[@id="{obj_id}"]/logs/point_log[type="{measurement}"]/period/measurement'
         if (found := search.find(locator)) is not None:
+            LOGGER.debug("HOI found!")
             value = found.text
+            LOGGER.debug("HOI found_value: %s", value)
             if isinstance(value, str):
                 return val
 

--- a/plugwise/helper.py
+++ b/plugwise/helper.py
@@ -771,6 +771,7 @@ class SmileHelper(SmileCommon):
         """
         measurements = DEVICE_MEASUREMENTS
         if self._is_thermostat and entity_id == self.gateway_id:
+            data["weather"] =  {}
             for measurement, attr in measurements.items():
                 LOGGER.debug("HOI meas: %s", measurement)
                 value = self._object_value(self._home_location, measurement, attr)
@@ -801,7 +802,7 @@ class SmileHelper(SmileCommon):
             value = found.text
             match measurement:
                 case "humidity":
-                    return int(value)
+                    return int(float(value))
                 case "outdoor_temperature":
                     return format_measure(value, getattr(attr, ATTR_UNIT_OF_MEASUREMENT))
                 case "solar_irradiance":

--- a/plugwise/helper.py
+++ b/plugwise/helper.py
@@ -779,7 +779,7 @@ class SmileHelper(SmileCommon):
                     if measurement == "wind_vector":
                         value = value.split(",")
                         data["wind_speed"] =  format_measure(value[0].strip("("), getattr(attr, ATTR_UNIT_OF_MEASUREMENT))
-                        data["wind_direction"] = format_measure(value[1].strip(")"), getattr(attr, ATTR_UNIT_OF_MEASUREMENT))
+                        data["wind_bearing"] = format_measure(value[1].strip(")"), getattr(attr, ATTR_UNIT_OF_MEASUREMENT))
                         self._count += 2
                     else:
                         data[measurement] = value
@@ -797,11 +797,7 @@ class SmileHelper(SmileCommon):
             value = found.text
             match measurement:
                 case "humidity":
-                    value = float(value)/100
-                    LOGGER.debug("HOI hum_val: %s", value)
-                    value = format_measure(str(value), getattr(attr, ATTR_UNIT_OF_MEASUREMENT))
-                    LOGGER.debug("HOI hum_val_fm: %s", value)
-                    return value
+                    return int(value)
                 case "outdoor_temperature":
                     return format_measure(value, getattr(attr, ATTR_UNIT_OF_MEASUREMENT))
                 case "solar_irradiance":

--- a/plugwise/helper.py
+++ b/plugwise/helper.py
@@ -811,17 +811,11 @@ class SmileHelper(SmileCommon):
             match measurement:
                 case "humidity":
                     return int(float(value))
-                case "outdoor_temperature":
+                case "outdoor_temperature" | "solar_irradiance":
                     return format_measure(
                         value, getattr(attrs, ATTR_UNIT_OF_MEASUREMENT)
                     )
-                case "solar_irradiance":
-                    return format_measure(
-                        value, getattr(attrs, ATTR_UNIT_OF_MEASUREMENT)
-                    )
-                case "weather_description":
-                    return value
-                case "wind_vector":
+                case _:
                     return value
 
         return None

--- a/plugwise/helper.py
+++ b/plugwise/helper.py
@@ -792,8 +792,10 @@ class SmileHelper(SmileCommon):
         if (found := search.find(locator)) is not None:
             value = found.text
             match measurement:
-                case "humidity": 
-                    return format_measure(float(value)/100, attr)
+                case "humidity":
+                    value = float(value)/100
+                    LOGGER.debug("HOI hum_val: %s", value)
+                    return format_measure(value, attr)
                 case "outdoor_temperature":
                     return format_measure(float(value), attr)
                 case "solar_irradiance":

--- a/plugwise/helper.py
+++ b/plugwise/helper.py
@@ -772,7 +772,7 @@ class SmileHelper(SmileCommon):
         if self._is_thermostat and entity_id == self.gateway_id:
             for measurement, attr in measurements.items():
                 LOGGER.debug("HOI meas: %s", measurement)
-                LOGGER.debug("HOI loc: %s", self._home_location)
+                LOGGER.debug("HOI attr: %s", attr)
                 value = self._object_value(self._home_location, measurement, attr)
                 LOGGER.debug("HOI value: %s", value)
                 if value is not None:

--- a/plugwise/helper.py
+++ b/plugwise/helper.py
@@ -768,16 +768,13 @@ class SmileHelper(SmileCommon):
 
         Available under the Home location.
         """
-        measurements = HEATER_CENTRAL_MEASUREMENTS
-        if self._is_thermostat:
-            if entity_id != self.gateway_id:
-                return
-
-            location_id = self.gw_entities[entity_id]["location"]
-            if (
-                location := self._domain_objects.find(f'./location[@id="{location_id}"]')
-            ) is not None:
-                self._appliance_measurements(location, data, measurements)
+        measurements = DEVICE_MEASUREMENTS
+        if self._is_thermostat and entity_id == self.gateway_id:
+            for measurement, attrs in measurements.items():
+                value = self._object_value(self._home_location, measurement)
+                if value is not None:
+                    data[measurement] = value
+                    self._count += 1
         
         return
 

--- a/plugwise/helper.py
+++ b/plugwise/helper.py
@@ -794,6 +794,9 @@ class SmileHelper(SmileCommon):
             if isinstance(value, str):
                 return value
 
+            if measurement == "humidity":
+                value = float(value/100)
+
             return format_measure(value, attr)
 
     def _process_c_heating_state(self, data: GwEntityData) -> None:

--- a/plugwise/helper.py
+++ b/plugwise/helper.py
@@ -773,9 +773,7 @@ class SmileHelper(SmileCommon):
         if self._is_thermostat and entity_id == self.gateway_id:
             data["weather"] =  {}
             for measurement, attrs in measurements.items():
-                LOGGER.debug("HOI meas: %s", measurement)
                 value = self._object_value(self._home_location, measurement, attrs)
-                LOGGER.debug("HOI value: %s", value)
                 if value is not None:
                     if measurement == "wind_vector":
                         value = value.split(",")

--- a/plugwise/helper.py
+++ b/plugwise/helper.py
@@ -586,7 +586,7 @@ class SmileHelper(SmileCommon):
 
         search = self._domain_objects
         loc.logs = search.find(f'./location[@id="{loc_id}"]/logs')
-        for loc.measurement, loc.attrs in P1_MEASUREMENTS.items():
+        for loc.measurement, loc.attr in P1_MEASUREMENTS.items():
             for loc.log_type in log_list:
                 self._collect_power_values(data, loc, t_string)
 
@@ -600,13 +600,13 @@ class SmileHelper(SmileCommon):
         measurements: dict[str, DATA | UOM],
     ) -> None:
         """Helper-function for _get_measurement_data() - collect appliance measurement data."""
-        for measurement, attrs in measurements.items():
+        for measurement, attr in measurements.items():
             p_locator = f'.//logs/point_log[type="{measurement}"]/period/measurement'
             if (appl_p_loc := appliance.find(p_locator)) is not None:
                 if skip_obsolete_measurements(appliance, measurement):
                     continue
 
-                if new_name := getattr(attrs, ATTR_NAME, None):
+                if new_name := getattr(attr, ATTR_NAME, None):
                     measurement = new_name
 
                 match measurement:
@@ -615,7 +615,7 @@ class SmileHelper(SmileCommon):
                     case "select_dhw_mode":
                         data["select_dhw_mode"] = appl_p_loc.text
 
-                common_match_cases(measurement, attrs, appl_p_loc, data)
+                common_match_cases(measurement, attr, appl_p_loc, data)
 
             i_locator = f'.//logs/interval_log[type="{measurement}"]/period/measurement'
             if (appl_i_loc := appliance.find(i_locator)) is not None:
@@ -770,10 +770,10 @@ class SmileHelper(SmileCommon):
         """
         measurements = DEVICE_MEASUREMENTS
         if self._is_thermostat and entity_id == self.gateway_id:
-            for measurement, attrs in measurements.items():
+            for measurement, attr in measurements.items():
                 LOGGER.debug("HOI meas: %s", measurement)
                 LOGGER.debug("HOI loc: %s", self._home_location)
-                value = self._object_value(self._home_location, measurement)
+                value = self._object_value(self._home_location, measurement, attr)
                 LOGGER.debug("HOI value: %s", value)
                 if value is not None:
                     data[measurement] = value
@@ -781,7 +781,7 @@ class SmileHelper(SmileCommon):
         
         return
 
-    def _object_value(self, obj_id: str, measurement: str) -> float | int | str| None:
+    def _object_value(self, obj_id: str, measurement: str, attr: str) -> float | int | str| None:
         """Helper-function for smile.py: _get_entity_data().
 
         Obtain the value/state for the given object from a location in DOMAIN_OBJECTS
@@ -794,7 +794,7 @@ class SmileHelper(SmileCommon):
             if isinstance(value, str):
                 return value
 
-            return format_measure(value, NONE)
+            return format_measure(value, attr)
 
     def _process_c_heating_state(self, data: GwEntityData) -> None:
         """Helper-function for _get_measurement_data().

--- a/plugwise/helper.py
+++ b/plugwise/helper.py
@@ -786,19 +786,15 @@ class SmileHelper(SmileCommon):
 
         Obtain the value/state for the given object from a location in DOMAIN_OBJECTS
         """
-        val: float | int | str | None = None
+        value: float | int | str | None = None
         search = self._domain_objects
         locator = f'./location[@id="{obj_id}"]/logs/point_log[type="{measurement}"]/period/measurement'
         if (found := search.find(locator)) is not None:
-            LOGGER.debug("HOI found!")
             value = found.text
-            LOGGER.debug("HOI found_value: %s", value)
             if isinstance(value, str):
-                return val
+                return value
 
             return format_measure(value, NONE)
-
-        return None
 
     def _process_c_heating_state(self, data: GwEntityData) -> None:
         """Helper-function for _get_measurement_data().

--- a/plugwise/helper.py
+++ b/plugwise/helper.py
@@ -778,11 +778,15 @@ class SmileHelper(SmileCommon):
                 if value is not None:
                     if measurement == "wind_vector":
                         value = value.split(",")
-                        data["wind_speed"] =  format_measure(value[0].strip("("), getattr(attr, ATTR_UNIT_OF_MEASUREMENT))
-                        data["wind_bearing"] = format_measure(value[1].strip(")"), getattr(attr, ATTR_UNIT_OF_MEASUREMENT))
+                        data["weather"]["wind_speed"] = format_measure(
+                            value[0].strip("("), getattr(attr, ATTR_UNIT_OF_MEASUREMENT)
+                        )
+                        data["weather"]["wind_bearing"] = format_measure(
+                            value[1].strip(")"), getattr(attr, ATTR_UNIT_OF_MEASUREMENT)
+                        )
                         self._count += 2
                     else:
-                        data[measurement] = value
+                        data["weather"][measurement] = value
                         self._count += 1
 
     def _object_value(self, obj_id: str, measurement: str, attr: str) -> float | int | str| None:

--- a/plugwise/util.py
+++ b/plugwise/util.py
@@ -157,6 +157,7 @@ def format_measure(measure: str, unit: str) -> float | int:
     try:
         result = int(measure)
         if unit == TEMP_CELSIUS:
+            # Return for instance 20 (degrees) as 20.0
             result = float(measure)
     except ValueError:
         float_measure = float(measure)

--- a/plugwise/util.py
+++ b/plugwise/util.py
@@ -203,12 +203,14 @@ def power_data_local_format(
 
 def remove_empty_platform_dicts(data: GwEntityData) -> None:
     """Helper-function for removing any empty platform dicts."""
-    if not data["binary_sensors"]:
+    if "binary_sensors" in data and not data["binary_sensors"]:
         data.pop("binary_sensors")
-    if not data["sensors"]:
+    if "sensors" in data and not data["sensors"]:
         data.pop("sensors")
-    if not data["switches"]:
+    if "switches" in data and not data["switches"]:
         data.pop("switches")
+    if "weather" in data and not data["weather"]:
+        data.pop("weather")
 
 
 def return_valid(value: etree | None, default: etree) -> etree:

--- a/plugwise/util.py
+++ b/plugwise/util.py
@@ -195,10 +195,10 @@ def power_data_local_format(
     # Special formatting of P1_MEASUREMENT POWER_WATT values, do not move to util-format_measure() function!
     if all(item in key_string for item in ("electricity", "cumulative")):
         return format_measure(val, ENERGY_KILO_WATT_HOUR)
-    if (attr_uom := getattr(attrs, ATTR_UNIT_OF_MEASUREMENT)) == POWER_WATT:
+    if (attrs_uom := getattr(attrs, ATTR_UNIT_OF_MEASUREMENT)) == POWER_WATT:
         return int(round(float(val)))
 
-    return format_measure(val, attr_uom)
+    return format_measure(val, attrs_uom)
 
 
 def remove_empty_platform_dicts(data: GwEntityData) -> None:

--- a/plugwise/util.py
+++ b/plugwise/util.py
@@ -119,7 +119,7 @@ def check_model(name: str | None, vendor_name: str | None) -> str | None:
 
 def common_match_cases(
     measurement: str,
-    attr: DATA | UOM,
+    attrs: DATA | UOM,
     location: etree,
     data: GwEntityData,
 ) -> None:
@@ -132,7 +132,7 @@ def common_match_cases(
         case _ as measurement if measurement in SENSORS:
             s_key = cast(SensorType, measurement)
             s_value = format_measure(
-                location.text, getattr(attr, ATTR_UNIT_OF_MEASUREMENT)
+                location.text, getattr(attrs, ATTR_UNIT_OF_MEASUREMENT)
             )
             data["sensors"][s_key] = s_value
         case _ as measurement if measurement in SWITCHES:
@@ -189,13 +189,13 @@ def get_vendor_name(module: etree, model_data: ModuleData) -> ModuleData:
 
 
 def power_data_local_format(
-    attr: dict[str, str], key_string: str, val: str
+    attrs: dict[str, str], key_string: str, val: str
 ) -> float | int:
     """Format power data."""
     # Special formatting of P1_MEASUREMENT POWER_WATT values, do not move to util-format_measure() function!
     if all(item in key_string for item in ("electricity", "cumulative")):
         return format_measure(val, ENERGY_KILO_WATT_HOUR)
-    if (attr_uom := getattr(atts, ATTR_UNIT_OF_MEASUREMENT)) == POWER_WATT:
+    if (attr_uom := getattr(attrs, ATTR_UNIT_OF_MEASUREMENT)) == POWER_WATT:
         return int(round(float(val)))
 
     return format_measure(val, attr_uom)

--- a/plugwise/util.py
+++ b/plugwise/util.py
@@ -119,7 +119,7 @@ def check_model(name: str | None, vendor_name: str | None) -> str | None:
 
 def common_match_cases(
     measurement: str,
-    attrs: DATA | UOM,
+    attr: DATA | UOM,
     location: etree,
     data: GwEntityData,
 ) -> None:
@@ -132,7 +132,7 @@ def common_match_cases(
         case _ as measurement if measurement in SENSORS:
             s_key = cast(SensorType, measurement)
             s_value = format_measure(
-                location.text, getattr(attrs, ATTR_UNIT_OF_MEASUREMENT)
+                location.text, getattr(attr, ATTR_UNIT_OF_MEASUREMENT)
             )
             data["sensors"][s_key] = s_value
         case _ as measurement if measurement in SWITCHES:
@@ -189,16 +189,16 @@ def get_vendor_name(module: etree, model_data: ModuleData) -> ModuleData:
 
 
 def power_data_local_format(
-    attrs: dict[str, str], key_string: str, val: str
+    attr: dict[str, str], key_string: str, val: str
 ) -> float | int:
     """Format power data."""
     # Special formatting of P1_MEASUREMENT POWER_WATT values, do not move to util-format_measure() function!
     if all(item in key_string for item in ("electricity", "cumulative")):
         return format_measure(val, ENERGY_KILO_WATT_HOUR)
-    if (attrs_uom := getattr(attrs, ATTR_UNIT_OF_MEASUREMENT)) == POWER_WATT:
+    if (attr_uom := getattr(atts, ATTR_UNIT_OF_MEASUREMENT)) == POWER_WATT:
         return int(round(float(val)))
 
-    return format_measure(val, attrs_uom)
+    return format_measure(val, attr_uom)
 
 
 def remove_empty_platform_dicts(data: GwEntityData) -> None:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name            = "plugwise"
-version         = "1.6.4"
+version         = "1.7.0a0"
 license         = {file = "LICENSE"}
 description     = "Plugwise Smile (Adam/Anna/P1) and Stretch module for Python 3."
 readme          = "README.md"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name            = "plugwise"
-version         = "1.7.0a0"
+version         = "1.7.0a1"
 license         = {file = "LICENSE"}
 description     = "Plugwise Smile (Adam/Anna/P1) and Stretch module for Python 3."
 readme          = "README.md"

--- a/scripts/manual_fixtures.py
+++ b/scripts/manual_fixtures.py
@@ -139,7 +139,7 @@ m_adam_cooling["devices"]["da224107914542988a88561b4452b0f6"][
 m_adam_cooling["devices"]["da224107914542988a88561b4452b0f6"][
     "regulation_modes"
 ].append("cooling")
-m_adam_cooling["devices"]["da224107914542988a88561b4452b0f6"]["sensors"][
+m_adam_cooling["devices"]["da224107914542988a88561b4452b0f6"]["weather"][
     "outdoor_temperature"
 ] = 29.65
 
@@ -220,7 +220,7 @@ m_adam_heating["devices"]["da224107914542988a88561b4452b0f6"][
 m_adam_heating["devices"]["da224107914542988a88561b4452b0f6"][
     "regulation_modes"
 ].remove("cooling")
-m_adam_heating["devices"]["da224107914542988a88561b4452b0f6"]["sensors"][
+m_adam_heating["devices"]["da224107914542988a88561b4452b0f6"]["weather"][
     "outdoor_temperature"
 ] = -1.25
 
@@ -295,7 +295,7 @@ m_anna_heatpump_cooling["devices"]["1cbf783bb11e4a7c8a6843dee3a86927"]["sensors"
 ] = 28.0
 
 # Go for 015a
-m_anna_heatpump_cooling["devices"]["015ae9ea3f964e668e490fa39da3870b"]["sensors"][
+m_anna_heatpump_cooling["devices"]["015ae9ea3f964e668e490fa39da3870b"]["weather"][
     "outdoor_temperature"
 ] = 28.2
 

--- a/scripts/tests_and_coverage.sh
+++ b/scripts/tests_and_coverage.sh
@@ -43,8 +43,7 @@ set +u
 
 if [ -z "${GITHUB_ACTIONS}" ] || [ "$1" == "test_and_coverage" ] ; then
     # Python tests (rerun with debug if failures)
-    # PYTHONPATH=$(pwd) pytest -qx tests/ --cov='.' --no-cov-on-fail --cov-report term-missing || 
-    PYTHONPATH=$(pwd) pytest -xrpP --log-level debug tests/
+    PYTHONPATH=$(pwd) pytest -qx tests/ --cov='.' --no-cov-on-fail --cov-report term-missing || PYTHONPATH=$(pwd) pytest -xrpP --log-level debug tests/
     handle_command_error "python code testing"
 fi
 

--- a/scripts/tests_and_coverage.sh
+++ b/scripts/tests_and_coverage.sh
@@ -43,7 +43,8 @@ set +u
 
 if [ -z "${GITHUB_ACTIONS}" ] || [ "$1" == "test_and_coverage" ] ; then
     # Python tests (rerun with debug if failures)
-    PYTHONPATH=$(pwd) pytest -qx tests/ --cov='.' --no-cov-on-fail --cov-report term-missing || PYTHONPATH=$(pwd) pytest -xrpP --log-level debug tests/
+    # PYTHONPATH=$(pwd) pytest -qx tests/ --cov='.' --no-cov-on-fail --cov-report term-missing || 
+    PYTHONPATH=$(pwd) pytest -xrpP --log-level debug tests/
     handle_command_error "python code testing"
 fi
 

--- a/tests/data/adam/adam_heatpump_cooling.json
+++ b/tests/data/adam/adam_heatpump_cooling.json
@@ -305,10 +305,15 @@
       ],
       "select_gateway_mode": "full",
       "select_regulation_mode": "cooling",
-      "sensors": {
-        "outdoor_temperature": 13.4
-      },
       "vendor": "Plugwise",
+      "weather": {
+        "humidity": 88,
+        "outdoor_temperature": 13.4,
+        "solar_irradiance": 208.2,
+        "weather_description": "clouded",
+        "wind_bearing": 228.0,
+        "wind_speed": 1.79
+      },
       "zigbee_mac_address": "ABCD012345670101"
     },
     "7fda9f84f01342f8afe9ebbbbff30c0f": {

--- a/tests/data/adam/adam_heatpump_cooling.json
+++ b/tests/data/adam/adam_heatpump_cooling.json
@@ -305,11 +305,13 @@
       ],
       "select_gateway_mode": "full",
       "select_regulation_mode": "cooling",
+      "sensors": {
+        "solar_irradiance": 208.2
+      },
       "vendor": "Plugwise",
       "weather": {
         "humidity": 88,
         "outdoor_temperature": 13.4,
-        "solar_irradiance": 208.2,
         "weather_description": "clouded",
         "wind_bearing": 228.0,
         "wind_speed": 1.79

--- a/tests/data/adam/adam_jip.json
+++ b/tests/data/adam/adam_jip.json
@@ -225,10 +225,15 @@
       "regulation_modes": ["heating", "off", "bleeding_cold", "bleeding_hot"],
       "select_gateway_mode": "full",
       "select_regulation_mode": "heating",
-      "sensors": {
-        "outdoor_temperature": 24.9
-      },
       "vendor": "Plugwise",
+      "weather": {
+        "humidity": 68,
+        "outdoor_temperature": 24.9,
+        "solar_irradiance": 449.2,
+        "weather_description": "overcast",
+        "wind_bearing": 216.0,
+        "wind_speed": 2.68
+      },
       "zigbee_mac_address": "ABCD012345670101"
     },
     "d27aede973b54be484f6842d1b2802ad": {

--- a/tests/data/adam/adam_jip.json
+++ b/tests/data/adam/adam_jip.json
@@ -225,11 +225,13 @@
       "regulation_modes": ["heating", "off", "bleeding_cold", "bleeding_hot"],
       "select_gateway_mode": "full",
       "select_regulation_mode": "heating",
+      "sensors": {
+        "solar_irradiance": 449.2
+      },
       "vendor": "Plugwise",
       "weather": {
         "humidity": 68,
         "outdoor_temperature": 24.9,
-        "solar_irradiance": 449.2,
         "weather_description": "overcast",
         "wind_bearing": 216.0,
         "wind_speed": 2.68

--- a/tests/data/adam/adam_multiple_devices_per_zone.json
+++ b/tests/data/adam/adam_multiple_devices_per_zone.json
@@ -580,10 +580,15 @@
       "model_id": "smile_open_therm",
       "name": "Adam",
       "select_regulation_mode": "heating",
-      "sensors": {
-        "outdoor_temperature": 7.81
-      },
       "vendor": "Plugwise",
+      "weather": {
+        "humidity": 75,
+        "outdoor_temperature": 7.81,
+        "solar_irradiance": 157.5,
+        "weather_description": "cloudy",
+        "wind_bearing": 40.0,
+        "wind_speed": 8.2
+      },
       "zigbee_mac_address": "ABCD012345670101"
     }
   }

--- a/tests/data/adam/adam_multiple_devices_per_zone.json
+++ b/tests/data/adam/adam_multiple_devices_per_zone.json
@@ -580,11 +580,13 @@
       "model_id": "smile_open_therm",
       "name": "Adam",
       "select_regulation_mode": "heating",
+      "sensors": {
+        "solar_irradiance": 157.5
+      },
       "vendor": "Plugwise",
       "weather": {
         "humidity": 75,
         "outdoor_temperature": 7.81,
-        "solar_irradiance": 157.5,
         "weather_description": "cloudy",
         "wind_bearing": 40.0,
         "wind_speed": 8.2

--- a/tests/data/adam/adam_onoff_cooling_fake_firmware.json
+++ b/tests/data/adam/adam_onoff_cooling_fake_firmware.json
@@ -59,10 +59,15 @@
       ],
       "select_gateway_mode": "full",
       "select_regulation_mode": "cooling",
-      "sensors": {
-        "outdoor_temperature": 13.4
-      },
       "vendor": "Plugwise",
+      "weather": {
+        "humidity": 88,
+        "outdoor_temperature": 13.4,
+        "solar_irradiance": 208.2,
+        "weather_description": "clouded",
+        "wind_bearing": 228.0,
+        "wind_speed": 1.79
+      },
       "zigbee_mac_address": "ABCD012345670101"
     },
     "ca79d23ae0094120b877558734cff85c": {

--- a/tests/data/adam/adam_onoff_cooling_fake_firmware.json
+++ b/tests/data/adam/adam_onoff_cooling_fake_firmware.json
@@ -59,11 +59,13 @@
       ],
       "select_gateway_mode": "full",
       "select_regulation_mode": "cooling",
+      "sensors": {
+        "solar_irradiance": 208.2
+      },
       "vendor": "Plugwise",
       "weather": {
         "humidity": 88,
         "outdoor_temperature": 13.4,
-        "solar_irradiance": 208.2,
         "weather_description": "clouded",
         "wind_bearing": 228.0,
         "wind_speed": 1.79

--- a/tests/data/adam/adam_plus_anna.json
+++ b/tests/data/adam/adam_plus_anna.json
@@ -86,11 +86,13 @@
       "model_id": "smile_open_therm",
       "name": "Adam",
       "select_regulation_mode": "heating",
+      "sensors": {
+        "solar_irradiance": 53.8
+      },
       "vendor": "Plugwise",
       "weather": {
         "humidity": 58,
         "outdoor_temperature": 11.9,
-        "solar_irradiance": 53.8,
         "weather_description": "overcast",
         "wind_bearing": 220.0,
         "wind_speed": 2.6

--- a/tests/data/adam/adam_plus_anna.json
+++ b/tests/data/adam/adam_plus_anna.json
@@ -86,10 +86,15 @@
       "model_id": "smile_open_therm",
       "name": "Adam",
       "select_regulation_mode": "heating",
-      "sensors": {
-        "outdoor_temperature": 11.9
-      },
       "vendor": "Plugwise",
+      "weather": {
+        "humidity": 58,
+        "outdoor_temperature": 11.9,
+        "solar_irradiance": 53.8,
+        "weather_description": "overcast",
+        "wind_bearing": 220.0,
+        "wind_speed": 2.6
+      },
       "zigbee_mac_address": "ABCD012345670101"
     },
     "ee62cad889f94e8ca3d09021f03a660b": {

--- a/tests/data/adam/adam_plus_anna_new.json
+++ b/tests/data/adam/adam_plus_anna_new.json
@@ -172,10 +172,15 @@
       "regulation_modes": ["bleeding_hot", "bleeding_cold", "off", "heating"],
       "select_gateway_mode": "full",
       "select_regulation_mode": "heating",
-      "sensors": {
-        "outdoor_temperature": 9.19
-      },
       "vendor": "Plugwise",
+      "weather": {
+        "humidity": 90,
+        "outdoor_temperature": 9.19,
+        "solar_irradiance": 3.0,
+        "weather_description": "rain",
+        "wind_bearing": 291.0,
+        "wind_speed": 6.26
+      },
       "zigbee_mac_address": "000D6F000D5A168D"
     },
     "e2f4322d57924fa090fbbc48b3a140dc": {

--- a/tests/data/adam/adam_plus_anna_new.json
+++ b/tests/data/adam/adam_plus_anna_new.json
@@ -172,11 +172,13 @@
       "regulation_modes": ["bleeding_hot", "bleeding_cold", "off", "heating"],
       "select_gateway_mode": "full",
       "select_regulation_mode": "heating",
+      "sensors": {
+        "solar_irradiance": 3.0
+      },
       "vendor": "Plugwise",
       "weather": {
         "humidity": 90,
         "outdoor_temperature": 9.19,
-        "solar_irradiance": 3.0,
         "weather_description": "rain",
         "wind_bearing": 291.0,
         "wind_speed": 6.26

--- a/tests/data/adam/adam_plus_anna_new_regulation_off.json
+++ b/tests/data/adam/adam_plus_anna_new_regulation_off.json
@@ -172,10 +172,15 @@
       "regulation_modes": ["bleeding_hot", "bleeding_cold", "off", "heating"],
       "select_gateway_mode": "full",
       "select_regulation_mode": "off",
-      "sensors": {
-        "outdoor_temperature": 9.19
-      },
       "vendor": "Plugwise",
+      "weather": {
+        "humidity": 90,
+        "outdoor_temperature": 9.19,
+        "solar_irradiance": 3.0,
+        "weather_description": "rain",
+        "wind_bearing": 291.0,
+        "wind_speed": 6.26
+      },
       "zigbee_mac_address": "000D6F000D5A168D"
     },
     "e2f4322d57924fa090fbbc48b3a140dc": {

--- a/tests/data/adam/adam_plus_anna_new_regulation_off.json
+++ b/tests/data/adam/adam_plus_anna_new_regulation_off.json
@@ -172,11 +172,13 @@
       "regulation_modes": ["bleeding_hot", "bleeding_cold", "off", "heating"],
       "select_gateway_mode": "full",
       "select_regulation_mode": "off",
+      "sensors": {
+        "solar_irradiance": 3.0
+      },
       "vendor": "Plugwise",
       "weather": {
         "humidity": 90,
         "outdoor_temperature": 9.19,
-        "solar_irradiance": 3.0,
         "weather_description": "rain",
         "wind_bearing": 291.0,
         "wind_speed": 6.26

--- a/tests/data/adam/adam_zone_per_device.json
+++ b/tests/data/adam/adam_zone_per_device.json
@@ -577,10 +577,15 @@
       "model_id": "smile_open_therm",
       "name": "Adam",
       "select_regulation_mode": "heating",
-      "sensors": {
-        "outdoor_temperature": 7.69
-      },
       "vendor": "Plugwise",
+      "weather": {
+        "humidity": 70,
+        "outdoor_temperature": 7.69,
+        "solar_irradiance": 86.2,
+        "weather_description": "cloudy",
+        "wind_bearing": 40.0,
+        "wind_speed": 7.2
+      },
       "zigbee_mac_address": "ABCD012345670101"
     }
   }

--- a/tests/data/adam/adam_zone_per_device.json
+++ b/tests/data/adam/adam_zone_per_device.json
@@ -577,11 +577,13 @@
       "model_id": "smile_open_therm",
       "name": "Adam",
       "select_regulation_mode": "heating",
+      "sensors": {
+        "solar_irradiance": 86.2
+      },
       "vendor": "Plugwise",
       "weather": {
         "humidity": 70,
         "outdoor_temperature": 7.69,
-        "solar_irradiance": 86.2,
         "weather_description": "cloudy",
         "wind_bearing": 40.0,
         "wind_speed": 7.2

--- a/tests/data/anna/anna_elga_2.json
+++ b/tests/data/anna/anna_elga_2.json
@@ -83,11 +83,13 @@
       "model": "Gateway",
       "model_id": "smile_thermo",
       "name": "Smile Anna",
+      "sensors": {
+        "solar_irradiance": 0.0
+      },
       "vendor": "Plugwise",
       "weather": {
         "humidity": 42,
         "outdoor_temperature": 13.0,
-        "solar_irradiance": 0.0,
         "weather_description": "cloudy",
         "wind_bearing": 120.0,
         "wind_speed": 3.6

--- a/tests/data/anna/anna_elga_2.json
+++ b/tests/data/anna/anna_elga_2.json
@@ -83,10 +83,15 @@
       "model": "Gateway",
       "model_id": "smile_thermo",
       "name": "Smile Anna",
-      "sensors": {
-        "outdoor_temperature": 13.0
-      },
-      "vendor": "Plugwise"
+      "vendor": "Plugwise",
+      "weather": {
+        "humidity": 42,
+        "outdoor_temperature": 13.0,
+        "solar_irradiance": 0.0,
+        "weather_description": "cloudy",
+        "wind_bearing": 120.0,
+        "wind_speed": 3.6
+      }
     }
   }
 }

--- a/tests/data/anna/anna_elga_2_cooling.json
+++ b/tests/data/anna/anna_elga_2_cooling.json
@@ -83,11 +83,13 @@
       "model": "Gateway",
       "model_id": "smile_thermo",
       "name": "Smile Anna",
+      "sensors": {
+        "solar_irradiance": 0.0
+      },
       "vendor": "Plugwise",
       "weather": {
         "humidity": 42,
         "outdoor_temperature": 31.0,
-        "solar_irradiance": 0.0,
         "weather_description": "cloudy",
         "wind_bearing": 120.0,
         "wind_speed": 3.6

--- a/tests/data/anna/anna_elga_2_cooling.json
+++ b/tests/data/anna/anna_elga_2_cooling.json
@@ -83,10 +83,15 @@
       "model": "Gateway",
       "model_id": "smile_thermo",
       "name": "Smile Anna",
-      "sensors": {
-        "outdoor_temperature": 31.0
-      },
-      "vendor": "Plugwise"
+      "vendor": "Plugwise",
+      "weather": {
+        "humidity": 42,
+        "outdoor_temperature": 31.0,
+        "solar_irradiance": 0.0,
+        "weather_description": "cloudy",
+        "wind_bearing": 120.0,
+        "wind_speed": 3.6
+      }
     }
   }
 }

--- a/tests/data/anna/anna_elga_2_cooling_UPDATED_DATA.json
+++ b/tests/data/anna/anna_elga_2_cooling_UPDATED_DATA.json
@@ -83,10 +83,15 @@
       "model": "Gateway",
       "model_id": "smile_thermo",
       "name": "Smile Anna",
-      "sensors": {
-        "outdoor_temperature": 3.0
-      },
-      "vendor": "Plugwise"
+      "vendor": "Plugwise",
+      "weather": {
+        "humidity": 42,
+        "outdoor_temperature": 3.0,
+        "solar_irradiance": 0.0,
+        "weather_description": "cloudy",
+        "wind_bearing": 120.0,
+        "wind_speed": 3.6
+      }
     }
   }
 }

--- a/tests/data/anna/anna_elga_2_cooling_UPDATED_DATA.json
+++ b/tests/data/anna/anna_elga_2_cooling_UPDATED_DATA.json
@@ -83,11 +83,13 @@
       "model": "Gateway",
       "model_id": "smile_thermo",
       "name": "Smile Anna",
+      "sensors": {
+        "solar_irradiance": 0.0
+      },
       "vendor": "Plugwise",
       "weather": {
         "humidity": 42,
         "outdoor_temperature": 3.0,
-        "solar_irradiance": 0.0,
         "weather_description": "cloudy",
         "wind_bearing": 120.0,
         "wind_speed": 3.6

--- a/tests/data/anna/anna_elga_2_schedule_off.json
+++ b/tests/data/anna/anna_elga_2_schedule_off.json
@@ -83,11 +83,13 @@
       "model": "Gateway",
       "model_id": "smile_thermo",
       "name": "Smile Anna",
+      "sensors": {
+        "solar_irradiance": 0.0
+      },
       "vendor": "Plugwise",
       "weather": {
         "humidity": 42,
         "outdoor_temperature": 13.0,
-        "solar_irradiance": 0.0,
         "weather_description": "cloudy",
         "wind_bearing": 120.0,
         "wind_speed": 3.6

--- a/tests/data/anna/anna_elga_2_schedule_off.json
+++ b/tests/data/anna/anna_elga_2_schedule_off.json
@@ -83,10 +83,15 @@
       "model": "Gateway",
       "model_id": "smile_thermo",
       "name": "Smile Anna",
-      "sensors": {
-        "outdoor_temperature": 13.0
-      },
-      "vendor": "Plugwise"
+      "vendor": "Plugwise",
+      "weather": {
+        "humidity": 42,
+        "outdoor_temperature": 13.0,
+        "solar_irradiance": 0.0,
+        "weather_description": "cloudy",
+        "wind_bearing": 120.0,
+        "wind_speed": 3.6
+      }
     }
   }
 }

--- a/tests/data/anna/anna_elga_no_cooling.json
+++ b/tests/data/anna/anna_elga_no_cooling.json
@@ -12,10 +12,15 @@
       "model": "Gateway",
       "model_id": "smile_thermo",
       "name": "Smile Anna",
-      "sensors": {
-        "outdoor_temperature": 20.2
-      },
-      "vendor": "Plugwise"
+      "vendor": "Plugwise",
+      "weather": {
+        "humidity": 42,
+        "outdoor_temperature": 20.2,
+        "solar_irradiance": 653.6,
+        "weather_description": "clear",
+        "wind_bearing": 50.0,
+        "wind_speed": 4.1
+      }
     },
     "1cbf783bb11e4a7c8a6843dee3a86927": {
       "available": true,

--- a/tests/data/anna/anna_elga_no_cooling.json
+++ b/tests/data/anna/anna_elga_no_cooling.json
@@ -12,11 +12,13 @@
       "model": "Gateway",
       "model_id": "smile_thermo",
       "name": "Smile Anna",
+      "sensors": {
+        "solar_irradiance": 653.6
+      },
       "vendor": "Plugwise",
       "weather": {
         "humidity": 42,
         "outdoor_temperature": 20.2,
-        "solar_irradiance": 653.6,
         "weather_description": "clear",
         "wind_bearing": 50.0,
         "wind_speed": 4.1

--- a/tests/data/anna/anna_heatpump_cooling.json
+++ b/tests/data/anna/anna_heatpump_cooling.json
@@ -12,11 +12,13 @@
       "model": "Gateway",
       "model_id": "smile_thermo",
       "name": "Smile Anna",
+      "sensors": {
+        "solar_irradiance": 207.2
+      },
       "vendor": "Plugwise",
       "weather": {
         "humidity": 35,
         "outdoor_temperature": 22.0,
-        "solar_irradiance": 207.2,
         "weather_description": "overcast",
         "wind_bearing": 0.0,
         "wind_speed": 2.1

--- a/tests/data/anna/anna_heatpump_cooling.json
+++ b/tests/data/anna/anna_heatpump_cooling.json
@@ -12,10 +12,15 @@
       "model": "Gateway",
       "model_id": "smile_thermo",
       "name": "Smile Anna",
-      "sensors": {
-        "outdoor_temperature": 22.0
-      },
-      "vendor": "Plugwise"
+      "vendor": "Plugwise",
+      "weather": {
+        "humidity": 35,
+        "outdoor_temperature": 22.0,
+        "solar_irradiance": 207.2,
+        "weather_description": "overcast",
+        "wind_bearing": 0.0,
+        "wind_speed": 2.1
+      }
     },
     "1cbf783bb11e4a7c8a6843dee3a86927": {
       "available": true,

--- a/tests/data/anna/anna_heatpump_cooling_fake_firmware.json
+++ b/tests/data/anna/anna_heatpump_cooling_fake_firmware.json
@@ -12,11 +12,13 @@
       "model": "Gateway",
       "model_id": "smile_thermo",
       "name": "Smile Anna",
+      "sensors": {
+        "solar_irradiance": 207.2
+      },
       "vendor": "Plugwise",
       "weather": {
         "humidity": 35,
         "outdoor_temperature": 22.0,
-        "solar_irradiance": 207.2,
         "weather_description": "overcast",
         "wind_bearing": 0.0,
         "wind_speed": 2.1

--- a/tests/data/anna/anna_heatpump_cooling_fake_firmware.json
+++ b/tests/data/anna/anna_heatpump_cooling_fake_firmware.json
@@ -12,10 +12,15 @@
       "model": "Gateway",
       "model_id": "smile_thermo",
       "name": "Smile Anna",
-      "sensors": {
-        "outdoor_temperature": 22.0
-      },
-      "vendor": "Plugwise"
+      "vendor": "Plugwise",
+      "weather": {
+        "humidity": 35,
+        "outdoor_temperature": 22.0,
+        "solar_irradiance": 207.2,
+        "weather_description": "overcast",
+        "wind_bearing": 0.0,
+        "wind_speed": 2.1
+      }
     },
     "1cbf783bb11e4a7c8a6843dee3a86927": {
       "available": true,

--- a/tests/data/anna/anna_heatpump_heating.json
+++ b/tests/data/anna/anna_heatpump_heating.json
@@ -12,10 +12,15 @@
       "model": "Gateway",
       "model_id": "smile_thermo",
       "name": "Smile Anna",
-      "sensors": {
-        "outdoor_temperature": 20.2
-      },
-      "vendor": "Plugwise"
+      "vendor": "Plugwise",
+      "weather": {
+        "humidity": 42,
+        "outdoor_temperature": 20.2,
+        "solar_irradiance": 653.6,
+        "weather_description": "clear",
+        "wind_bearing": 50.0,
+        "wind_speed": 4.1
+      }
     },
     "1cbf783bb11e4a7c8a6843dee3a86927": {
       "available": true,

--- a/tests/data/anna/anna_heatpump_heating.json
+++ b/tests/data/anna/anna_heatpump_heating.json
@@ -12,11 +12,13 @@
       "model": "Gateway",
       "model_id": "smile_thermo",
       "name": "Smile Anna",
+      "sensors": {
+        "solar_irradiance": 653.6
+      },
       "vendor": "Plugwise",
       "weather": {
         "humidity": 42,
         "outdoor_temperature": 20.2,
-        "solar_irradiance": 653.6,
         "weather_description": "clear",
         "wind_bearing": 50.0,
         "wind_speed": 4.1

--- a/tests/data/anna/anna_loria_cooling_active.json
+++ b/tests/data/anna/anna_loria_cooling_active.json
@@ -46,10 +46,15 @@
       "model": "Gateway",
       "model_id": "smile_thermo",
       "name": "Smile Anna",
-      "sensors": {
-        "outdoor_temperature": 15.5
-      },
-      "vendor": "Plugwise"
+      "vendor": "Plugwise",
+      "weather": {
+        "humidity": 65,
+        "outdoor_temperature": 15.5,
+        "solar_irradiance": 84.7,
+        "weather_description": "overcast",
+        "wind_bearing": 289.0,
+        "wind_speed": 2.2
+      }
     },
     "bfb5ee0a88e14e5f97bfa725a760cc49": {
       "available": true,

--- a/tests/data/anna/anna_loria_cooling_active.json
+++ b/tests/data/anna/anna_loria_cooling_active.json
@@ -46,11 +46,13 @@
       "model": "Gateway",
       "model_id": "smile_thermo",
       "name": "Smile Anna",
+      "sensors": {
+        "solar_irradiance": 84.7
+      },
       "vendor": "Plugwise",
       "weather": {
         "humidity": 65,
         "outdoor_temperature": 15.5,
-        "solar_irradiance": 84.7,
         "weather_description": "overcast",
         "wind_bearing": 289.0,
         "wind_speed": 2.2

--- a/tests/data/anna/anna_loria_driessens.json
+++ b/tests/data/anna/anna_loria_driessens.json
@@ -12,10 +12,15 @@
       "model": "Gateway",
       "model_id": "smile_thermo",
       "name": "Smile Anna",
-      "sensors": {
-        "outdoor_temperature": 6.81
-      },
-      "vendor": "Plugwise"
+      "vendor": "Plugwise",
+      "weather": {
+        "humidity": 88,
+        "outdoor_temperature": 6.81,
+        "solar_irradiance": 97.6,
+        "weather_description": "clouded",
+        "wind_bearing": 230.0,
+        "wind_speed": 4.12
+      }
     },
     "9fb768d699e44c7fb5cc50309dc4e7d4": {
       "active_preset": "home",

--- a/tests/data/anna/anna_loria_driessens.json
+++ b/tests/data/anna/anna_loria_driessens.json
@@ -12,11 +12,13 @@
       "model": "Gateway",
       "model_id": "smile_thermo",
       "name": "Smile Anna",
+      "sensors": {
+        "solar_irradiance": 97.6
+      },
       "vendor": "Plugwise",
       "weather": {
         "humidity": 88,
         "outdoor_temperature": 6.81,
-        "solar_irradiance": 97.6,
         "weather_description": "clouded",
         "wind_bearing": 230.0,
         "wind_speed": 4.12

--- a/tests/data/anna/anna_loria_heating_idle.json
+++ b/tests/data/anna/anna_loria_heating_idle.json
@@ -46,10 +46,15 @@
       "model": "Gateway",
       "model_id": "smile_thermo",
       "name": "Smile Anna",
-      "sensors": {
-        "outdoor_temperature": 15.5
-      },
-      "vendor": "Plugwise"
+      "vendor": "Plugwise",
+      "weather": {
+        "humidity": 65,
+        "outdoor_temperature": 15.5,
+        "solar_irradiance": 84.7,
+        "weather_description": "overcast",
+        "wind_bearing": 289.0,
+        "wind_speed": 2.2
+      }
     },
     "bfb5ee0a88e14e5f97bfa725a760cc49": {
       "available": true,

--- a/tests/data/anna/anna_loria_heating_idle.json
+++ b/tests/data/anna/anna_loria_heating_idle.json
@@ -46,11 +46,13 @@
       "model": "Gateway",
       "model_id": "smile_thermo",
       "name": "Smile Anna",
+      "sensors": {
+        "solar_irradiance": 84.7
+      },
       "vendor": "Plugwise",
       "weather": {
         "humidity": 65,
         "outdoor_temperature": 15.5,
-        "solar_irradiance": 84.7,
         "weather_description": "overcast",
         "wind_bearing": 289.0,
         "wind_speed": 2.2

--- a/tests/data/anna/anna_v4.json
+++ b/tests/data/anna/anna_v4.json
@@ -44,10 +44,15 @@
       "model": "Gateway",
       "model_id": "smile_thermo",
       "name": "Smile Anna",
-      "sensors": {
-        "outdoor_temperature": 7.44
-      },
-      "vendor": "Plugwise"
+      "vendor": "Plugwise",
+      "weather": {
+        "humidity": 81,
+        "outdoor_temperature": 7.44,
+        "solar_irradiance": 449.4,
+        "weather_description": "clear",
+        "wind_bearing": 240.0,
+        "wind_speed": 3.6
+      }
     },
     "cd0e6156b1f04d5f952349ffbe397481": {
       "available": true,

--- a/tests/data/anna/anna_v4.json
+++ b/tests/data/anna/anna_v4.json
@@ -44,11 +44,13 @@
       "model": "Gateway",
       "model_id": "smile_thermo",
       "name": "Smile Anna",
+      "sensors": {
+        "solar_irradiance": 449.4
+      },
       "vendor": "Plugwise",
       "weather": {
         "humidity": 81,
         "outdoor_temperature": 7.44,
-        "solar_irradiance": 449.4,
         "weather_description": "clear",
         "wind_bearing": 240.0,
         "wind_speed": 3.6

--- a/tests/data/anna/anna_v4_UPDATED_DATA.json
+++ b/tests/data/anna/anna_v4_UPDATED_DATA.json
@@ -47,10 +47,12 @@
       }
     },
     "0466eae8520144c78afb29628384edeb": {
+      "sensors": {
+        "solar_irradiance": 449.4
+      },
       "weather": {
         "humidity": 81,
         "outdoor_temperature": 6.44,
-        "solar_irradiance": 449.4,
         "weather_description": "clear",
         "wind_bearing": 240.0,
         "wind_speed": 3.6

--- a/tests/data/anna/anna_v4_UPDATED_DATA.json
+++ b/tests/data/anna/anna_v4_UPDATED_DATA.json
@@ -47,8 +47,13 @@
       }
     },
     "0466eae8520144c78afb29628384edeb": {
-      "sensors": {
-        "outdoor_temperature": 6.44
+      "weather": {
+        "humidity": 81,
+        "outdoor_temperature": 6.44,
+        "solar_irradiance": 449.4,
+        "weather_description": "clear",
+        "wind_bearing": 240.0,
+        "wind_speed": 3.6
       }
     }
   }

--- a/tests/data/anna/anna_v4_dhw.json
+++ b/tests/data/anna/anna_v4_dhw.json
@@ -44,10 +44,15 @@
       "model": "Gateway",
       "model_id": "smile_thermo",
       "name": "Smile Anna",
-      "sensors": {
-        "outdoor_temperature": 7.44
-      },
-      "vendor": "Plugwise"
+      "vendor": "Plugwise",
+      "weather": {
+        "humidity": 81,
+        "outdoor_temperature": 7.44,
+        "solar_irradiance": 449.4,
+        "weather_description": "clear",
+        "wind_bearing": 240.0,
+        "wind_speed": 3.6
+      }
     },
     "cd0e6156b1f04d5f952349ffbe397481": {
       "available": true,

--- a/tests/data/anna/anna_v4_dhw.json
+++ b/tests/data/anna/anna_v4_dhw.json
@@ -44,11 +44,13 @@
       "model": "Gateway",
       "model_id": "smile_thermo",
       "name": "Smile Anna",
+      "sensors": {
+        "solar_irradiance": 449.4
+      },
       "vendor": "Plugwise",
       "weather": {
         "humidity": 81,
         "outdoor_temperature": 7.44,
-        "solar_irradiance": 449.4,
         "weather_description": "clear",
         "wind_bearing": 240.0,
         "wind_speed": 3.6

--- a/tests/data/anna/anna_v4_no_tag.json
+++ b/tests/data/anna/anna_v4_no_tag.json
@@ -44,10 +44,15 @@
       "model": "Gateway",
       "model_id": "smile_thermo",
       "name": "Smile Anna",
-      "sensors": {
-        "outdoor_temperature": 7.44
-      },
-      "vendor": "Plugwise"
+      "vendor": "Plugwise",
+      "weather": {
+        "humidity": 81,
+        "outdoor_temperature": 7.44,
+        "solar_irradiance": 449.4,
+        "weather_description": "clear",
+        "wind_bearing": 240.0,
+        "wind_speed": 3.6
+      }
     },
     "cd0e6156b1f04d5f952349ffbe397481": {
       "available": true,

--- a/tests/data/anna/anna_v4_no_tag.json
+++ b/tests/data/anna/anna_v4_no_tag.json
@@ -44,11 +44,13 @@
       "model": "Gateway",
       "model_id": "smile_thermo",
       "name": "Smile Anna",
+      "sensors": {
+        "solar_irradiance": 449.4
+      },
       "vendor": "Plugwise",
       "weather": {
         "humidity": 81,
         "outdoor_temperature": 7.44,
-        "solar_irradiance": 449.4,
         "weather_description": "clear",
         "wind_bearing": 240.0,
         "wind_speed": 3.6

--- a/tests/data/anna/anna_without_boiler_fw441.json
+++ b/tests/data/anna/anna_without_boiler_fw441.json
@@ -44,11 +44,13 @@
       "model": "Gateway",
       "model_id": "smile_thermo",
       "name": "Smile Anna",
+      "sensors": {
+        "solar_irradiance": 0.0
+      },
       "vendor": "Plugwise",
       "weather": {
         "humidity": 91,
         "outdoor_temperature": 8.31,
-        "solar_irradiance": 0.0,
         "weather_description": "rain",
         "wind_bearing": 208.0,
         "wind_speed": 6.77

--- a/tests/data/anna/anna_without_boiler_fw441.json
+++ b/tests/data/anna/anna_without_boiler_fw441.json
@@ -44,10 +44,15 @@
       "model": "Gateway",
       "model_id": "smile_thermo",
       "name": "Smile Anna",
-      "sensors": {
-        "outdoor_temperature": 8.31
-      },
-      "vendor": "Plugwise"
+      "vendor": "Plugwise",
+      "weather": {
+        "humidity": 91,
+        "outdoor_temperature": 8.31,
+        "solar_irradiance": 0.0,
+        "weather_description": "rain",
+        "wind_bearing": 208.0,
+        "wind_speed": 6.77
+      }
     },
     "c46b4794d28149699eacf053deedd003": {
       "binary_sensors": {

--- a/tests/test_adam.py
+++ b/tests/test_adam.py
@@ -36,7 +36,7 @@ class TestPlugwiseAdam(TestPlugwise):  # pylint: disable=attribute-defined-outsi
         assert smile.gateway_id == "da224107914542988a88561b4452b0f6"
         assert smile._last_active["f2bf9048bef64cc5b6d5110154e33c81"] == "Weekschema"
         assert smile._last_active["f871b8c4d63549319221e294e4f88074"] == "Badkamer"
-        assert self.entity_items == 177
+        assert self.entity_items == 182
         assert self.entity_list == [
             "da224107914542988a88561b4452b0f6",
             "056ee145a816487eaa69243c3280f8bf",
@@ -207,7 +207,7 @@ class TestPlugwiseAdam(TestPlugwise):  # pylint: disable=attribute-defined-outsi
         assert smile._last_active["82fa13f017d240daa0d0ea1775420f24"] == CV_JESSIE
         assert smile._last_active["08963fec7c53423ca5680aa4cb502c63"] == BADKAMER_SCHEMA
         assert smile._last_active["446ac08dd04d4eff8ac57489757b7314"] == BADKAMER_SCHEMA
-        assert self.entity_items == 369
+        assert self.entity_items == 374
 
         assert "af82e4ccf9c548528166d38e560662a4" in self.notifications
         await smile.delete_notification()
@@ -287,7 +287,7 @@ class TestPlugwiseAdam(TestPlugwise):  # pylint: disable=attribute-defined-outsi
         assert smile._last_active["82fa13f017d240daa0d0ea1775420f24"] == CV_JESSIE
         assert smile._last_active["08963fec7c53423ca5680aa4cb502c63"] == BADKAMER_SCHEMA
         assert smile._last_active["446ac08dd04d4eff8ac57489757b7314"] == BADKAMER_SCHEMA
-        assert self.entity_items == 369
+        assert self.entity_items == 374
 
         assert "af82e4ccf9c548528166d38e560662a4" in self.notifications
 
@@ -325,7 +325,7 @@ class TestPlugwiseAdam(TestPlugwise):  # pylint: disable=attribute-defined-outsi
         assert smile._last_active["a562019b0b1f47a4bde8ebe3dbe3e8a9"] == WERKDAG_SCHEMA
         assert smile._last_active["8cf650a4c10c44819e426bed406aec34"] == WERKDAG_SCHEMA
         assert smile._last_active["5cc21042f87f4b4c94ccb5537c47a53f"] == WERKDAG_SCHEMA
-        assert self.entity_items == 497
+        assert self.entity_items == 502
         assert self.cooling_present
         assert self._cooling_enabled
 
@@ -348,7 +348,7 @@ class TestPlugwiseAdam(TestPlugwise):  # pylint: disable=attribute-defined-outsi
         )
 
         await self.device_test(smile, "2022-01-02 00:00:01", testdata)
-        assert self.entity_items == 64
+        assert self.entity_items == 69
         assert self.cooling_present
         # assert self._cooling_enabled - no cooling_enabled indication present
 
@@ -373,7 +373,7 @@ class TestPlugwiseAdam(TestPlugwise):  # pylint: disable=attribute-defined-outsi
         await self.device_test(smile, "2020-03-22 00:00:01", testdata)
         assert smile.gateway_id == "b128b4bbbd1f47e9bf4d756e8fb5ee94"
         assert smile._last_active["009490cc2f674ce6b576863fbb64f867"] == "Weekschema"
-        assert self.entity_items == 80
+        assert self.entity_items == 85
         assert "6fb89e35caeb4b1cb275184895202d84" in self.notifications
 
         result = await self.tinker_thermostat(
@@ -419,7 +419,7 @@ class TestPlugwiseAdam(TestPlugwise):  # pylint: disable=attribute-defined-outsi
         assert smile._last_active["06aecb3d00354375924f50c47af36bd2"] is None
         assert smile._last_active["d27aede973b54be484f6842d1b2802ad"] is None
         assert smile._last_active["13228dab8ce04617af318a2888b3c548"] is None
-        assert self.entity_items == 244
+        assert self.entity_items == 249
 
         # Negative test
         result = await self.tinker_thermostat(

--- a/tests/test_anna.py
+++ b/tests/test_anna.py
@@ -30,7 +30,7 @@ class TestPlugwiseAnna(TestPlugwise):  # pylint: disable=attribute-defined-outsi
         await self.device_test(smile, "2020-04-05 00:00:01", testdata)
         assert smile.gateway_id == "0466eae8520144c78afb29628384edeb"
         assert smile._last_active["eb5309212bf5407bb143e5bfa3b18aee"] == "Standaard"
-        assert self.entity_items == 58
+        assert self.entity_items == 63
         assert not self.notifications
 
         assert not self.cooling_present
@@ -109,7 +109,7 @@ class TestPlugwiseAnna(TestPlugwise):  # pylint: disable=attribute-defined-outsi
 
         await self.device_test(smile, "2020-04-05 00:00:01", testdata)
         assert smile._last_active["eb5309212bf5407bb143e5bfa3b18aee"] == "Standaard"
-        assert self.entity_items == 58
+        assert self.entity_items == 63
         assert not self.notifications
 
         result = await self.tinker_thermostat(
@@ -138,7 +138,7 @@ class TestPlugwiseAnna(TestPlugwise):  # pylint: disable=attribute-defined-outsi
         )
 
         await self.device_test(smile, "2020-04-05 00:00:01", testdata)
-        assert self.entity_items == 58
+        assert self.entity_items == 63
 
         result = await self.tinker_thermostat(
             smile,
@@ -167,7 +167,7 @@ class TestPlugwiseAnna(TestPlugwise):  # pylint: disable=attribute-defined-outsi
 
         await self.device_test(smile, "2022-05-16 00:00:01", testdata)
         assert smile._last_active["c34c6864216446528e95d88985e714cc"] == "Normaal"
-        assert self.entity_items == 39
+        assert self.entity_items == 44
         assert not self.notifications
 
         result = await self.tinker_thermostat(
@@ -196,7 +196,7 @@ class TestPlugwiseAnna(TestPlugwise):  # pylint: disable=attribute-defined-outsi
         await self.device_test(smile, "2020-04-12 00:00:01", testdata)
         assert smile.gateway_id == "015ae9ea3f964e668e490fa39da3870b"
         assert smile._last_active["c784ee9fdab44e1395b8dee7d7a497d5"] == "standaard"
-        assert self.entity_items == 67
+        assert self.entity_items == 72
         assert not self.notifications
         assert self.cooling_present
         assert not self._cooling_enabled
@@ -226,7 +226,7 @@ class TestPlugwiseAnna(TestPlugwise):  # pylint: disable=attribute-defined-outsi
         await self.device_test(
             smile, "2020-04-13 00:00:01", testdata_updated, initialize=False
         )
-        assert self.entity_items == 64
+        assert self.entity_items == 69
         await smile.close_connection()
         await self.disconnect(server, client)
 
@@ -252,7 +252,7 @@ class TestPlugwiseAnna(TestPlugwise):  # pylint: disable=attribute-defined-outsi
 
         await self.device_test(smile, "2020-04-19 00:00:01", testdata)
         assert smile._last_active["c784ee9fdab44e1395b8dee7d7a497d5"] == "standaard"
-        assert self.entity_items == 64
+        assert self.entity_items == 69
         assert self.cooling_present
         assert not self.notifications
 
@@ -298,7 +298,7 @@ class TestPlugwiseAnna(TestPlugwise):  # pylint: disable=attribute-defined-outsi
         )
 
         await self.device_test(smile, "2020-04-19 00:00:01", testdata)
-        assert self.entity_items == 64
+        assert self.entity_items == 69
         assert self.cooling_present
         assert self._cooling_enabled
         assert self._cooling_active
@@ -325,7 +325,7 @@ class TestPlugwiseAnna(TestPlugwise):  # pylint: disable=attribute-defined-outsi
         await self.device_test(smile, "2020-04-12 00:00:01", testdata)
         assert smile.gateway_id == "015ae9ea3f964e668e490fa39da3870b"
         assert smile._last_active["c784ee9fdab44e1395b8dee7d7a497d5"] == "standaard"
-        assert self.entity_items == 63
+        assert self.entity_items == 68
         assert not self.notifications
         assert not self.cooling_present
 
@@ -352,7 +352,7 @@ class TestPlugwiseAnna(TestPlugwise):  # pylint: disable=attribute-defined-outsi
             smile._last_active["d3ce834534114348be628b61b26d9220"]
             == THERMOSTAT_SCHEDULE
         )
-        assert self.entity_items == 63
+        assert self.entity_items == 68
         assert smile.gateway_id == "fb49af122f6e4b0f91267e1cf7666d6f"
         assert self.cooling_present
         assert not self._cooling_enabled
@@ -377,7 +377,7 @@ class TestPlugwiseAnna(TestPlugwise):  # pylint: disable=attribute-defined-outsi
         )
         assert self.cooling_present
         assert not self._cooling_enabled
-        assert self.entity_items == 63
+        assert self.entity_items == 68
 
         await smile.close_connection()
         await self.disconnect(server, client)
@@ -406,7 +406,7 @@ class TestPlugwiseAnna(TestPlugwise):  # pylint: disable=attribute-defined-outsi
             smile._last_active["d3ce834534114348be628b61b26d9220"]
             == THERMOSTAT_SCHEDULE
         )
-        assert self.entity_items == 63
+        assert self.entity_items == 68
         assert not self.notifications
 
         assert self.cooling_present
@@ -460,7 +460,7 @@ class TestPlugwiseAnna(TestPlugwise):  # pylint: disable=attribute-defined-outsi
 
         await self.device_test(smile, "2022-05-16 00:00:01", testdata)
         assert smile._last_active["15da035090b847e7a21f93e08c015ebc"] == "Winter"
-        assert self.entity_items == 66
+        assert self.entity_items == 71
         assert self.cooling_present
         assert not self._cooling_enabled
 
@@ -528,7 +528,7 @@ class TestPlugwiseAnna(TestPlugwise):  # pylint: disable=attribute-defined-outsi
 
         await self.device_test(smile, "2022-05-16 00:00:01", testdata)
         assert smile._last_active["15da035090b847e7a21f93e08c015ebc"] == "Winter"
-        assert self.entity_items == 66
+        assert self.entity_items == 71
         assert self.cooling_present
         assert self._cooling_enabled
 
@@ -551,7 +551,7 @@ class TestPlugwiseAnna(TestPlugwise):  # pylint: disable=attribute-defined-outsi
         )
 
         await self.device_test(smile, "2022-05-16 00:00:01", testdata)
-        assert self.entity_items == 66
+        assert self.entity_items == 71
         assert self.cooling_present
         assert not self._cooling_enabled
 


### PR DESCRIPTION
@CoMPaTech I was preparing a little bit for the Anna P1 device and I realized there is also interesting data available at the Gateway / Home location for thermostat devices.

Also, this will allow us to add the weather-platform to the Integrations.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Introduced a new `weather` data structure for devices, replacing the previous `sensors` structure, which includes attributes like humidity, outdoor temperature, solar irradiance, weather description, wind bearing, and wind speed.
	- Updated item counts for multiple gateways, reflecting the addition of new items being tracked.

- **Bug Fixes**
	- Adjusted expected values in test cases to align with the new data structures and item counts.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->