### PR TITLE
Refresh Anna  Elga 2 main userdata

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Ongoing
 
 - Continuous improvements [#678](https://github.com/plugwise/python-plugwise/pull/678)
+- Refresh Anna_Elga_2 userdata and adapt, add missing item-count, line-up test-data headers [#679](https://github.com/plugwise/python-plugwise/pull/679)
 
 ## v1.6.4
 

--- a/fixtures/anna_elga_2/all_data.json
+++ b/fixtures/anna_elga_2/all_data.json
@@ -3,35 +3,29 @@
     "573c152e7d4f4720878222bd75638f5b": {
       "available": true,
       "binary_sensors": {
-        "compressor_state": false,
+        "compressor_state": true,
         "cooling_enabled": false,
         "cooling_state": false,
         "dhw_state": false,
-        "flame_state": false,
-        "heating_state": false,
-        "secondary_boiler_state": false
+        "flame_state": true,
+        "heating_state": true,
+        "secondary_boiler_state": true
       },
       "dev_class": "heater_central",
       "location": "d34dfe6ab90b410c98068e75de3eb631",
-      "maximum_boiler_temperature": {
-        "lower_bound": 0.0,
-        "resolution": 1.0,
-        "setpoint": 60.0,
-        "upper_bound": 100.0
-      },
       "model": "Generic heater/cooler",
       "name": "OpenTherm",
       "sensors": {
         "domestic_hot_water_setpoint": 60.0,
-        "intended_boiler_temperature": 0.0,
-        "modulation_level": 0.0,
-        "outdoor_air_temperature": 14.0,
-        "return_temperature": 23.4,
+        "intended_boiler_temperature": 58.3,
+        "modulation_level": 55,
+        "outdoor_air_temperature": 6.0,
+        "return_temperature": 35.5,
         "water_pressure": 0.5,
-        "water_temperature": 22.8
+        "water_temperature": 42.6
       },
       "switches": {
-        "dhw_cm_switch": true
+        "dhw_cm_switch": false
       },
       "vendor": "Techneco"
     },
@@ -39,7 +33,7 @@
       "active_preset": "home",
       "available_schedules": ["Thermostat schedule", "off"],
       "climate_mode": "auto",
-      "control_state": "idle",
+      "control_state": "heating",
       "dev_class": "thermostat",
       "firmware": "2018-02-08T11:15:53+01:00",
       "hardware": "6539-1301-5002",
@@ -49,12 +43,12 @@
       "preset_modes": ["away", "no_frost", "vacation", "home", "asleep"],
       "select_schedule": "Thermostat schedule",
       "sensors": {
-        "cooling_activation_outdoor_temperature": 26.0,
-        "cooling_deactivation_threshold": 3.0,
+        "cooling_activation_outdoor_temperature": 24.0,
+        "cooling_deactivation_threshold": 2.0,
         "illuminance": 0.5,
         "setpoint_high": 30.0,
         "setpoint_low": 19.5,
-        "temperature": 20.9
+        "temperature": 19.2
       },
       "temperature_offset": {
         "lower_bound": -2.0,
@@ -76,7 +70,7 @@
         "plugwise_notification": false
       },
       "dev_class": "gateway",
-      "firmware": "4.2.1",
+      "firmware": "4.4.1",
       "hardware": "AME Smile 2.0 board",
       "location": "d34dfe6ab90b410c98068e75de3eb631",
       "mac_address": "C4930002FE76",
@@ -84,7 +78,7 @@
       "model_id": "smile_thermo",
       "name": "Smile Anna",
       "sensors": {
-        "outdoor_temperature": 13.0
+        "outdoor_temperature": 6.38
       },
       "vendor": "Plugwise"
     }
@@ -93,7 +87,7 @@
     "cooling_present": true,
     "gateway_id": "fb49af122f6e4b0f91267e1cf7666d6f",
     "heater_id": "573c152e7d4f4720878222bd75638f5b",
-    "item_count": 64,
+    "item_count": 60,
     "notifications": {},
     "reboot": true,
     "smile_name": "Smile Anna"

--- a/fixtures/anna_elga_2/all_data.json
+++ b/fixtures/anna_elga_2/all_data.json
@@ -93,7 +93,7 @@
     "cooling_present": true,
     "gateway_id": "fb49af122f6e4b0f91267e1cf7666d6f",
     "heater_id": "573c152e7d4f4720878222bd75638f5b",
-    "item_count": 63,
+    "item_count": 64,
     "notifications": {},
     "reboot": true,
     "smile_name": "Smile Anna"

--- a/fixtures/anna_elga_2_cooling/all_data.json
+++ b/fixtures/anna_elga_2_cooling/all_data.json
@@ -93,7 +93,7 @@
     "cooling_present": true,
     "gateway_id": "fb49af122f6e4b0f91267e1cf7666d6f",
     "heater_id": "573c152e7d4f4720878222bd75638f5b",
-    "item_count": 63,
+    "item_count": 64,
     "notifications": {},
     "reboot": true,
     "smile_name": "Smile Anna"

--- a/fixtures/anna_elga_2_schedule_off/all_data.json
+++ b/fixtures/anna_elga_2_schedule_off/all_data.json
@@ -93,7 +93,7 @@
     "cooling_present": true,
     "gateway_id": "fb49af122f6e4b0f91267e1cf7666d6f",
     "heater_id": "573c152e7d4f4720878222bd75638f5b",
-    "item_count": 63,
+    "item_count": 64,
     "notifications": {},
     "reboot": true,
     "smile_name": "Smile Anna"

--- a/fixtures/anna_elga_no_cooling/all_data.json
+++ b/fixtures/anna_elga_no_cooling/all_data.json
@@ -95,7 +95,7 @@
     "cooling_present": false,
     "gateway_id": "015ae9ea3f964e668e490fa39da3870b",
     "heater_id": "1cbf783bb11e4a7c8a6843dee3a86927",
-    "item_count": 63,
+    "item_count": 64,
     "notifications": {},
     "reboot": true,
     "smile_name": "Smile Anna"

--- a/fixtures/anna_heatpump_cooling/all_data.json
+++ b/fixtures/anna_heatpump_cooling/all_data.json
@@ -94,7 +94,7 @@
     "cooling_present": true,
     "gateway_id": "015ae9ea3f964e668e490fa39da3870b",
     "heater_id": "1cbf783bb11e4a7c8a6843dee3a86927",
-    "item_count": 64,
+    "item_count": 65,
     "notifications": {},
     "reboot": true,
     "smile_name": "Smile Anna"

--- a/fixtures/anna_heatpump_cooling_fake_firmware/all_data.json
+++ b/fixtures/anna_heatpump_cooling_fake_firmware/all_data.json
@@ -94,7 +94,7 @@
     "cooling_present": true,
     "gateway_id": "015ae9ea3f964e668e490fa39da3870b",
     "heater_id": "1cbf783bb11e4a7c8a6843dee3a86927",
-    "item_count": 64,
+    "item_count": 65,
     "notifications": {},
     "reboot": true,
     "smile_name": "Smile Anna"

--- a/fixtures/anna_heatpump_heating/all_data.json
+++ b/fixtures/anna_heatpump_heating/all_data.json
@@ -99,7 +99,7 @@
     "cooling_present": true,
     "gateway_id": "015ae9ea3f964e668e490fa39da3870b",
     "heater_id": "1cbf783bb11e4a7c8a6843dee3a86927",
-    "item_count": 67,
+    "item_count": 68,
     "notifications": {},
     "reboot": true,
     "smile_name": "Smile Anna"

--- a/fixtures/anna_loria_cooling_active/all_data.json
+++ b/fixtures/anna_loria_cooling_active/all_data.json
@@ -98,7 +98,7 @@
     "cooling_present": true,
     "gateway_id": "9ff0569b4984459fb243af64c0901894",
     "heater_id": "bfb5ee0a88e14e5f97bfa725a760cc49",
-    "item_count": 66,
+    "item_count": 67,
     "notifications": {},
     "reboot": true,
     "smile_name": "Smile Anna"

--- a/fixtures/anna_loria_driessens/all_data.json
+++ b/fixtures/anna_loria_driessens/all_data.json
@@ -104,7 +104,7 @@
     "cooling_present": true,
     "gateway_id": "5c118b1842e943c0a5b6ef88a60bb17a",
     "heater_id": "a449cbc334ae4a5bb7f89064984b2906",
-    "item_count": 66,
+    "item_count": 67,
     "notifications": {},
     "reboot": true,
     "smile_name": "Smile Anna"

--- a/fixtures/anna_loria_heating_idle/all_data.json
+++ b/fixtures/anna_loria_heating_idle/all_data.json
@@ -98,7 +98,7 @@
     "cooling_present": true,
     "gateway_id": "9ff0569b4984459fb243af64c0901894",
     "heater_id": "bfb5ee0a88e14e5f97bfa725a760cc49",
-    "item_count": 66,
+    "item_count": 67,
     "notifications": {},
     "reboot": true,
     "smile_name": "Smile Anna"

--- a/fixtures/anna_v4/all_data.json
+++ b/fixtures/anna_v4/all_data.json
@@ -90,7 +90,7 @@
     "cooling_present": false,
     "gateway_id": "0466eae8520144c78afb29628384edeb",
     "heater_id": "cd0e6156b1f04d5f952349ffbe397481",
-    "item_count": 58,
+    "item_count": 59,
     "notifications": {},
     "reboot": true,
     "smile_name": "Smile Anna"

--- a/fixtures/anna_v4_dhw/all_data.json
+++ b/fixtures/anna_v4_dhw/all_data.json
@@ -90,7 +90,7 @@
     "cooling_present": false,
     "gateway_id": "0466eae8520144c78afb29628384edeb",
     "heater_id": "cd0e6156b1f04d5f952349ffbe397481",
-    "item_count": 58,
+    "item_count": 59,
     "notifications": {},
     "reboot": true,
     "smile_name": "Smile Anna"

--- a/fixtures/anna_v4_no_tag/all_data.json
+++ b/fixtures/anna_v4_no_tag/all_data.json
@@ -90,7 +90,7 @@
     "cooling_present": false,
     "gateway_id": "0466eae8520144c78afb29628384edeb",
     "heater_id": "cd0e6156b1f04d5f952349ffbe397481",
-    "item_count": 58,
+    "item_count": 59,
     "notifications": {},
     "reboot": true,
     "smile_name": "Smile Anna"

--- a/fixtures/anna_without_boiler_fw441/all_data.json
+++ b/fixtures/anna_without_boiler_fw441/all_data.json
@@ -63,7 +63,7 @@
     "cooling_present": false,
     "gateway_id": "a270735e4ccd45239424badc0578a2b1",
     "heater_id": "c46b4794d28149699eacf053deedd003",
-    "item_count": 39,
+    "item_count": 40,
     "notifications": {},
     "reboot": true,
     "smile_name": "Smile Anna"

--- a/fixtures/m_anna_heatpump_cooling/all_data.json
+++ b/fixtures/m_anna_heatpump_cooling/all_data.json
@@ -99,7 +99,7 @@
     "cooling_present": true,
     "gateway_id": "015ae9ea3f964e668e490fa39da3870b",
     "heater_id": "1cbf783bb11e4a7c8a6843dee3a86927",
-    "item_count": 67,
+    "item_count": 68,
     "notifications": {},
     "reboot": true,
     "smile_name": "Smile Anna"

--- a/fixtures/m_anna_heatpump_idle/all_data.json
+++ b/fixtures/m_anna_heatpump_idle/all_data.json
@@ -99,7 +99,7 @@
     "cooling_present": true,
     "gateway_id": "015ae9ea3f964e668e490fa39da3870b",
     "heater_id": "1cbf783bb11e4a7c8a6843dee3a86927",
-    "item_count": 67,
+    "item_count": 68,
     "notifications": {},
     "reboot": true,
     "smile_name": "Smile Anna"

--- a/plugwise/data.py
+++ b/plugwise/data.py
@@ -313,6 +313,7 @@ class SmileData(SmileHelper):
     def _get_anna_control_state(self, data: GwEntityData) -> None:
         """Set the thermostat control_state based on the opentherm/onoff device state."""
         data["control_state"] = "idle"
+        self._count += 1
         for entity in self.gw_entities.values():
             if entity["dev_class"] != "heater_central":
                 continue

--- a/plugwise/helper.py
+++ b/plugwise/helper.py
@@ -968,11 +968,9 @@ class SmileHelper(SmileCommon):
         Represents the heating/cooling demand-state of the local primary thermostat.
         Note: heating or cooling can still be active when the setpoint has been reached.
         """
-        locator = f'location[@id="{loc_id}"]'
-        if (location := self._domain_objects.find(locator)) is not None:
-            locator = './actuator_functionalities/thermostat_functionality[type="thermostat"]/control_state'
-            if (ctrl_state := location.find(locator)) is not None:
-                return str(ctrl_state.text)
+        locator = f'location[@id="{loc_id}"]/actuator_functionalities/thermostat_functionality[type="thermostat"]/control_state'
+        if (ctrl_state := self._domain_objects.find(locator)) is not None:
+            return str(ctrl_state.text)
 
         # Handle missing control_state in regulation_mode off for firmware >= 3.2.0 (issue #776)
         # In newer firmware versions, default to "off" when control_state is not present

--- a/tests/data/adam/adam_jip.json
+++ b/tests/data/adam/adam_jip.json
@@ -1,5 +1,5 @@
 {
-  "entities": {
+  "devices": {
     "06aecb3d00354375924f50c47af36bd2": {
       "active_preset": "no_frost",
       "climate_mode": "heat",

--- a/tests/data/adam/adam_onoff_cooling_fake_firmware.json
+++ b/tests/data/adam/adam_onoff_cooling_fake_firmware.json
@@ -1,5 +1,5 @@
 {
-  "entities": {
+  "devices": {
     "0ca13e8176204ca7bf6f09de59f81c83": {
       "binary_sensors": {
         "cooling_enabled": true,

--- a/tests/data/adam/adam_plus_anna_new.json
+++ b/tests/data/adam/adam_plus_anna_new.json
@@ -1,5 +1,5 @@
 {
-  "device_zones": {
+  "devices": {
     "056ee145a816487eaa69243c3280f8bf": {
       "available": true,
       "binary_sensors": {

--- a/tests/data/adam/adam_plus_anna_new_UPDATED_DATA.json
+++ b/tests/data/adam/adam_plus_anna_new_UPDATED_DATA.json
@@ -1,5 +1,5 @@
 {
-  "entities": {
+  "devices": {
     "67d73d0bd469422db25a618a5fb8eeb0": {
       "switches": {
         "lock": true

--- a/tests/data/adam/adam_plus_anna_new_regulation_off.json
+++ b/tests/data/adam/adam_plus_anna_new_regulation_off.json
@@ -1,5 +1,5 @@
 {
-  "device_zones": {
+  "devices": {
     "056ee145a816487eaa69243c3280f8bf": {
       "available": true,
       "binary_sensors": {

--- a/tests/data/anna/anna_elga_2.json
+++ b/tests/data/anna/anna_elga_2.json
@@ -1,37 +1,31 @@
 {
-  "entities": {
+  "devices": {
     "573c152e7d4f4720878222bd75638f5b": {
       "available": true,
       "binary_sensors": {
-        "compressor_state": false,
+        "compressor_state": true,
         "cooling_enabled": false,
         "cooling_state": false,
         "dhw_state": false,
-        "flame_state": false,
-        "heating_state": false,
-        "secondary_boiler_state": false
+        "flame_state": true,
+        "heating_state": true,
+        "secondary_boiler_state": true
       },
       "dev_class": "heater_central",
       "location": "d34dfe6ab90b410c98068e75de3eb631",
-      "maximum_boiler_temperature": {
-        "lower_bound": 0.0,
-        "resolution": 1.0,
-        "setpoint": 60.0,
-        "upper_bound": 100.0
-      },
       "model": "Generic heater/cooler",
       "name": "OpenTherm",
       "sensors": {
         "domestic_hot_water_setpoint": 60.0,
-        "intended_boiler_temperature": 0.0,
-        "modulation_level": 0.0,
-        "outdoor_air_temperature": 14.0,
-        "return_temperature": 23.4,
+        "intended_boiler_temperature": 58.3,
+        "modulation_level": 55,
+        "outdoor_air_temperature": 6.0,
+        "return_temperature": 35.5,
         "water_pressure": 0.5,
-        "water_temperature": 22.8
+        "water_temperature": 42.6
       },
       "switches": {
-        "dhw_cm_switch": true
+        "dhw_cm_switch": false
       },
       "vendor": "Techneco"
     },
@@ -39,7 +33,7 @@
       "active_preset": "home",
       "available_schedules": ["Thermostat schedule", "off"],
       "climate_mode": "auto",
-      "control_state": "idle",
+      "control_state": "heating",
       "dev_class": "thermostat",
       "firmware": "2018-02-08T11:15:53+01:00",
       "hardware": "6539-1301-5002",
@@ -49,12 +43,12 @@
       "preset_modes": ["away", "no_frost", "vacation", "home", "asleep"],
       "select_schedule": "Thermostat schedule",
       "sensors": {
-        "cooling_activation_outdoor_temperature": 26.0,
-        "cooling_deactivation_threshold": 3.0,
+        "cooling_activation_outdoor_temperature": 24.0,
+        "cooling_deactivation_threshold": 2.0,
         "illuminance": 0.5,
         "setpoint_high": 30.0,
         "setpoint_low": 19.5,
-        "temperature": 20.9
+        "temperature": 19.2
       },
       "temperature_offset": {
         "lower_bound": -2.0,
@@ -76,7 +70,7 @@
         "plugwise_notification": false
       },
       "dev_class": "gateway",
-      "firmware": "4.2.1",
+      "firmware": "4.4.1",
       "hardware": "AME Smile 2.0 board",
       "location": "d34dfe6ab90b410c98068e75de3eb631",
       "mac_address": "C4930002FE76",
@@ -84,7 +78,7 @@
       "model_id": "smile_thermo",
       "name": "Smile Anna",
       "sensors": {
-        "outdoor_temperature": 13.0
+        "outdoor_temperature": 6.38
       },
       "vendor": "Plugwise"
     }

--- a/tests/data/anna/anna_elga_2_cooling.json
+++ b/tests/data/anna/anna_elga_2_cooling.json
@@ -1,5 +1,5 @@
 {
-  "entities": {
+  "devices": {
     "573c152e7d4f4720878222bd75638f5b": {
       "available": true,
       "binary_sensors": {

--- a/tests/data/anna/anna_elga_2_cooling_UPDATED_DATA.json
+++ b/tests/data/anna/anna_elga_2_cooling_UPDATED_DATA.json
@@ -1,5 +1,5 @@
 {
-  "entities": {
+  "devices": {
     "573c152e7d4f4720878222bd75638f5b": {
       "available": true,
       "binary_sensors": {

--- a/tests/data/anna/anna_elga_2_schedule_off.json
+++ b/tests/data/anna/anna_elga_2_schedule_off.json
@@ -1,5 +1,5 @@
 {
-  "entities": {
+  "devices": {
     "573c152e7d4f4720878222bd75638f5b": {
       "available": true,
       "binary_sensors": {

--- a/tests/data/anna/anna_elga_no_cooling.json
+++ b/tests/data/anna/anna_elga_no_cooling.json
@@ -1,5 +1,5 @@
 {
-  "entities": {
+  "devices": {
     "015ae9ea3f964e668e490fa39da3870b": {
       "binary_sensors": {
         "plugwise_notification": false

--- a/tests/data/anna/anna_heatpump_cooling.json
+++ b/tests/data/anna/anna_heatpump_cooling.json
@@ -1,5 +1,5 @@
 {
-  "entities": {
+  "devices": {
     "015ae9ea3f964e668e490fa39da3870b": {
       "binary_sensors": {
         "plugwise_notification": false

--- a/tests/data/anna/anna_heatpump_cooling_fake_firmware.json
+++ b/tests/data/anna/anna_heatpump_cooling_fake_firmware.json
@@ -1,5 +1,5 @@
 {
-  "entities": {
+  "devices": {
     "015ae9ea3f964e668e490fa39da3870b": {
       "binary_sensors": {
         "plugwise_notification": false

--- a/tests/data/anna/anna_heatpump_heating.json
+++ b/tests/data/anna/anna_heatpump_heating.json
@@ -1,5 +1,5 @@
 {
-  "entities": {
+  "devices": {
     "015ae9ea3f964e668e490fa39da3870b": {
       "binary_sensors": {
         "plugwise_notification": false

--- a/tests/data/anna/anna_heatpump_heating_UPDATED_DATA.json
+++ b/tests/data/anna/anna_heatpump_heating_UPDATED_DATA.json
@@ -1,5 +1,5 @@
 {
-  "entities": {
+  "devices": {
     "1cbf783bb11e4a7c8a6843dee3a86927": {
       "dev_class": "heater_central",
       "location": "a57efe5f145f498c9be62a9b63626fbf",

--- a/tests/data/anna/anna_loria_cooling_active.json
+++ b/tests/data/anna/anna_loria_cooling_active.json
@@ -1,5 +1,5 @@
 {
-  "entities": {
+  "devices": {
     "582dfbdace4d4aeb832923ce7d1ddda0": {
       "active_preset": "home",
       "available_schedules": ["Winter", "Test ", "off"],

--- a/tests/data/anna/anna_loria_driessens.json
+++ b/tests/data/anna/anna_loria_driessens.json
@@ -1,5 +1,5 @@
 {
-  "entities": {
+  "devices": {
     "5c118b1842e943c0a5b6ef88a60bb17a": {
       "binary_sensors": {
         "plugwise_notification": false

--- a/tests/data/anna/anna_loria_heating_idle.json
+++ b/tests/data/anna/anna_loria_heating_idle.json
@@ -1,5 +1,5 @@
 {
-  "entities": {
+  "devices": {
     "582dfbdace4d4aeb832923ce7d1ddda0": {
       "active_preset": "home",
       "available_schedules": ["Winter", "Test ", "off"],

--- a/tests/data/anna/anna_v4.json
+++ b/tests/data/anna/anna_v4.json
@@ -1,5 +1,5 @@
 {
-  "device_zones": {
+  "devices": {
     "01b85360fdd243d0aaad4d6ac2a5ba7e": {
       "active_preset": "home",
       "available_schedules": ["Standaard", "Thuiswerken", "off"],

--- a/tests/data/anna/anna_v4_UPDATED_DATA.json
+++ b/tests/data/anna/anna_v4_UPDATED_DATA.json
@@ -1,5 +1,5 @@
 {
-  "entities": {
+  "devices": {
     "cd0e6156b1f04d5f952349ffbe397481": {
       "maximum_boiler_temperature": {
         "setpoint": 69.0,

--- a/tests/data/anna/anna_v4_dhw.json
+++ b/tests/data/anna/anna_v4_dhw.json
@@ -1,5 +1,5 @@
 {
-  "entities": {
+  "devices": {
     "01b85360fdd243d0aaad4d6ac2a5ba7e": {
       "active_preset": "home",
       "available_schedules": ["Standaard", "Thuiswerken", "off"],

--- a/tests/data/anna/anna_v4_no_tag.json
+++ b/tests/data/anna/anna_v4_no_tag.json
@@ -1,5 +1,5 @@
 {
-  "entities": {
+  "devices": {
     "01b85360fdd243d0aaad4d6ac2a5ba7e": {
       "active_preset": "home",
       "available_schedules": ["Standaard", "Thuiswerken", "off"],

--- a/tests/data/anna/anna_without_boiler_fw441.json
+++ b/tests/data/anna/anna_without_boiler_fw441.json
@@ -1,5 +1,5 @@
 {
-  "entities": {
+  "devices": {
     "7ffbb3ab4b6c4ab2915d7510f7bf8fe9": {
       "active_preset": "home",
       "available_schedules": ["Test", "Normaal", "off"],

--- a/tests/data/anna/legacy_anna.json
+++ b/tests/data/anna/legacy_anna.json
@@ -1,5 +1,5 @@
 {
-  "device_zones": {
+  "devices": {
     "0000aaaa0000aaaa0000aaaa0000aa00": {
       "dev_class": "gateway",
       "firmware": "1.8.22",

--- a/tests/data/anna/legacy_anna_2.json
+++ b/tests/data/anna/legacy_anna_2.json
@@ -1,5 +1,5 @@
 {
-  "entities": {
+  "devices": {
     "9e7377867dc24e51b8098a5ba02bd89d": {
       "active_preset": null,
       "available_schedules": ["Thermostat schedule", "off"],

--- a/tests/data/p1/p1v4.json
+++ b/tests/data/p1/p1v4.json
@@ -1,40 +1,42 @@
 {
-  "a455b61e52394b2db5081ce025a430f3": {
-    "dev_class": "gateway",
-    "firmware": "4.1.1",
-    "hardware": "AME Smile 2.0 board",
-    "location": "a455b61e52394b2db5081ce025a430f3",
-    "mac_address": "012345670001",
-    "model": "Gateway",
-    "model_id": "smile",
-    "name": "Smile P1",
-    "vendor": "Plugwise",
-    "binary_sensors": {
-      "plugwise_notification": true
-    }
-  },
-  "ba4de7613517478da82dd9b6abea36af": {
-    "dev_class": "smartmeter",
-    "location": "a455b61e52394b2db5081ce025a430f3",
-    "model": "KFM5KAIFA-METER",
-    "name": "P1",
-    "vendor": "SHENZHEN KAIFA TECHNOLOGY CHENGDU CO.",
-    "available": false,
-    "sensors": {
-      "net_electricity_point": 571.0,
-      "electricity_consumed_peak_point": 571.0,
-      "electricity_consumed_off_peak_point": 0.0,
-      "net_electricity_cumulative": 20983.453,
-      "electricity_consumed_peak_cumulative": 9067.554,
-      "electricity_consumed_off_peak_cumulative": 11915.899,
-      "electricity_consumed_peak_interval": 335.0,
-      "electricity_consumed_off_peak_interval": 0.0,
-      "electricity_produced_peak_point": 0.0,
-      "electricity_produced_off_peak_point": 0.0,
-      "electricity_produced_peak_cumulative": 0.0,
-      "electricity_produced_off_peak_cumulative": 0.0,
-      "electricity_produced_peak_interval": 0.0,
-      "electricity_produced_off_peak_interval": 0.0
+  "devices": {
+    "a455b61e52394b2db5081ce025a430f3": {
+      "dev_class": "gateway",
+      "firmware": "4.1.1",
+      "hardware": "AME Smile 2.0 board",
+      "location": "a455b61e52394b2db5081ce025a430f3",
+      "mac_address": "012345670001",
+      "model": "Gateway",
+      "model_id": "smile",
+      "name": "Smile P1",
+      "vendor": "Plugwise",
+      "binary_sensors": {
+        "plugwise_notification": true
+      }
+    },
+    "ba4de7613517478da82dd9b6abea36af": {
+      "dev_class": "smartmeter",
+      "location": "a455b61e52394b2db5081ce025a430f3",
+      "model": "KFM5KAIFA-METER",
+      "name": "P1",
+      "vendor": "SHENZHEN KAIFA TECHNOLOGY CHENGDU CO.",
+      "available": false,
+      "sensors": {
+        "net_electricity_point": 571.0,
+        "electricity_consumed_peak_point": 571.0,
+        "electricity_consumed_off_peak_point": 0.0,
+        "net_electricity_cumulative": 20983.453,
+        "electricity_consumed_peak_cumulative": 9067.554,
+        "electricity_consumed_off_peak_cumulative": 11915.899,
+        "electricity_consumed_peak_interval": 335.0,
+        "electricity_consumed_off_peak_interval": 0.0,
+        "electricity_produced_peak_point": 0.0,
+        "electricity_produced_off_peak_point": 0.0,
+        "electricity_produced_peak_cumulative": 0.0,
+        "electricity_produced_off_peak_cumulative": 0.0,
+        "electricity_produced_peak_interval": 0.0,
+        "electricity_produced_off_peak_interval": 0.0
+      }
     }
   }
 }

--- a/tests/data/p1/p1v4_442_single.json
+++ b/tests/data/p1/p1v4_442_single.json
@@ -1,5 +1,5 @@
 {
-  "entities": {
+  "devices": {
     "a455b61e52394b2db5081ce025a430f3": {
       "binary_sensors": {
         "plugwise_notification": false

--- a/tests/data/p1/p1v4_442_single_UPDATED_DATA.json
+++ b/tests/data/p1/p1v4_442_single_UPDATED_DATA.json
@@ -1,5 +1,5 @@
 {
-  "entities": {
+  "devices": {
     "ba4de7613517478da82dd9b6abea36af": {
       "sensors": {
         "net_electricity_point": -2248.0,

--- a/tests/data/p1/p1v4_442_triple.json
+++ b/tests/data/p1/p1v4_442_triple.json
@@ -1,5 +1,5 @@
 {
-  "entities": {
+  "devices": {
     "03e65b16e4b247a29ae0d75a78cb492e": {
       "binary_sensors": {
         "plugwise_notification": true

--- a/tests/data/p1/smile_p1_v2.json
+++ b/tests/data/p1/smile_p1_v2.json
@@ -1,5 +1,5 @@
 {
-  "device_zones": {
+  "devices": {
     "938696c4bcdb4b8a9a595cb38ed43913": {
       "dev_class": "smartmeter",
       "location": "938696c4bcdb4b8a9a595cb38ed43913",

--- a/tests/data/p1/smile_p1_v2_2.json
+++ b/tests/data/p1/smile_p1_v2_2.json
@@ -1,5 +1,5 @@
 {
-  "entities": {
+  "devices": {
     "199aa40f126840f392983d171374ab0b": {
       "dev_class": "smartmeter",
       "location": "199aa40f126840f392983d171374ab0b",

--- a/tests/data/p1/smile_p1_v2_2_UPDATED_DATA.json
+++ b/tests/data/p1/smile_p1_v2_2_UPDATED_DATA.json
@@ -1,5 +1,5 @@
 {
-  "entities": {
+  "devices": {
     "199aa40f126840f392983d171374ab0b": {
       "sensors": {
         "net_electricity_point": -2248.0,

--- a/tests/data/stretch/stretch_v23.json
+++ b/tests/data/stretch/stretch_v23.json
@@ -1,5 +1,5 @@
 {
-  "entities": {
+  "devices": {
     "0000aaaa0000aaaa0000aaaa0000aa00": {
       "dev_class": "gateway",
       "firmware": "2.3.12",

--- a/tests/data/stretch/stretch_v27_no_domain.json
+++ b/tests/data/stretch/stretch_v27_no_domain.json
@@ -1,5 +1,5 @@
 {
-  "entities": {
+  "devices": {
     "0000aaaa0000aaaa0000aaaa0000aa00": {
       "dev_class": "gateway",
       "firmware": "2.7.18",

--- a/tests/data/stretch/stretch_v31.json
+++ b/tests/data/stretch/stretch_v31.json
@@ -1,5 +1,5 @@
 {
-  "device_zones": {
+  "devices": {
     "0000aaaa0000aaaa0000aaaa0000aa00": {
       "dev_class": "gateway",
       "firmware": "3.1.11",

--- a/tests/data/stretch/stretch_v31_UPDATED_DATA.json
+++ b/tests/data/stretch/stretch_v31_UPDATED_DATA.json
@@ -1,5 +1,5 @@
 {
-  "device_zones": {
+  "devices": {
     "aac7b735042c4832ac9ff33aae4f453b": {
       "sensors": {
         "electricity_consumed": 1000.0,

--- a/tests/test_anna.py
+++ b/tests/test_anna.py
@@ -30,7 +30,7 @@ class TestPlugwiseAnna(TestPlugwise):  # pylint: disable=attribute-defined-outsi
         await self.device_test(smile, "2020-04-05 00:00:01", testdata)
         assert smile.gateway_id == "0466eae8520144c78afb29628384edeb"
         assert smile._last_active["eb5309212bf5407bb143e5bfa3b18aee"] == "Standaard"
-        assert self.entity_items == 58
+        assert self.entity_items == 59
         assert not self.notifications
 
         assert not self.cooling_present
@@ -109,7 +109,7 @@ class TestPlugwiseAnna(TestPlugwise):  # pylint: disable=attribute-defined-outsi
 
         await self.device_test(smile, "2020-04-05 00:00:01", testdata)
         assert smile._last_active["eb5309212bf5407bb143e5bfa3b18aee"] == "Standaard"
-        assert self.entity_items == 58
+        assert self.entity_items == 59
         assert not self.notifications
 
         result = await self.tinker_thermostat(
@@ -138,7 +138,7 @@ class TestPlugwiseAnna(TestPlugwise):  # pylint: disable=attribute-defined-outsi
         )
 
         await self.device_test(smile, "2020-04-05 00:00:01", testdata)
-        assert self.entity_items == 58
+        assert self.entity_items == 59
 
         result = await self.tinker_thermostat(
             smile,
@@ -167,7 +167,7 @@ class TestPlugwiseAnna(TestPlugwise):  # pylint: disable=attribute-defined-outsi
 
         await self.device_test(smile, "2022-05-16 00:00:01", testdata)
         assert smile._last_active["c34c6864216446528e95d88985e714cc"] == "Normaal"
-        assert self.entity_items == 39
+        assert self.entity_items == 40
         assert not self.notifications
 
         result = await self.tinker_thermostat(
@@ -196,7 +196,7 @@ class TestPlugwiseAnna(TestPlugwise):  # pylint: disable=attribute-defined-outsi
         await self.device_test(smile, "2020-04-12 00:00:01", testdata)
         assert smile.gateway_id == "015ae9ea3f964e668e490fa39da3870b"
         assert smile._last_active["c784ee9fdab44e1395b8dee7d7a497d5"] == "standaard"
-        assert self.entity_items == 67
+        assert self.entity_items == 68
         assert not self.notifications
         assert self.cooling_present
         assert not self._cooling_enabled
@@ -226,7 +226,7 @@ class TestPlugwiseAnna(TestPlugwise):  # pylint: disable=attribute-defined-outsi
         await self.device_test(
             smile, "2020-04-13 00:00:01", testdata_updated, initialize=False
         )
-        assert self.entity_items == 64
+        assert self.entity_items == 65
         await smile.close_connection()
         await self.disconnect(server, client)
 
@@ -252,7 +252,7 @@ class TestPlugwiseAnna(TestPlugwise):  # pylint: disable=attribute-defined-outsi
 
         await self.device_test(smile, "2020-04-19 00:00:01", testdata)
         assert smile._last_active["c784ee9fdab44e1395b8dee7d7a497d5"] == "standaard"
-        assert self.entity_items == 64
+        assert self.entity_items == 65
         assert self.cooling_present
         assert not self.notifications
 
@@ -298,7 +298,7 @@ class TestPlugwiseAnna(TestPlugwise):  # pylint: disable=attribute-defined-outsi
         )
 
         await self.device_test(smile, "2020-04-19 00:00:01", testdata)
-        assert self.entity_items == 64
+        assert self.entity_items == 65
         assert self.cooling_present
         assert self._cooling_enabled
         assert self._cooling_active
@@ -325,7 +325,7 @@ class TestPlugwiseAnna(TestPlugwise):  # pylint: disable=attribute-defined-outsi
         await self.device_test(smile, "2020-04-12 00:00:01", testdata)
         assert smile.gateway_id == "015ae9ea3f964e668e490fa39da3870b"
         assert smile._last_active["c784ee9fdab44e1395b8dee7d7a497d5"] == "standaard"
-        assert self.entity_items == 63
+        assert self.entity_items == 64
         assert not self.notifications
         assert not self.cooling_present
 
@@ -352,7 +352,7 @@ class TestPlugwiseAnna(TestPlugwise):  # pylint: disable=attribute-defined-outsi
             smile._last_active["d3ce834534114348be628b61b26d9220"]
             == THERMOSTAT_SCHEDULE
         )
-        assert self.entity_items == 63
+        assert self.entity_items == 64
         assert smile.gateway_id == "fb49af122f6e4b0f91267e1cf7666d6f"
         assert self.cooling_present
         assert not self._cooling_enabled
@@ -377,7 +377,7 @@ class TestPlugwiseAnna(TestPlugwise):  # pylint: disable=attribute-defined-outsi
         )
         assert self.cooling_present
         assert not self._cooling_enabled
-        assert self.entity_items == 63
+        assert self.entity_items == 64
 
         await smile.close_connection()
         await self.disconnect(server, client)
@@ -406,7 +406,7 @@ class TestPlugwiseAnna(TestPlugwise):  # pylint: disable=attribute-defined-outsi
             smile._last_active["d3ce834534114348be628b61b26d9220"]
             == THERMOSTAT_SCHEDULE
         )
-        assert self.entity_items == 63
+        assert self.entity_items == 64
         assert not self.notifications
 
         assert self.cooling_present
@@ -460,7 +460,7 @@ class TestPlugwiseAnna(TestPlugwise):  # pylint: disable=attribute-defined-outsi
 
         await self.device_test(smile, "2022-05-16 00:00:01", testdata)
         assert smile._last_active["15da035090b847e7a21f93e08c015ebc"] == "Winter"
-        assert self.entity_items == 66
+        assert self.entity_items == 67
         assert self.cooling_present
         assert not self._cooling_enabled
 
@@ -528,7 +528,7 @@ class TestPlugwiseAnna(TestPlugwise):  # pylint: disable=attribute-defined-outsi
 
         await self.device_test(smile, "2022-05-16 00:00:01", testdata)
         assert smile._last_active["15da035090b847e7a21f93e08c015ebc"] == "Winter"
-        assert self.entity_items == 66
+        assert self.entity_items == 67
         assert self.cooling_present
         assert self._cooling_enabled
 
@@ -551,7 +551,7 @@ class TestPlugwiseAnna(TestPlugwise):  # pylint: disable=attribute-defined-outsi
         )
 
         await self.device_test(smile, "2022-05-16 00:00:01", testdata)
-        assert self.entity_items == 66
+        assert self.entity_items == 67
         assert self.cooling_present
         assert not self._cooling_enabled
 

--- a/tests/test_anna.py
+++ b/tests/test_anna.py
@@ -344,7 +344,7 @@ class TestPlugwiseAnna(TestPlugwise):  # pylint: disable=attribute-defined-outsi
         self.validate_test_basics(
             _LOGGER,
             smile,
-            smile_version="4.2.1",
+            smile_version="4.4.1",
         )
 
         await self.device_test(smile, "2022-03-13 00:00:01", testdata)
@@ -352,7 +352,7 @@ class TestPlugwiseAnna(TestPlugwise):  # pylint: disable=attribute-defined-outsi
             smile._last_active["d3ce834534114348be628b61b26d9220"]
             == THERMOSTAT_SCHEDULE
         )
-        assert self.entity_items == 64
+        assert self.entity_items == 60
         assert smile.gateway_id == "fb49af122f6e4b0f91267e1cf7666d6f"
         assert self.cooling_present
         assert not self._cooling_enabled

--- a/userdata/anna_elga_2/core.domain_objects.xml
+++ b/userdata/anna_elga_2/core.domain_objects.xml
@@ -1875,6 +1875,7 @@
 				<regulations><ame_regulation id='1c8b1a395ed848a2a67d65996bf0bb75'/></regulations>
 				<cooling_allowed>true</cooling_allowed>
 				<preheating_allowed>true</preheating_allowed>
+				<control_state>off</control_state>
 				<regulation_control>active</regulation_control>
 			</thermostat_functionality>
 		</actuator_functionalities>

--- a/userdata/anna_elga_2/core.domain_objects.xml
+++ b/userdata/anna_elga_2/core.domain_objects.xml
@@ -1,2128 +1,2481 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <domain_objects>
-	<template id='c9a9744aad4646f5a1b02ed9d72191a3' tag="zone_setpoint_and_state_based_on_preset">
-		<name>Zone preset template</name>
-		<description>Template for actuating thermostats and relays on a preset basis.</description>
-		<single_actor>true</single_actor>
-		<created_date>2017-10-25T14:55:02.526+02:00</created_date>
-		<modified_date>2022-03-02T17:47:56.632+01:00</modified_date>
-		<deleted_date></deleted_date>
-		<objects>
-			<object name="zone" type="Location"/>
-		</objects>
-		<parameters>
-			<parameter name="preset" source="zone.preset" type="Preset"/>
-		</parameters>
-		<results>
-			<result name="cooling_setpoint" type="Number" action="zone.iterateFunctionalities('ThermostatFunctionality', 'thermostat')().setSetpoint(null, null, cooling_setpoint)"/>
-			<result name="domestic_hot_water_state" type="OnOff" action="zone.iterateFunctionalities('ToggleFunctionality', 'domestic_hot_water_state')().state = domestic_hot_water_state"/>
-			<result name="heating_setpoint" type="Number" action="zone.iterateFunctionalities('ThermostatFunctionality', 'thermostat')().setSetpoint(null, heating_setpoint, null)"/>
-			<result name="state" type="OnOff" action="zone.iterateFunctionalities('RelayFunctionality')().state = state"/>
-		</results>
-	</template>
-	<module id='0fb9b855195d4c90b7cb6fe3cdd12aa1'>
-		<vendor_name>Plugwise</vendor_name>
-		<vendor_model>Gateway</vendor_model>
-		<hardware_version>AME Smile 2.0 board</hardware_version>
-		<firmware_version></firmware_version>
-		<created_date>2018-07-12T11:13:19.719+02:00</created_date>
-		<modified_date>2021-10-28T04:56:48.081+02:00</modified_date>
-		<deleted_date></deleted_date>
-		<services>
-			<network_state id='6fbd440a76444188adfcce9366e5e800' log_type='wlan_state'>
-				<functionalities><point_log id='43466b056f2f457493b720430ba254c5'/></functionalities>
-			</network_state>
-			<network_address id='936a423321184cf88cfc6c700e872230' log_type='wlan_ip_address'>
-				<functionalities><point_log id='856cc738696245d1a580706b6db5574e'/></functionalities>
-			</network_address>
-			<network_state id='af06c116bc7e4e7bbcac5b4d235bd2c8' log_type='lan_state'>
-				<functionalities><point_log id='e523c94b2efc445ba8bb26ec27152d6a'/></functionalities>
-			</network_state>
-			<link_quality id='af0f81cc5ca844c492ef164e2c114508' log_type='link_quality'>
-				<functionalities><point_log id='b41f590d2c06410dbe8be8e9f7b74deb'/></functionalities>
-			</link_quality>
-			<network_address id='b4124ec2cee84ae182a6612e610e1690' log_type='lan_ip_address'>
-				<functionalities><point_log id='170726b59a1c45f395dbc3d2920f9217'/></functionalities>
-			</network_address>
-			<gateway_mode_control id='bfa38e00cc3d405b80dadfc05bea8a9b' log_type='gateway_mode'>
-				<functionalities><gateway_mode_control_functionality id='43a20461689e4536bcf02758b6a2c340'/><point_log id='aa949dbf9f654ba09d3f8bff22f91cd3'/></functionalities>
-			</gateway_mode_control>
-			<signal_strength id='c61cb1657e7046f78f77f3a6a8bd4e01' log_type='signal_strength'>
-				<functionalities><point_log id='2dfe41f254c74ce9a9e9aaff6be9dbe7'/></functionalities>
-			</signal_strength>
-		</services>
-		<protocols>
-			<local_area_network id='44bed71f40c742e584168b9d6b8735da'/>
-			<wireless_local_area_network id='95bd9155f73e4adf941b6b7f84f58468'/>
-		</protocols>
-	</module>
-	<module id='c53888603af34264bbed2a05998ee572'>
-		<vendor_name>Techneco</vendor_name>
-		<vendor_model></vendor_model>
-		<hardware_version></hardware_version>
-		<firmware_version></firmware_version>
-		<created_date>2019-07-22T11:08:27.495+02:00</created_date>
-		<modified_date>2021-10-28T04:56:25.609+02:00</modified_date>
-		<deleted_date></deleted_date>
-		<services>
-			<pressure_gauge id='01d551e4bb2b475a9463912a3fd887da' log_type='central_heater_water_pressure'>
-				<functionalities><point_log id='e799a764479a4c4586179dd0760fe54e'/></functionalities>
-			</pressure_gauge>
-			<thermostat id='07c7b619be4242d6919733e6098a5b5e' log_type='maximum_outdoor_unit_steady_temperature'>
-				<functionalities><thermostat_functionality id='9cee766c36c843288b9bc17628e2a5a7'/><point_log id='c0a8e16b4efd465a88ed471330a99046'/></functionalities>
-			</thermostat>
-			<thermo_meter id='167efda4780e4fa8bbc8f588f4708fa2' log_type='temperature'>
-				<functionalities><point_log id='48f202225fb94f0b96540d97e65397c7'/></functionalities>
-			</thermo_meter>
-			<timer id='1b79f533784742c796c973856b30909d' log_type='indoor_temperature_transition_time'>
-				<functionalities><timer_functionality id='4e627a99dcf94bc086b31aa3a6de44b2'/><point_log id='c49b3ce126314dca848d51429a0ef2ea'/></functionalities>
-			</timer>
-			<thermo_meter id='1d0d91857e4042ec9180e2bc78898d13' log_type='intended_boiler_temperature'>
-				<functionalities><point_log id='0b1f4d8bbbbd451bb5214a7f592124e5'/></functionalities>
-			</thermo_meter>
-			<boiler_state id='1efb6c04052e4defbe429d6440c285c6' log_type='compressor_state'>
-				<functionalities><point_log id='40e35727c7b947f48099b5221633474c'/></functionalities>
-			</boiler_state>
-			<thermostat id='211f6996e8394d12a1f2cdb23b420a2c' log_type='heatpump_minimum_outdoor_temperature'>
-				<functionalities><thermostat_functionality id='c9b707c378b04420a55bdffe00e4f8f6'/><point_log id='daac6bf095ce472082653bd4a57c58f9'/></functionalities>
-			</thermostat>
-			<domestic_hot_water_toggle id='29fb663d576a46c79d629826edff95f0' log_type='domestic_hot_water_comfort_mode'>
-				<functionalities><point_log id='2e0289df2c7f4b66b8a4f562658a6903'/><toggle_functionality id='700bd52a8729461bb0fdf6d055c08710'/></functionalities>
-			</domestic_hot_water_toggle>
-			<fault_code id='310985c85e5e42238c4ae63180e8ed2c' log_type='elga_outdoor_unit_fault_code'>
-				<functionalities><point_log id='24b48396d2c24a7089fd3a3f0476fe3d'/></functionalities>
-			</fault_code>
-			<thermostat id='333ef91f62d94f78ad7b9bedaecc71f2' log_type='maximum_outdoor_unit_temperature'>
-				<functionalities><point_log id='10cea8565cd343768a6867c47c0300c6'/><thermostat_functionality id='a67b1c7b6d2f403aba383a56ad3d8e0a'/></functionalities>
-			</thermostat>
-			<thermostat id='3636e8c24b764f9dae52ba36695ed476' log_type='weather_dependent_maximum_supply_temperature'>
-				<functionalities><thermostat_functionality id='9cfae18be05b4509b32d52571107f0ff'/><point_log id='d517c9c0c3254926bd881c61b41f2185'/></functionalities>
-			</thermostat>
-			<threshold id='38eadee2fac04aaab6f8fac793560c82' log_type='boiler_activation_threshold'>
-				<functionalities><threshold_functionality id='57fb489e615a46888a051712ca8954f2'/><point_log id='e809f761a4c14287a852a8c727bbdc40'/></functionalities>
-			</threshold>
-			<timer id='397304cc8cbe47798f41930b1d62b009' log_type='hibernation_lead_time'>
-				<functionalities><point_log id='02b66447758049fab71cfc396d0b4423'/><timer_functionality id='4823c26f51bc4b07928acbb5ef056ca1'/></functionalities>
-			</timer>
-			<fault_code id='3af7b55915d841808e61d89a7663b7a2' log_type='open_therm_slave_oem_fault_code'>
-				<functionalities><point_log id='a45bc7ff672748328d3f83e6a4808ea3'/></functionalities>
-			</fault_code>
-			<timer id='4ac8d9303b644429b5c5bae03a79470a' log_type='pump_lag_time'>
-				<functionalities><timer_functionality id='631c67b8e2f2411d83ffa5a687f3b79b'/><point_log id='d703b335844c4d789b707534cb5dbd3e'/></functionalities>
-			</timer>
-			<thermostat id='4b8a974d347f4cf1872a5bc07f613068' log_type='maximum_heating_supply_temperature'>
-				<functionalities><thermostat_functionality id='b6579ded90e7489ca51a48768c721eb0'/><point_log id='f3eaebe5868840099b2f6eea9763dec3'/></functionalities>
-			</thermostat>
-			<dip_switch id='4d79c04aa75340519aca29545955bf76' log_type='input_contacts_installed'>
-				<functionalities><point_log id='80737def763544d797ce2ecebbaaf606'/></functionalities>
-			</dip_switch>
-			<thermostat id='5304a8c3c39e42b990c9b057e880f8a4' log_type='minimum_cooling_supply_temperature'>
-				<functionalities><point_log id='705e0e0f37574caabd69dd6a9db1620d'/><thermostat_functionality id='a1f29fd4edae4894a74c0b8c523f8ef3'/></functionalities>
-			</thermostat>
-			<dip_switch id='53a892b70e7a4f01a6174415509e8590' log_type='hibernation_enabled'>
-				<functionalities><point_log id='188ba49897614157a0b2723087058010'/></functionalities>
-			</dip_switch>
-			<thermostat id='564f724946434905b7d2b6c142e4ba67' log_type='maximum_outdoor_unit_power_increase_temperature'>
-				<functionalities><point_log id='083ba290a88245f3bd56957d6695dd55'/><thermostat_functionality id='f8b9ad4b594846628e305fdf7ff26b3e'/></functionalities>
-			</thermostat>
-			<dip_switch id='5f729e9aa96c4e33ad866f2efe41e694' log_type='thermostat_enabled'>
-				<functionalities><point_log id='7e6f7d5dfdd84b5ca8287d0f30944e8b'/></functionalities>
-			</dip_switch>
-			<dip_switch id='60c6512c9b9249199ca4adb48ab30e4e' log_type='weather_dependent_regulation'>
-				<functionalities><point_log id='56c09638ead640a5a7b6864a6a1db81b'/></functionalities>
-			</dip_switch>
-			<timer id='68a4b6945cbb49e0b1629ae6a44da34b' log_type='external_pump_cooling_lead_time'>
-				<functionalities><point_log id='78125fc1129b404782f7cf08c1a72401'/><timer_functionality id='8dcd68a78d704da8b0a61083d376223f'/></functionalities>
-			</timer>
-			<fault_code id='6e268f4aa86e4cc0a29c084d00c8319b' log_type='open_therm_oem_fault_code'>
-				<functionalities><point_log id='7d79610e27234506b0220b7e1a14eb3a'/></functionalities>
-			</fault_code>
-			<boiler_state id='72ac57601ea7410381c889a1f58b191c' log_type='intended_central_heating_state'>
-				<functionalities><point_log id='5f0c73d239254abea42bdf1cf02bd7de'/></functionalities>
-			</boiler_state>
-			<dip_switch id='74fab0d973c049e09f3514141f58c0ef' log_type='temperature_sensor_enabled'>
-				<functionalities><point_log id='7a90e2fb40a34176a94e408957c5c27c'/></functionalities>
-			</dip_switch>
-			<dip_switch id='769ba34f091e4fe4a0718ed34defea99' log_type='second_fan_enabled'>
-				<functionalities><point_log id='a6e3ad5afe8e4c6c9feafbd95f221a3a'/></functionalities>
-			</dip_switch>
-			<thermostat id='7c4e5837e0474ad3888e97cf21a51670' log_type='night_reduction_setpoint'>
-				<functionalities><thermostat_functionality id='07699ce0bdd6491db490f0e15642ca43'/><point_log id='8bbc4ca809b84a41b6c6115a8ccacecf'/></functionalities>
-			</thermostat>
-			<temperature_offset id='7c77a680bb0645aeb325f196e4a3df57' log_type='cooling_upper_offset'>
-				<functionalities><offset_functionality id='69ed60c3bc3846449e61dba62e71da40'/><point_log id='e5f051ef9b1542f2bf1b340fb6ba26d2'/></functionalities>
-			</temperature_offset>
-			<timer id='7ccb6bc94f1948ee9f16ecfb5c80d719' log_type='internal_pump_cooling_lead_time'>
-				<functionalities><point_log id='72e0439587ac443c8880f35543c12834'/><timer_functionality id='d24d209910e34533a95e361c8c66352c'/></functionalities>
-			</timer>
-			<thermostat id='82b1c7dcc6674568af1dbace5e64af8b' log_type='maximum_cooling_supply_temperature'>
-				<functionalities><point_log id='292c77f567194b14a0e7c3d63b340e66'/><thermostat_functionality id='6385d825e10545bfabc3cd3574920b68'/></functionalities>
-			</thermostat>
-			<thermo_meter id='8609fbdcab4b46e387953184f9878c28' log_type='outdoor_temperature'>
-				<functionalities><point_log id='fa0e3334f8d941cbbb040c5bf52fb2df'/></functionalities>
-			</thermo_meter>
-			<timer id='881f3c1377bc4efda8c78409a18ebe55' log_type='internal_pump_heating_lead_time'>
-				<functionalities><timer_functionality id='0646e6e1204147668157d2a7c59ef3ee'/><point_log id='1365f71019794971bbb06ebd881b7c84'/></functionalities>
-			</timer>
-			<modulation_level id='8862e6a7a98842928028e3f14493de8b' log_type='modulation_level'>
-				<functionalities><point_log id='1a94ecad909b40848efdce89197bae6d'/></functionalities>
-			</modulation_level>
-			<thermo_meter id='8eafb561fafb42ef8305eae670851e4a' log_type='boiler_temperature'>
-				<functionalities><point_log id='9556ad80c44b48459e297eeca0720cc3'/></functionalities>
-			</thermo_meter>
-			<dip_switch id='8eeb17de38da4b37992c7ef910592306' log_type='simultaneous_boiler_operation'>
-				<functionalities><point_log id='c65f2f2e30df4e1cb48bff1afc6bfaf5'/></functionalities>
-			</dip_switch>
-			<status_code id='91eb08ab048d4f8c947399a64a2e618b' log_type='elga_status_code'>
-				<functionalities><point_log id='1d03fff43bf640f998150fabc2aa7522'/></functionalities>
-			</status_code>
-			<boiler_state id='93242446d05a443fa31dc19c56fef767' log_type='central_heating_state'>
-				<functionalities><point_log id='d6e5970949cc4c48a1e20d830e3f9856'/></functionalities>
-			</boiler_state>
-			<boiler_state id='9c0a03f4a7f94290997bef767e5a81c2' log_type='flame_state'>
-				<functionalities><point_log id='00c5146fe1a749e3925627d59700652a'/></functionalities>
-			</boiler_state>
-			<thermostat id='9d9f24a42c514c99887d85091ba46d74' log_type='minimum_heating_supply_temperature'>
-				<functionalities><thermostat_functionality id='5b6c3a3cf0de4adc92e4aac0d93e1962'/><point_log id='5cd62cb4ac5a4067859f074a9a0eeb66'/></functionalities>
-			</thermostat>
-			<thermo_meter id='a2847eec8a634ccdb70d3c1a79c60df7' log_type='return_water_temperature'>
-				<functionalities><point_log id='f9aff78878654f84a8344c0851d7cb33'/></functionalities>
-			</thermo_meter>
-			<boiler_state id='a5d3ae6bd1474d4ebf506f405bb94b06' log_type='slave_boiler_state'>
-				<functionalities><point_log id='3ad82db986354586b9a0b63ffe9685d6'/></functionalities>
-			</boiler_state>
-			<fault_code id='a649c0c0731b4efe8f971a2174d95901' log_type='open_therm_application_specific_fault_code'>
-				<functionalities><point_log id='db8123f44611441095c67a6c2ff84ec7'/></functionalities>
-			</fault_code>
-			<timer id='a783fff6c496488cbee3d8b43fd5be7e' log_type='minimum_boiler_off_time'>
-				<functionalities><timer_functionality id='00a41642a7764d1d80fe37b0cd493730'/><point_log id='bf9870695c254ead9edc22f9abe52260'/></functionalities>
-			</timer>
-			<dip_switch id='a8d50bc1b02c4453acbf78c484da2ed0' log_type='boiler_enabled'>
-				<functionalities><point_log id='b4629113c7b44a43a3ba634fc054279c'/></functionalities>
-			</dip_switch>
-			<boiler_state id='aad2f61001b345ca85e9dda8e0beba70' log_type='domestic_hot_water_state'>
-				<functionalities><point_log id='09e461faff3a4abc9259f7c6e26ffcf0'/></functionalities>
-			</boiler_state>
-			<dip_switch id='acc1480a9e1f4b02ad9d94f7cbd8c6d9' log_type='serial_boiler_installation'>
-				<functionalities><point_log id='6e461af3d33245ffb49ffeaa2752a340'/></functionalities>
-			</dip_switch>
-			<interval_chrono_meter id='afda7f45daef401d9a0b651846933815' log_type='burner_operation_time'>
-				<functionalities><interval_log id='38e63c9a554249a9848053ad0ef8f148'/></functionalities>
-			</interval_chrono_meter>
-			<dip_switch id='bc0af70f6ee24c6b9a48542b4e1cb7f0' log_type='heating_curve'>
-				<functionalities><point_log id='e86e337316754960bca3bd5c3efe87c4'/></functionalities>
-			</dip_switch>
-			<thermostat id='bfe6665d0f05467b977b077b7b787cf1' log_type='boiler_minimum_outdoor_temperature'>
-				<functionalities><point_log id='0444ed9ec551496fadbeb728ab619daa'/><thermostat_functionality id='965f1d814e594fb191268c47ff527022'/></functionalities>
-			</thermostat>
-			<temperature_offset id='c2c422292b904217a49eb2ebb64139fa' log_type='cooling_lower_offset'>
-				<functionalities><offset_functionality id='08ca8e47df01477ebfc92442fc327ba8'/><point_log id='6c6734ca9c52437ebdd012dc1c9237b6'/></functionalities>
-			</temperature_offset>
-			<dip_switch id='c90363c157d84f3cb34ec9fa0ad4a1b1' log_type='first_fan_enabled'>
-				<functionalities><point_log id='08b3982eb0e445e79001228b879db934'/></functionalities>
-			</dip_switch>
-			<dip_switch id='cbbc6155ab0945248c08fb6c08be2e64' log_type='outdoor_temperature_used'>
-				<functionalities><point_log id='1e2304cab4b14e80a91d30f733509659'/></functionalities>
-			</dip_switch>
-			<timer id='cd3755b4f6454aa482f5603edc7c7019' log_type='external_pump_heating_lead_time'>
-				<functionalities><timer_functionality id='4538146f706d42098e9e233b0ef4d1bd'/><point_log id='7a088fe1ff4d44d5a03be6f1ddb69b1a'/></functionalities>
-			</timer>
-			<dip_switch id='cdcb69e61cf7452dad650f828827fc3c' log_type='thermostat_supports_cooling'>
-				<functionalities><point_log id='25e405154876410cbb760583417206bb'/></functionalities>
-			</dip_switch>
-			<thermo_meter id='ce44bfc81c5b4f2d82331c48b548aae7' log_type='refrigerent_out_temperature'>
-				<functionalities><point_log id='acedb4c2dd3d49039768c23832f7b599'/></functionalities>
-			</thermo_meter>
-			<dip_switch id='d127367c661c4c3582b544a08b0c68ad' log_type='underfloor_heating'>
-				<functionalities><point_log id='0a12b2e6991e4f42bf2912673547b156'/></functionalities>
-			</dip_switch>
-			<thermo_meter id='d26080b9f53246c08ff76d20e162670a' log_type='refrigerent_in_temperature'>
-				<functionalities><point_log id='375a05154d6647148cf393ac8b2c8b65'/></functionalities>
-			</thermo_meter>
-			<dip_switch id='d3abfcd0012e4b47af6d69911031f7ab' log_type='boiler_installed'>
-				<functionalities><point_log id='3f1313a814ec4614be4e709e659a4f8d'/></functionalities>
-			</dip_switch>
-			<thermo_meter id='dec96976f5f14d97a6cc290f9110e5ee' log_type='domestic_hot_water_setpoint'>
-				<functionalities><point_log id='af12fd7e384c4081b3700f7fc424ac79'/></functionalities>
-			</thermo_meter>
-			<dip_switch id='ebf84b976e4e4cb39c5b553e7a9e5fc1' log_type='night_reduction'>
-				<functionalities><point_log id='dd64bb930f484e2e8047c5020ef9c185'/></functionalities>
-			</dip_switch>
-			<timer id='ecbec078612949e6aa050f2ad9b55958' log_type='minimum_boiler_run_time'>
-				<functionalities><timer_functionality id='4d846b97eca946d78e6f3c0ae70f9db4'/><point_log id='e7b09f30833c458c9291c7cf761f0068'/></functionalities>
-			</timer>
-			<boiler_state id='f613e055261943f4987856badb3fb0ae' log_type='cooling_state'>
-				<functionalities><point_log id='bbfaf21ad4e14ca3be4ba9b508047d6b'/></functionalities>
-			</boiler_state>
-			<thermostat id='f7512e547d1c40f18d8911bd8bd1cce7' log_type='maximum_boiler_temperature'>
-				<functionalities><thermostat_functionality id='c0d682baec2b45979720a0c4253665b0'/><point_log id='d368799910734cc89ed1e3d5d60363fc'/></functionalities>
-			</thermostat>
-		</services>
-		<protocols>
-			<open_therm_boiler id='b2481333821543b0994b280c60395ba5'>
-				<thermo_extension id='668c0412fb2b420a80de9642b9f8a2f1'/>
-				<open_therm_version>0.0</open_therm_version>
-				<is_modulating>true</is_modulating>
-				<with_cooling>false</with_cooling>
-				<with_domestic_hot_water>false</with_domestic_hot_water>
-				<with_domestic_hot_water_storage>false</with_domestic_hot_water_storage>
-				<with_master_low_off_and_pump_control>true</with_master_low_off_and_pump_control>
-				<with_secondary_heating_circuit>false</with_secondary_heating_circuit>
-				<smartgrid_control>smart_grid_off</smartgrid_control>
-				<test_mode>off</test_mode>
-			</open_therm_boiler>
-		</protocols>
-	</module>
-	<appliance id='ebd90df1ab334565b5895f37590ccff4'>
-		<name>Anna</name>
-		<description>A thermostat</description>
-		<type>thermostat</type>
-		<created_date>2019-07-22T11:03:36.852+02:00</created_date>
-		<modified_date>2022-03-10T19:01:01.334+01:00</modified_date>
-		<deleted_date></deleted_date>
-		<location id='d3ce834534114348be628b61b26d9220'/>
-		<groups/>
-		<logs>
-			<point_log id='01a06384c7d449bba2725e8edf714584'>
-				<type>temperature_offset</type>
-				<unit>C</unit>
-				<updated_date>2022-03-02T17:48:18.308+01:00</updated_date>
-				<last_consecutive_log_date>2019-07-22T11:08:14.705+02:00</last_consecutive_log_date>
-				<interval/>
-				<temperature_offset id='a7b6d9b100ac460eaa9316b20a4ac407'/>
-				<period start_date="2022-03-02T17:48:18.308+01:00" end_date="2022-03-02T17:48:18.308+01:00">
-					<measurement log_date="2022-03-02T17:48:18.308+01:00">0.00</measurement>
-				</period>
-			</point_log>
-			<point_log id='05cfa5d4403b42ddb2f0258dc76d6754'>
-				<type>open_therm_boiler_activation_threshold</type>
-				<unit>C</unit>
-				<updated_date>2022-03-02T17:48:18.199+01:00</updated_date>
-				<last_consecutive_log_date>2020-07-09T16:11:46.259+02:00</last_consecutive_log_date>
-				<interval/>
-				<temperature_offset_meter id='b107e4d0690c40e38f9519de498f80d0'/>
-				<period start_date="2022-03-02T17:48:18.199+01:00" end_date="2022-03-02T17:48:18.199+01:00">
-					<measurement log_date="2022-03-02T17:48:18.199+01:00">0.00</measurement>
-				</period>
-			</point_log>
-			<point_log id='19a51cc2909a42308846d07095089c48'>
-				<type>decentral_heat_demand_offset</type>
-				<unit>C</unit>
-				<updated_date>2022-03-10T19:01:39.262+01:00</updated_date>
-				<last_consecutive_log_date>2020-08-15T17:11:15.017+02:00</last_consecutive_log_date>
-				<interval/>
-				<temperature_offset_meter id='1b662f928c4f4a739b521214d8539c47'/>
-				<period start_date="2022-03-10T19:01:39.262+01:00" end_date="2022-03-10T19:01:39.262+01:00">
-					<measurement log_date="2022-03-10T19:01:39.262+01:00">0.00</measurement>
-				</period>
-			</point_log>
-			<point_log id='23544f8616644a87a971bb584cd2c926'>
-				<type>proximity_detection</type>
-				<unit></unit>
-				<updated_date>2021-11-20T23:26:01.029+01:00</updated_date>
-				<last_consecutive_log_date>2021-11-20T23:26:01.029+01:00</last_consecutive_log_date>
-				<interval/>
-				<proximity_sensor id='ef39b2e2aacb40f08568a6fc638c242a'/>
-				<period start_date="2021-11-20T23:26:01.029+01:00" end_date="2021-11-20T23:26:01.029+01:00">
-					<measurement log_date="2021-11-20T23:26:01.029+01:00">proximity_detected</measurement>
-				</period>
-			</point_log>
-			<point_log id='5337865ab7f743388dca27d127deecb0'>
-				<type>cooling_deactivation_threshold</type>
-				<unit>C</unit>
-				<updated_date>2020-09-07T19:07:13.679+02:00</updated_date>
-				<last_consecutive_log_date>2020-09-07T19:07:13.679+02:00</last_consecutive_log_date>
-				<interval/>
-				<threshold id='06c97b7ed1504d498e09d1aa33240317'/>
-				<period start_date="2020-09-07T19:07:13.679+02:00" end_date="2020-09-07T19:07:13.679+02:00">
-					<measurement log_date="2020-09-07T19:07:13.679+02:00">3</measurement>
-				</period>
-			</point_log>
-			<point_log id='5c206e6a6fff4962b3e06d965c9caf4d'>
-				<type>derivative_coefficient</type>
-				<unit>s</unit>
-				<updated_date>2022-03-02T17:48:18.207+01:00</updated_date>
-				<last_consecutive_log_date>2020-07-10T05:28:54.022+02:00</last_consecutive_log_date>
-				<interval/>
-				<coefficient id='9c5191459bfa42e2bc92a951886ca6c0'/>
-				<period start_date="2022-03-02T17:48:18.207+01:00" end_date="2022-03-02T17:48:18.207+01:00">
-					<measurement log_date="2022-03-02T17:48:18.207+01:00">0</measurement>
-				</period>
-			</point_log>
-			<point_log id='6b8756139eb34bab9692edb22d0bcd50'>
-				<type>button_left</type>
-				<unit></unit>
-				<updated_date>2022-03-09T18:38:03.814+01:00</updated_date>
-				<last_consecutive_log_date>2022-03-09T18:38:03.814+01:00</last_consecutive_log_date>
-				<interval/>
-				<button id='d349d6b8767c491991390ea199337223'/>
-				<period start_date="2022-03-09T18:38:03.814+01:00" end_date="2022-03-09T18:38:03.814+01:00">
-					<measurement log_date="2022-03-09T18:38:03.814+01:00">up</measurement>
-				</period>
-			</point_log>
-			<point_log id='6c53a08fca4f44518247ca583f3f7741'>
-				<type>intended_domestic_hot_water_comfort_mode</type>
-				<unit></unit>
-				<updated_date>2022-03-10T18:58:40.707+01:00</updated_date>
-				<last_consecutive_log_date>2021-06-18T19:48:06.020+02:00</last_consecutive_log_date>
-				<interval/>
-				<boiler_state id='d67523ab0c934c4e9a0ec9262f7677b5'/>
-				<period start_date="2022-03-10T18:58:40.707+01:00" end_date="2022-03-10T18:58:40.707+01:00">
-					<measurement log_date="2022-03-10T18:58:40.707+01:00">on</measurement>
-				</period>
-			</point_log>
-			<point_log id='87a32c244021436b88d59ae44af16378'>
-				<type>button_right</type>
-				<unit></unit>
-				<updated_date>2022-03-09T18:38:06.192+01:00</updated_date>
-				<last_consecutive_log_date>2022-03-09T18:38:06.192+01:00</last_consecutive_log_date>
-				<interval/>
-				<button id='d8d99db2d9214863a3c7e28bcd115b12'/>
-				<period start_date="2022-03-09T18:38:06.192+01:00" end_date="2022-03-09T18:38:06.192+01:00">
-					<measurement log_date="2022-03-09T18:38:06.192+01:00">up</measurement>
-				</period>
-			</point_log>
-			<point_log id='90c3a54e3a1c465eb81302fef57f4410'>
-				<type>onoff_boiler_temperature_deadband</type>
-				<unit>C</unit>
-				<updated_date>2022-03-02T17:48:18.201+01:00</updated_date>
-				<last_consecutive_log_date>2019-07-22T11:08:16.530+02:00</last_consecutive_log_date>
-				<interval/>
-				<temperature_offset_meter id='725e6fbd7440407a99c3bf13cc22d870'/>
-				<period start_date="2022-03-02T17:48:18.201+01:00" end_date="2022-03-02T17:48:18.201+01:00">
-					<measurement log_date="2022-03-02T17:48:18.201+01:00">0.50</measurement>
-				</period>
-			</point_log>
-			<point_log id='9c2e08cbe1184ac9ae604d2c7a7c88cd'>
-				<type>temperature</type>
-				<unit>C</unit>
-				<updated_date>2022-03-10T19:01:01.330+01:00</updated_date>
-				<last_consecutive_log_date>2022-03-10T19:01:01.330+01:00</last_consecutive_log_date>
-				<interval>PT3H</interval>
-				<thermo_meter id='00426b5ea5584f91a1705c1baffde511'/>
-				<period start_date="2022-03-10T19:01:01.330+01:00" end_date="2022-03-10T19:01:01.330+01:00">
-					<measurement log_date="2022-03-10T19:01:01.330+01:00">20.93</measurement>
-				</period>
-			</point_log>
-			<point_log id='a1041c7b4a0544ce84870460f4f7624a'>
-				<type>proximity_sensor_state</type>
-				<unit></unit>
-				<updated_date>2022-03-02T17:48:18.302+01:00</updated_date>
-				<last_consecutive_log_date>2020-09-05T10:05:15.387+02:00</last_consecutive_log_date>
-				<interval/>
-				<proximity_sensor_toggle id='fbebb29bb7814191bae5c343567f4d8c'/>
-				<period start_date="2022-03-02T17:48:18.302+01:00" end_date="2022-03-02T17:48:18.302+01:00">
-					<measurement log_date="2022-03-02T17:48:18.302+01:00">on</measurement>
-				</period>
-			</point_log>
-			<point_log id='a406a1ebacf84ba2acde0a7bc37542e7'>
-				<type>button_top</type>
-				<unit></unit>
-				<updated_date>2022-03-09T21:05:01.647+01:00</updated_date>
-				<last_consecutive_log_date>2022-03-09T21:05:01.647+01:00</last_consecutive_log_date>
-				<interval/>
-				<button id='f84d8f82ff114da995c4af377cecede7'/>
-				<period start_date="2022-03-09T21:05:01.647+01:00" end_date="2022-03-09T21:05:01.647+01:00">
-					<measurement log_date="2022-03-09T21:05:01.647+01:00">up</measurement>
-				</period>
-			</point_log>
-			<point_log id='a5da72e538e94d0690a3491ea1f5c35a'>
-				<type>illuminance</type>
-				<unit>lx</unit>
-				<updated_date>2022-03-10T18:47:34.152+01:00</updated_date>
-				<last_consecutive_log_date>2022-03-10T18:47:34.152+01:00</last_consecutive_log_date>
-				<interval/>
-				<illuminance_meter id='4792764e63104d1691efa5bc966f5187'/>
-				<period start_date="2022-03-10T18:47:34.152+01:00" end_date="2022-03-10T18:47:34.152+01:00">
-					<measurement log_date="2022-03-10T18:47:34.152+01:00">0.50</measurement>
-				</period>
-			</point_log>
-			<point_log id='bed93c9f59cf445e8e796daba3f61df1'>
-				<type>intended_central_heating_state</type>
-				<unit></unit>
-				<updated_date>2022-03-10T18:58:40.707+01:00</updated_date>
-				<last_consecutive_log_date>2022-03-10T07:14:23.476+01:00</last_consecutive_log_date>
-				<interval/>
-				<boiler_state id='90771c033acc44f481f194309e2ed032'/>
-				<period start_date="2022-03-10T18:58:40.707+01:00" end_date="2022-03-10T18:58:40.707+01:00">
-					<measurement log_date="2022-03-10T18:58:40.707+01:00">off</measurement>
-				</period>
-			</point_log>
-			<point_log id='bfd9477530694a46bdc6749548fd218c'>
-				<type>thermostat</type>
-				<unit>C</unit>
-				<updated_date>2022-03-10T06:45:00.389+01:00</updated_date>
-				<last_consecutive_log_date>2022-03-10T06:45:00.389+01:00</last_consecutive_log_date>
-				<interval/>
-				<thermostat id='52b5a053e83446e6a11fde60a6c9ed11'/>
-				<period start_date="2022-03-10T06:45:00.389+01:00" end_date="2022-03-10T06:45:00.389+01:00">
-					<measurement log_date="2022-03-10T06:45:00.389+01:00">19.50</measurement>
-				</period>
-			</point_log>
-			<point_log id='cecd3059ab6d4ece9b419b7bf820b7f4'>
-				<type>cpu_frequency</type>
-				<unit>Hz</unit>
-				<updated_date>2022-03-09T21:05:36+01:00</updated_date>
-				<last_consecutive_log_date>2022-03-09T21:05:36+01:00</last_consecutive_log_date>
-				<interval/>
-				<frequency_meter id='894b17e281dd4429bb5982de7048d929'/>
-				<period start_date="2022-03-09T21:05:36+01:00" end_date="2022-03-09T21:05:36+01:00">
-					<measurement log_date="2022-03-09T21:05:36+01:00">8000000</measurement>
-				</period>
-			</point_log>
-			<point_log id='dbb111e942c74bc3bdac40d228d58082'>
-				<type>target_temperature</type>
-				<unit>C</unit>
-				<updated_date>2022-03-10T07:21:30.916+01:00</updated_date>
-				<last_consecutive_log_date>2022-03-10T07:21:30.916+01:00</last_consecutive_log_date>
-				<interval/>
-				<thermo_meter id='261d7f5dd4494c139cf30bcc20a87ebe'/>
-				<period start_date="2022-03-10T07:21:30.916+01:00" end_date="2022-03-10T07:21:30.916+01:00">
-					<measurement log_date="2022-03-10T07:21:30.916+01:00">19.50</measurement>
-				</period>
-			</point_log>
-			<point_log id='e2e178a233174a1fa9268c5d90a43bfe'>
-				<type>cooling_activation_outdoor_temperature</type>
-				<unit>C</unit>
-				<updated_date>2021-06-18T20:48:58.071+02:00</updated_date>
-				<last_consecutive_log_date>2021-06-18T20:48:58.071+02:00</last_consecutive_log_date>
-				<interval/>
-				<thermostat id='6be1fe5740ee44ada8faf4fe8c7b24b8'/>
-				<period start_date="2021-06-18T20:48:58.071+02:00" end_date="2021-06-18T20:48:58.071+02:00">
-					<measurement log_date="2021-06-18T20:48:58.071+02:00">26.00</measurement>
-				</period>
-			</point_log>
-			<point_log id='fa88a8770fe846f3a11e1bdffc09b7b5'>
-				<type>preheating_target_temperature_rate</type>
-				<unit>C_hr</unit>
-				<updated_date>2022-03-02T17:48:18.072+01:00</updated_date>
-				<last_consecutive_log_date>2022-01-05T09:09:32.278+01:00</last_consecutive_log_date>
-				<interval/>
-				<temperature_rate id='725cff112a2b4d839ce6b8229c461c66'/>
-				<period start_date="2022-03-02T17:48:18.072+01:00" end_date="2022-03-02T17:48:18.072+01:00">
-					<measurement log_date="2022-03-02T17:48:18.072+01:00">9.97</measurement>
-				</period>
-			</point_log>
-		</logs>
-		<actuator_functionalities>
-			<threshold_functionality id='12c30fcd3ae0465c9a57661cbb6b5e22'>
-				<threshold id='06c97b7ed1504d498e09d1aa33240317'/>
-				<updated_date>2020-09-07T19:07:13.680+02:00</updated_date>
-				<type>cooling_deactivation_threshold</type>
-				<threshold>3</threshold>
-				<lower_bound>1</lower_bound>
-				<upper_bound>40</upper_bound>
-				<resolution>0.1</resolution>
-			</threshold_functionality>
-			<offset_functionality id='30ba5dff06a347938dbbcbef5a9b425d'>
-				<temperature_offset id='a7b6d9b100ac460eaa9316b20a4ac407'/>
-				<updated_date>2022-03-02T17:48:18.308+01:00</updated_date>
-				<type>temperature_offset</type>
-				<offset>0</offset>
-			</offset_functionality>
-			<thermostat_functionality id='5dd948c45a004b02a43d032117fda550'>
-				<updated_date>2021-06-18T20:48:58.072+02:00</updated_date>
-				<type>cooling_activation_outdoor_temperature</type>
-				<setpoint>26</setpoint>
-				<lower_bound>1</lower_bound>
-				<upper_bound>40</upper_bound>
-				<resolution>0.1</resolution>
-				<regulations/>
-				<thermostat id='6be1fe5740ee44ada8faf4fe8c7b24b8'/>
-			</thermostat_functionality>
-			<thermostat_functionality id='9d718e17024446f296adecf2a1da9e18'>
-				<updated_date>2022-03-10T06:45:00.390+01:00</updated_date>
-				<type>thermostat</type>
-				<setpoint>19.5</setpoint>
-				<lower_bound>4</lower_bound>
-				<upper_bound>30</upper_bound>
-				<resolution>0.1</resolution>
-				<regulations><ame_regulation id='1c8b1a395ed848a2a67d65996bf0bb75'/></regulations>
-				<thermostat id='52b5a053e83446e6a11fde60a6c9ed11'/>
-			</thermostat_functionality>
-			<toggle_functionality id='e841103f04ae4e8184c9b3e6172c2266'>
-				<proximity_sensor_toggle id='fbebb29bb7814191bae5c343567f4d8c'/>
-				<updated_date>2022-03-02T17:48:18.302+01:00</updated_date>
-				<type>proximity_sensor_state</type>
-				<state>on</state>
-			</toggle_functionality>
-		</actuator_functionalities>
-	</appliance>
-	<module id='3b36454dda794c6faaed4053a89e80ce'>
-		<vendor_name>Plugwise</vendor_name>
-		<vendor_model>ThermoTouch</vendor_model>
-		<hardware_version>6539-1301-5002</hardware_version>
-		<firmware_version>2018-02-08T11:15:53+01:00</firmware_version>
-		<created_date>2019-07-22T11:03:36.712+02:00</created_date>
-		<modified_date>2021-10-28T04:56:47.858+02:00</modified_date>
-		<deleted_date></deleted_date>
-		<services>
-			<thermo_meter id='00426b5ea5584f91a1705c1baffde511' log_type='temperature'>
-				<functionalities><point_log id='9c2e08cbe1184ac9ae604d2c7a7c88cd'/></functionalities>
-			</thermo_meter>
-			<threshold id='06c97b7ed1504d498e09d1aa33240317' log_type='cooling_deactivation_threshold'>
-				<functionalities><threshold_functionality id='12c30fcd3ae0465c9a57661cbb6b5e22'/><point_log id='5337865ab7f743388dca27d127deecb0'/></functionalities>
-			</threshold>
-			<temperature_offset_meter id='1b662f928c4f4a739b521214d8539c47' log_type='decentral_heat_demand_offset'>
-				<functionalities><point_log id='19a51cc2909a42308846d07095089c48'/></functionalities>
-			</temperature_offset_meter>
-			<thermo_meter id='261d7f5dd4494c139cf30bcc20a87ebe' log_type='target_temperature'>
-				<functionalities><point_log id='dbb111e942c74bc3bdac40d228d58082'/></functionalities>
-			</thermo_meter>
-			<illuminance_meter id='4792764e63104d1691efa5bc966f5187' log_type='illuminance'>
-				<functionalities><point_log id='a5da72e538e94d0690a3491ea1f5c35a'/></functionalities>
-			</illuminance_meter>
-			<thermostat id='52b5a053e83446e6a11fde60a6c9ed11' log_type='thermostat'>
-				<functionalities><thermostat_functionality id='9d718e17024446f296adecf2a1da9e18'/><point_log id='bfd9477530694a46bdc6749548fd218c'/></functionalities>
-			</thermostat>
-			<thermostat id='6be1fe5740ee44ada8faf4fe8c7b24b8' log_type='cooling_activation_outdoor_temperature'>
-				<functionalities><thermostat_functionality id='5dd948c45a004b02a43d032117fda550'/><point_log id='e2e178a233174a1fa9268c5d90a43bfe'/></functionalities>
-			</thermostat>
-			<temperature_rate id='725cff112a2b4d839ce6b8229c461c66' log_type='preheating_target_temperature_rate'>
-				<functionalities><point_log id='fa88a8770fe846f3a11e1bdffc09b7b5'/></functionalities>
-			</temperature_rate>
-			<temperature_offset_meter id='725e6fbd7440407a99c3bf13cc22d870' log_type='onoff_boiler_temperature_deadband'>
-				<functionalities><point_log id='90c3a54e3a1c465eb81302fef57f4410'/></functionalities>
-			</temperature_offset_meter>
-			<frequency_meter id='894b17e281dd4429bb5982de7048d929' log_type='cpu_frequency'>
-				<functionalities><point_log id='cecd3059ab6d4ece9b419b7bf820b7f4'/></functionalities>
-			</frequency_meter>
-			<boiler_state id='90771c033acc44f481f194309e2ed032' log_type='intended_central_heating_state'>
-				<functionalities><point_log id='bed93c9f59cf445e8e796daba3f61df1'/></functionalities>
-			</boiler_state>
-			<coefficient id='9c5191459bfa42e2bc92a951886ca6c0' log_type='derivative_coefficient'>
-				<functionalities><point_log id='5c206e6a6fff4962b3e06d965c9caf4d'/></functionalities>
-			</coefficient>
-			<temperature_offset id='a7b6d9b100ac460eaa9316b20a4ac407' log_type='temperature_offset'>
-				<functionalities><point_log id='01a06384c7d449bba2725e8edf714584'/><offset_functionality id='30ba5dff06a347938dbbcbef5a9b425d'/></functionalities>
-			</temperature_offset>
-			<temperature_offset_meter id='b107e4d0690c40e38f9519de498f80d0' log_type='open_therm_boiler_activation_threshold'>
-				<functionalities><point_log id='05cfa5d4403b42ddb2f0258dc76d6754'/></functionalities>
-			</temperature_offset_meter>
-			<button id='d349d6b8767c491991390ea199337223' log_type='button_left' position='left'>
-				<functionalities><point_log id='6b8756139eb34bab9692edb22d0bcd50'/></functionalities>
-			</button>
-			<boiler_state id='d67523ab0c934c4e9a0ec9262f7677b5' log_type='intended_domestic_hot_water_comfort_mode'>
-				<functionalities><point_log id='6c53a08fca4f44518247ca583f3f7741'/></functionalities>
-			</boiler_state>
-			<button id='d8d99db2d9214863a3c7e28bcd115b12' log_type='button_right' position='right'>
-				<functionalities><point_log id='87a32c244021436b88d59ae44af16378'/></functionalities>
-			</button>
-			<proximity_sensor id='ef39b2e2aacb40f08568a6fc638c242a' log_type='proximity_detection'>
-				<functionalities><point_log id='23544f8616644a87a971bb584cd2c926'/></functionalities>
-			</proximity_sensor>
-			<button id='f84d8f82ff114da995c4af377cecede7' log_type='button_top' position='top'>
-				<functionalities><point_log id='a406a1ebacf84ba2acde0a7bc37542e7'/></functionalities>
-			</button>
-			<proximity_sensor_toggle id='fbebb29bb7814191bae5c343567f4d8c' log_type='proximity_sensor_state'>
-				<functionalities><point_log id='a1041c7b4a0544ce84870460f4f7624a'/><toggle_functionality id='e841103f04ae4e8184c9b3e6172c2266'/></functionalities>
-			</proximity_sensor_toggle>
-		</services>
-		<protocols>
-			<thermo_touch id='af43990b4ca744cf8e9f9b5996190f6f'><thermo_extension id='668c0412fb2b420a80de9642b9f8a2f1'/></thermo_touch>
-		</protocols>
-	</module>
-	<template id='999adea416e84b9c96d9d198ed2005f8' tag="relay_state_based_on_time">
-		<name>Relay schedule template</name>
-		<description>Template for scheduling relays on a time basis.</description>
-		<single_actor>true</single_actor>
-		<created_date>2017-10-25T14:55:02.487+02:00</created_date>
-		<modified_date>2022-03-02T17:47:56.621+01:00</modified_date>
-		<deleted_date></deleted_date>
-		<objects>
-			<object name="direct_object" type="DirectObject"/>
-		</objects>
-		<parameters>
-			<parameter name="time" source="clock.weekTime" type="WeekTime"/>
-		</parameters>
-		<results>
-			<result name="state" type="OnOff" action="direct_object.iterateFunctionalities('RelayFunctionality')().state = state"/>
-		</results>
-	</template>
-	<gateway id='f65e90f31ac3496a9419f4b933e64c15'>
-		<created_date>2017-10-25T14:55:02.060+02:00</created_date>
-		<modified_date>2022-03-10T13:55:17.142+01:00</modified_date>
-		<deleted_date/>
-		<name></name>
-		<description></description>
-		<enabled>true</enabled>
-		<firmware_locked>false</firmware_locked>
-		<prevent_default_update>false</prevent_default_update>
-		<last_reset_date>2017-08-29T08:24:38.164+02:00</last_reset_date>
-		<last_boot_date>2021-10-31T14:48:27.951+01:00</last_boot_date>
-		<vendor_name>Plugwise</vendor_name>
-		<vendor_model>smile_thermo</vendor_model>
-		<hardware_version>AME Smile 2.0 board</hardware_version>
-		<firmware_version>4.2.1</firmware_version>
-		<mac_address>C4930002FE76</mac_address>
-		<short_id>abcdefgh</short_id>
-		<send_data>true</send_data>
-		<anonymous>true</anonymous>
-		<lan_ip></lan_ip>
-		<wifi_ip>127.0.0.2</wifi_ip>
-		<hostname>smile000000</hostname>
-		<time>2022-03-10T19:01:14+01:00</time>
-		<timezone>Europe/Amsterdam</timezone>
-		<ssh_relay>disabled</ssh_relay>
-		<project id='68e91423192a4093b6aaf3af0babe94f'>
-			<name>Techneco</name>
-			<description>Gateways voor Techneco</description>
-			<is_default>false</is_default>
-			<visible_in_production>false</visible_in_production>
-			<deleted_date></deleted_date>
-			<modified_date>2018-07-12T11:13:23.436+02:00</modified_date>
-			<created_date>2017-10-02T13:20:08+02:00</created_date>
-		</project>
-		<gateway_environment id='3034b99b7ec7493099e54d6d2849a86d'>
-			<savings_result_value/>
-			<longitude>4.49</longitude>
-			<thermostat_model/>
-			<city>Sassenheim</city>
-			<country>NL</country>
-			<electricity_consumption_tariff_structure/>
-			<electricity_production_peak_tariff/>
-			<central_heating_model/>
-			<household_children>2</household_children>
-			<thermostat_brand/>
-			<electricity_production_off_peak_tariff/>
-			<central_heating_installation_date/>
-			<postal_code>2171</postal_code>
-			<electricity_consumption_off_peak_tariff/>
-			<latitude>52.21</latitude>
-			<gas_consumption_tariff/>
-			<modified_date>2022-03-09T21:47:09.009+01:00</modified_date>
-			<electricity_production_tariff_structure/>
-			<tariff_region>NL</tariff_region>
-			<housing_construction_period>after_1990</housing_construction_period>
-			<electricity_production_single_tariff/>
-			<electricity_consumption_peak_tariff/>
-			<electricity_consumption_single_tariff/>
-			<central_heating_brand/>
-			<housing_type>detached</housing_type>
-			<currency>EUR</currency>
-			<savings_result_unit/>
-			<household_adults>3</household_adults>
-			<central_heating_year_of_manufacture/>
-			<deleted_date></deleted_date>
-			<modified_date>2022-03-09T21:47:09.009+01:00</modified_date>
-			<created_date>2022-03-08T22:00:34+01:00</created_date>
-		</gateway_environment>
-		<features>
-			<elga_support id='2a37ce7426b144688f2d09614ba20c36'>
-				<activation_date></activation_date>
-				<expiration_date>2038-01-19T04:14:07+01:00</expiration_date>
-				<validity_period/>
-				<valid_to></valid_to>
-				<valid_from></valid_from>
-				<grace_period/>
-				<deleted_date></deleted_date>
-				<modified_date>2018-07-12T11:13:23.659+02:00</modified_date>
-				<created_date>2017-10-31T15:37:07+01:00</created_date>
-			</elga_support>
-			<remote_control id='70b914220d974189ad03327c3ef023d6'>
-				<activation_date></activation_date>
-				<expiration_date>2038-01-19T04:14:07+01:00</expiration_date>
-				<validity_period/>
-				<valid_to></valid_to>
-				<valid_from></valid_from>
-				<grace_period/>
-				<deleted_date></deleted_date>
-				<modified_date>2018-07-12T11:13:23.496+02:00</modified_date>
-				<created_date>2017-10-31T15:37:07+01:00</created_date>
-			</remote_control>
-			<elga_support id='f23b22573edf4e928e0bf2f236c43aa6'>
-				<activation_date></activation_date>
-				<expiration_date>2038-01-19T04:14:07+01:00</expiration_date>
-				<validity_period/>
-				<valid_to></valid_to>
-				<valid_from></valid_from>
-				<grace_period/>
-				<deleted_date></deleted_date>
-				<modified_date>2018-07-12T11:13:23.723+02:00</modified_date>
-				<created_date>2017-10-31T15:38:09+01:00</created_date>
-			</elga_support>
-			<remote_control id='fcedcf651875495d8e7c89d75cc2c345'>
-				<activation_date></activation_date>
-				<expiration_date>2038-01-19T04:14:07+01:00</expiration_date>
-				<validity_period/>
-				<valid_to></valid_to>
-				<valid_from></valid_from>
-				<grace_period/>
-				<deleted_date></deleted_date>
-				<modified_date>2018-07-12T11:13:23.554+02:00</modified_date>
-				<created_date>2017-10-31T15:38:09+01:00</created_date>
-			</remote_control>
-		</features>
-	</gateway>
-	<appliance id='573c152e7d4f4720878222bd75638f5b'>
-		<name>Central heating boiler</name>
-		<description></description>
-		<type>heater_central</type>
-		<created_date>2019-07-22T11:08:27.693+02:00</created_date>
-		<modified_date>2022-03-10T19:03:14.319+01:00</modified_date>
-		<deleted_date></deleted_date>
-		<groups/>
-		<logs>
-			<point_log id='00c5146fe1a749e3925627d59700652a'>
-				<type>flame_state</type>
-				<unit></unit>
-				<updated_date>2022-03-10T18:58:40.743+01:00</updated_date>
-				<last_consecutive_log_date>2022-03-10T18:58:40.743+01:00</last_consecutive_log_date>
-				<interval/>
-				<boiler_state id='9c0a03f4a7f94290997bef767e5a81c2'/>
-				<period start_date="2022-03-10T18:58:40.743+01:00" end_date="2022-03-10T18:58:40.743+01:00">
-					<measurement log_date="2022-03-10T18:58:40.743+01:00">off</measurement>
-				</period>
-			</point_log>
-			<point_log id='02b66447758049fab71cfc396d0b4423'>
-				<type>hibernation_lead_time</type>
-				<unit>hr</unit>
-				<updated_date>2022-03-10T18:50:56.200+01:00</updated_date>
-				<last_consecutive_log_date>2020-07-09T14:27:57.508+02:00</last_consecutive_log_date>
-				<interval/>
-				<timer id='397304cc8cbe47798f41930b1d62b009'/>
-				<period start_date="2022-03-10T18:50:56.200+01:00" end_date="2022-03-10T18:50:56.200+01:00">
-					<measurement log_date="2022-03-10T18:50:56.200+01:00">10</measurement>
-				</period>
-			</point_log>
-			<point_log id='0444ed9ec551496fadbeb728ab619daa'>
-				<type>boiler_minimum_outdoor_temperature</type>
-				<unit>C</unit>
-				<updated_date>2022-03-10T18:52:08.027+01:00</updated_date>
-				<last_consecutive_log_date>2021-06-18T20:48:46.399+02:00</last_consecutive_log_date>
-				<interval/>
-				<thermostat id='bfe6665d0f05467b977b077b7b787cf1'/>
-				<period start_date="2022-03-10T18:52:08.027+01:00" end_date="2022-03-10T18:52:08.027+01:00">
-					<measurement log_date="2022-03-10T18:52:08.027+01:00">11.00</measurement>
-				</period>
-			</point_log>
-			<point_log id='083ba290a88245f3bd56957d6695dd55'>
-				<type>maximum_outdoor_unit_power_increase_temperature</type>
-				<unit>C</unit>
-				<updated_date>2022-03-10T18:51:35.435+01:00</updated_date>
-				<last_consecutive_log_date>2020-07-10T05:29:01.726+02:00</last_consecutive_log_date>
-				<interval/>
-				<thermostat id='564f724946434905b7d2b6c142e4ba67'/>
-				<period start_date="2022-03-10T18:51:35.435+01:00" end_date="2022-03-10T18:51:35.435+01:00">
-					<measurement log_date="2022-03-10T18:51:35.435+01:00">43.00</measurement>
-				</period>
-			</point_log>
-			<point_log id='08b3982eb0e445e79001228b879db934'>
-				<type>first_fan_enabled</type>
-				<unit></unit>
-				<updated_date>2022-03-10T19:02:55.817+01:00</updated_date>
-				<last_consecutive_log_date>2020-07-09T14:28:46.073+02:00</last_consecutive_log_date>
-				<interval/>
-				<dip_switch id='c90363c157d84f3cb34ec9fa0ad4a1b1'/>
-				<period start_date="2022-03-10T19:02:55.817+01:00" end_date="2022-03-10T19:02:55.817+01:00">
-					<measurement log_date="2022-03-10T19:02:55.817+01:00">off</measurement>
-				</period>
-			</point_log>
-			<point_log id='09e461faff3a4abc9259f7c6e26ffcf0'>
-				<type>domestic_hot_water_state</type>
-				<unit></unit>
-				<updated_date>2022-03-10T18:58:40.724+01:00</updated_date>
-				<last_consecutive_log_date>2022-03-10T18:58:40.724+01:00</last_consecutive_log_date>
-				<interval/>
-				<boiler_state id='aad2f61001b345ca85e9dda8e0beba70'/>
-				<period start_date="2022-03-10T18:58:40.724+01:00" end_date="2022-03-10T18:58:40.724+01:00">
-					<measurement log_date="2022-03-10T18:58:40.724+01:00">off</measurement>
-				</period>
-			</point_log>
-			<point_log id='0a12b2e6991e4f42bf2912673547b156'>
-				<type>underfloor_heating</type>
-				<unit></unit>
-				<updated_date>2022-03-10T19:03:27.643+01:00</updated_date>
-				<last_consecutive_log_date>2020-07-09T14:28:26.128+02:00</last_consecutive_log_date>
-				<interval/>
-				<dip_switch id='d127367c661c4c3582b544a08b0c68ad'/>
-				<period start_date="2022-03-10T19:03:27.643+01:00" end_date="2022-03-10T19:03:27.643+01:00">
-					<measurement log_date="2022-03-10T19:03:27.643+01:00">off</measurement>
-				</period>
-			</point_log>
-			<point_log id='0b1f4d8bbbbd451bb5214a7f592124e5'>
-				<type>intended_boiler_temperature</type>
-				<unit>C</unit>
-				<updated_date>2022-03-10T07:14:11.022+01:00</updated_date>
-				<last_consecutive_log_date>2022-03-10T07:14:11.022+01:00</last_consecutive_log_date>
-				<interval/>
-				<thermo_meter id='1d0d91857e4042ec9180e2bc78898d13'/>
-				<period start_date="2022-03-10T07:14:11.022+01:00" end_date="2022-03-10T07:14:11.022+01:00">
-					<measurement log_date="2022-03-10T07:14:11.022+01:00">0.00</measurement>
-				</period>
-			</point_log>
-			<point_log id='10cea8565cd343768a6867c47c0300c6'>
-				<type>maximum_outdoor_unit_temperature</type>
-				<unit>C</unit>
-				<updated_date>2022-03-10T18:51:25.148+01:00</updated_date>
-				<last_consecutive_log_date>2020-07-09T14:28:06.192+02:00</last_consecutive_log_date>
-				<interval/>
-				<thermostat id='333ef91f62d94f78ad7b9bedaecc71f2'/>
-				<period start_date="2022-03-10T18:51:25.148+01:00" end_date="2022-03-10T18:51:25.148+01:00">
-					<measurement log_date="2022-03-10T18:51:25.148+01:00">47.00</measurement>
-				</period>
-			</point_log>
-			<point_log id='1365f71019794971bbb06ebd881b7c84'>
-				<type>internal_pump_heating_lead_time</type>
-				<unit>s</unit>
-				<updated_date>2022-03-10T18:51:11.992+01:00</updated_date>
-				<last_consecutive_log_date>2020-07-09T14:27:25.659+02:00</last_consecutive_log_date>
-				<interval/>
-				<timer id='881f3c1377bc4efda8c78409a18ebe55'/>
-				<period start_date="2022-03-10T18:51:11.992+01:00" end_date="2022-03-10T18:51:11.992+01:00">
-					<measurement log_date="2022-03-10T18:51:11.992+01:00">60</measurement>
-				</period>
-			</point_log>
-			<point_log id='188ba49897614157a0b2723087058010'>
-				<type>hibernation_enabled</type>
-				<unit></unit>
-				<updated_date>2022-03-10T19:03:27.624+01:00</updated_date>
-				<last_consecutive_log_date>2020-07-09T14:28:22.042+02:00</last_consecutive_log_date>
-				<interval/>
-				<dip_switch id='53a892b70e7a4f01a6174415509e8590'/>
-				<period start_date="2022-03-10T19:03:27.624+01:00" end_date="2022-03-10T19:03:27.624+01:00">
-					<measurement log_date="2022-03-10T19:03:27.624+01:00">off</measurement>
-				</period>
-			</point_log>
-			<point_log id='1a94ecad909b40848efdce89197bae6d'>
-				<type>modulation_level</type>
-				<unit></unit>
-				<updated_date>2022-03-10T19:00:40.066+01:00</updated_date>
-				<last_consecutive_log_date>2022-03-10T04:18:58.547+01:00</last_consecutive_log_date>
-				<interval/>
-				<modulation_level id='8862e6a7a98842928028e3f14493de8b'/>
-				<period start_date="2022-03-10T19:00:40.066+01:00" end_date="2022-03-10T19:00:40.066+01:00">
-					<measurement log_date="2022-03-10T19:00:40.066+01:00">0.00</measurement>
-				</period>
-			</point_log>
-			<point_log id='1d03fff43bf640f998150fabc2aa7522'>
-				<type>elga_status_code</type>
-				<unit></unit>
-				<updated_date>2022-03-10T19:03:26.975+01:00</updated_date>
-				<last_consecutive_log_date>2022-03-10T07:58:46.609+01:00</last_consecutive_log_date>
-				<interval/>
-				<status_code id='91eb08ab048d4f8c947399a64a2e618b'/>
-				<period start_date="2022-03-10T19:03:26.975+01:00" end_date="2022-03-10T19:03:26.975+01:00">
-					<measurement log_date="2022-03-10T19:03:26.975+01:00">2</measurement>
-				</period>
-			</point_log>
-			<point_log id='1e2304cab4b14e80a91d30f733509659'>
-				<type>outdoor_temperature_used</type>
-				<unit></unit>
-				<updated_date>2022-03-10T19:02:55.805+01:00</updated_date>
-				<last_consecutive_log_date>2020-07-09T14:28:40.296+02:00</last_consecutive_log_date>
-				<interval/>
-				<dip_switch id='cbbc6155ab0945248c08fb6c08be2e64'/>
-				<period start_date="2022-03-10T19:02:55.805+01:00" end_date="2022-03-10T19:02:55.805+01:00">
-					<measurement log_date="2022-03-10T19:02:55.805+01:00">on</measurement>
-				</period>
-			</point_log>
-			<point_log id='24b48396d2c24a7089fd3a3f0476fe3d'>
-				<type>elga_outdoor_unit_fault_code</type>
-				<unit></unit>
-				<updated_date>2022-03-10T19:03:23.488+01:00</updated_date>
-				<last_consecutive_log_date>2020-07-10T05:29:03.330+02:00</last_consecutive_log_date>
-				<interval/>
-				<fault_code id='310985c85e5e42238c4ae63180e8ed2c'/>
-				<period start_date="2022-03-10T19:03:23.488+01:00" end_date="2022-03-10T19:03:23.488+01:00">
-					<measurement log_date="2022-03-10T19:03:23.488+01:00">0</measurement>
-				</period>
-			</point_log>
-			<point_log id='25e405154876410cbb760583417206bb'>
-				<type>thermostat_supports_cooling</type>
-				<unit></unit>
-				<updated_date>2022-03-10T19:03:27.599+01:00</updated_date>
-				<last_consecutive_log_date>2020-08-08T10:01:07.520+02:00</last_consecutive_log_date>
-				<interval/>
-				<dip_switch id='cdcb69e61cf7452dad650f828827fc3c'/>
-				<period start_date="2022-03-10T19:03:27.599+01:00" end_date="2022-03-10T19:03:27.599+01:00">
-					<measurement log_date="2022-03-10T19:03:27.599+01:00">on</measurement>
-				</period>
-			</point_log>
-			<point_log id='292c77f567194b14a0e7c3d63b340e66'>
-				<type>maximum_cooling_supply_temperature</type>
-				<unit>C</unit>
-				<updated_date>2022-03-10T18:51:53.457+01:00</updated_date>
-				<last_consecutive_log_date>2020-07-09T14:27:52.988+02:00</last_consecutive_log_date>
-				<interval/>
-				<thermostat id='82b1c7dcc6674568af1dbace5e64af8b'/>
-				<period start_date="2022-03-10T18:51:53.457+01:00" end_date="2022-03-10T18:51:53.457+01:00">
-					<measurement log_date="2022-03-10T18:51:53.457+01:00">21.00</measurement>
-				</period>
-			</point_log>
-			<point_log id='2e0289df2c7f4b66b8a4f562658a6903'>
-				<type>domestic_hot_water_comfort_mode</type>
-				<unit></unit>
-				<updated_date>2022-03-02T17:48:17.871+01:00</updated_date>
-				<last_consecutive_log_date>2021-06-18T19:48:06.123+02:00</last_consecutive_log_date>
-				<interval/>
-				<domestic_hot_water_toggle id='29fb663d576a46c79d629826edff95f0'/>
-				<period start_date="2022-03-02T17:48:17.871+01:00" end_date="2022-03-02T17:48:17.871+01:00">
-					<measurement log_date="2022-03-02T17:48:17.871+01:00">on</measurement>
-				</period>
-			</point_log>
-			<point_log id='375a05154d6647148cf393ac8b2c8b65'>
-				<type>refrigerent_in_temperature</type>
-				<unit>C</unit>
-				<updated_date>2022-03-10T19:03:13.936+01:00</updated_date>
-				<last_consecutive_log_date>2022-03-10T18:59:41.657+01:00</last_consecutive_log_date>
-				<interval/>
-				<thermo_meter id='d26080b9f53246c08ff76d20e162670a'/>
-				<period start_date="2022-03-10T19:03:13.936+01:00" end_date="2022-03-10T19:03:13.936+01:00">
-					<measurement log_date="2022-03-10T19:03:13.936+01:00">23.00</measurement>
-				</period>
-			</point_log>
-			<interval_log id='38e63c9a554249a9848053ad0ef8f148'>
-				<type>burner_operation_time</type>
-				<unit>s</unit>
-				<updated_date>2022-03-10T18:00:00+01:00</updated_date>
-				<last_consecutive_log_date>2022-03-10T17:00:00+01:00</last_consecutive_log_date>
-				<interval>PT1H</interval>
-				<interval_chrono_meter id='afda7f45daef401d9a0b651846933815'/>
-				<period start_date="2022-03-10T18:00:00+01:00" end_date="2022-03-10T18:00:00+01:00" interval="PT1H">
-					<measurement log_date="2022-03-10T18:00:00+01:00">66</measurement>
-				</period>
-			</interval_log>
-			<point_log id='3ad82db986354586b9a0b63ffe9685d6'>
-				<type>slave_boiler_state</type>
-				<unit></unit>
-				<updated_date>2022-03-10T19:03:05.441+01:00</updated_date>
-				<last_consecutive_log_date>2022-03-10T07:58:53.378+01:00</last_consecutive_log_date>
-				<interval/>
-				<boiler_state id='a5d3ae6bd1474d4ebf506f405bb94b06'/>
-				<period start_date="2022-03-10T19:03:05.441+01:00" end_date="2022-03-10T19:03:05.441+01:00">
-					<measurement log_date="2022-03-10T19:03:05.441+01:00">off</measurement>
-				</period>
-			</point_log>
-			<point_log id='3f1313a814ec4614be4e709e659a4f8d'>
-				<type>boiler_installed</type>
-				<unit></unit>
-				<updated_date>2022-03-10T19:02:55.820+01:00</updated_date>
-				<last_consecutive_log_date>2020-07-09T14:28:47.551+02:00</last_consecutive_log_date>
-				<interval/>
-				<dip_switch id='d3abfcd0012e4b47af6d69911031f7ab'/>
-				<period start_date="2022-03-10T19:02:55.820+01:00" end_date="2022-03-10T19:02:55.820+01:00">
-					<measurement log_date="2022-03-10T19:02:55.820+01:00">on</measurement>
-				</period>
-			</point_log>
-			<point_log id='40e35727c7b947f48099b5221633474c'>
-				<type>compressor_state</type>
-				<unit></unit>
-				<updated_date>2022-03-10T19:03:20.412+01:00</updated_date>
-				<last_consecutive_log_date>2022-03-10T04:19:06.754+01:00</last_consecutive_log_date>
-				<interval/>
-				<boiler_state id='1efb6c04052e4defbe429d6440c285c6'/>
-				<period start_date="2022-03-10T19:03:20.412+01:00" end_date="2022-03-10T19:03:20.412+01:00">
-					<measurement log_date="2022-03-10T19:03:20.412+01:00">off</measurement>
-				</period>
-			</point_log>
-			<point_log id='48f202225fb94f0b96540d97e65397c7'>
-				<type>temperature</type>
-				<unit>C</unit>
-				<updated_date></updated_date>
-				<last_consecutive_log_date></last_consecutive_log_date>
-				<interval>PT3H</interval>
-				<thermo_meter id='167efda4780e4fa8bbc8f588f4708fa2'/>
-			</point_log>
-			<point_log id='56c09638ead640a5a7b6864a6a1db81b'>
-				<type>weather_dependent_regulation</type>
-				<unit></unit>
-				<updated_date>2022-03-10T19:02:55.799+01:00</updated_date>
-				<last_consecutive_log_date>2020-07-09T14:28:37.344+02:00</last_consecutive_log_date>
-				<interval/>
-				<dip_switch id='60c6512c9b9249199ca4adb48ab30e4e'/>
-				<period start_date="2022-03-10T19:02:55.799+01:00" end_date="2022-03-10T19:02:55.799+01:00">
-					<measurement log_date="2022-03-10T19:02:55.799+01:00">off</measurement>
-				</period>
-			</point_log>
-			<point_log id='5cd62cb4ac5a4067859f074a9a0eeb66'>
-				<type>minimum_heating_supply_temperature</type>
-				<unit>C</unit>
-				<updated_date>2022-03-10T18:51:45.258+01:00</updated_date>
-				<last_consecutive_log_date>2020-07-09T14:27:54.422+02:00</last_consecutive_log_date>
-				<interval/>
-				<thermostat id='9d9f24a42c514c99887d85091ba46d74'/>
-				<period start_date="2022-03-10T18:51:45.258+01:00" end_date="2022-03-10T18:51:45.258+01:00">
-					<measurement log_date="2022-03-10T18:51:45.258+01:00">40.00</measurement>
-				</period>
-			</point_log>
-			<point_log id='5f0c73d239254abea42bdf1cf02bd7de'>
-				<type>intended_central_heating_state</type>
-				<unit></unit>
-				<updated_date>2022-03-10T07:14:23.490+01:00</updated_date>
-				<last_consecutive_log_date>2022-03-10T07:14:23.490+01:00</last_consecutive_log_date>
-				<interval/>
-				<boiler_state id='72ac57601ea7410381c889a1f58b191c'/>
-				<period start_date="2022-03-10T07:14:23.490+01:00" end_date="2022-03-10T07:14:23.490+01:00">
-					<measurement log_date="2022-03-10T07:14:23.490+01:00">off</measurement>
-				</period>
-			</point_log>
-			<point_log id='6c6734ca9c52437ebdd012dc1c9237b6'>
-				<type>cooling_lower_offset</type>
-				<unit>C</unit>
-				<updated_date>2022-03-10T18:51:54.652+01:00</updated_date>
-				<last_consecutive_log_date>2021-07-15T14:56:23.167+02:00</last_consecutive_log_date>
-				<interval/>
-				<temperature_offset id='c2c422292b904217a49eb2ebb64139fa'/>
-				<period start_date="2022-03-10T18:51:54.652+01:00" end_date="2022-03-10T18:51:54.652+01:00">
-					<measurement log_date="2022-03-10T18:51:54.652+01:00">1.00</measurement>
-				</period>
-			</point_log>
-			<point_log id='6e461af3d33245ffb49ffeaa2752a340'>
-				<type>serial_boiler_installation</type>
-				<unit></unit>
-				<updated_date>2022-03-10T19:02:55.814+01:00</updated_date>
-				<last_consecutive_log_date>2020-07-09T14:28:44.626+02:00</last_consecutive_log_date>
-				<interval/>
-				<dip_switch id='acc1480a9e1f4b02ad9d94f7cbd8c6d9'/>
-				<period start_date="2022-03-10T19:02:55.814+01:00" end_date="2022-03-10T19:02:55.814+01:00">
-					<measurement log_date="2022-03-10T19:02:55.814+01:00">on</measurement>
-				</period>
-			</point_log>
-			<point_log id='705e0e0f37574caabd69dd6a9db1620d'>
-				<type>minimum_cooling_supply_temperature</type>
-				<unit>C</unit>
-				<updated_date>2022-03-10T18:51:54.508+01:00</updated_date>
-				<last_consecutive_log_date>2020-07-09T14:27:51.551+02:00</last_consecutive_log_date>
-				<interval/>
-				<thermostat id='5304a8c3c39e42b990c9b057e880f8a4'/>
-				<period start_date="2022-03-10T18:51:54.508+01:00" end_date="2022-03-10T18:51:54.508+01:00">
-					<measurement log_date="2022-03-10T18:51:54.508+01:00">17.00</measurement>
-				</period>
-			</point_log>
-			<point_log id='72e0439587ac443c8880f35543c12834'>
-				<type>internal_pump_cooling_lead_time</type>
-				<unit>s</unit>
-				<updated_date>2022-03-10T18:50:38.763+01:00</updated_date>
-				<last_consecutive_log_date>2020-07-10T05:28:58.206+02:00</last_consecutive_log_date>
-				<interval/>
-				<timer id='7ccb6bc94f1948ee9f16ecfb5c80d719'/>
-				<period start_date="2022-03-10T18:50:38.763+01:00" end_date="2022-03-10T18:50:38.763+01:00">
-					<measurement log_date="2022-03-10T18:50:38.763+01:00">120</measurement>
-				</period>
-			</point_log>
-			<point_log id='78125fc1129b404782f7cf08c1a72401'>
-				<type>external_pump_cooling_lead_time</type>
-				<unit>s</unit>
-				<updated_date>2022-03-10T18:50:29.536+01:00</updated_date>
-				<last_consecutive_log_date>2020-07-10T05:28:58.417+02:00</last_consecutive_log_date>
-				<interval/>
-				<timer id='68a4b6945cbb49e0b1629ae6a44da34b'/>
-				<period start_date="2022-03-10T18:50:29.536+01:00" end_date="2022-03-10T18:50:29.536+01:00">
-					<measurement log_date="2022-03-10T18:50:29.536+01:00">120</measurement>
-				</period>
-			</point_log>
-			<point_log id='7a088fe1ff4d44d5a03be6f1ddb69b1a'>
-				<type>external_pump_heating_lead_time</type>
-				<unit>s</unit>
-				<updated_date>2022-03-10T18:51:00.507+01:00</updated_date>
-				<last_consecutive_log_date>2021-07-15T14:57:03.163+02:00</last_consecutive_log_date>
-				<interval/>
-				<timer id='cd3755b4f6454aa482f5603edc7c7019'/>
-				<period start_date="2022-03-10T18:51:00.507+01:00" end_date="2022-03-10T18:51:00.507+01:00">
-					<measurement log_date="2022-03-10T18:51:00.507+01:00">60</measurement>
-				</period>
-			</point_log>
-			<point_log id='7a90e2fb40a34176a94e408957c5c27c'>
-				<type>temperature_sensor_enabled</type>
-				<unit></unit>
-				<updated_date>2022-03-10T19:02:55.812+01:00</updated_date>
-				<last_consecutive_log_date>2020-07-09T14:28:43.155+02:00</last_consecutive_log_date>
-				<interval/>
-				<dip_switch id='74fab0d973c049e09f3514141f58c0ef'/>
-				<period start_date="2022-03-10T19:02:55.812+01:00" end_date="2022-03-10T19:02:55.812+01:00">
-					<measurement log_date="2022-03-10T19:02:55.812+01:00">off</measurement>
-				</period>
-			</point_log>
-			<point_log id='7d79610e27234506b0220b7e1a14eb3a'>
-				<type>open_therm_oem_fault_code</type>
-				<unit></unit>
-				<updated_date>2022-03-02T17:48:17.669+01:00</updated_date>
-				<last_consecutive_log_date>2021-06-18T20:15:20.896+02:00</last_consecutive_log_date>
-				<interval/>
-				<fault_code id='6e268f4aa86e4cc0a29c084d00c8319b'/>
-				<period start_date="2022-03-02T17:48:17.669+01:00" end_date="2022-03-02T17:48:17.669+01:00">
-					<measurement log_date="2022-03-02T17:48:17.669+01:00">0</measurement>
-				</period>
-			</point_log>
-			<point_log id='7e6f7d5dfdd84b5ca8287d0f30944e8b'>
-				<type>thermostat_enabled</type>
-				<unit></unit>
-				<updated_date>2022-03-10T19:03:27.593+01:00</updated_date>
-				<last_consecutive_log_date>2020-07-09T14:28:16.761+02:00</last_consecutive_log_date>
-				<interval/>
-				<dip_switch id='5f729e9aa96c4e33ad866f2efe41e694'/>
-				<period start_date="2022-03-10T19:03:27.593+01:00" end_date="2022-03-10T19:03:27.593+01:00">
-					<measurement log_date="2022-03-10T19:03:27.593+01:00">off</measurement>
-				</period>
-			</point_log>
-			<point_log id='80737def763544d797ce2ecebbaaf606'>
-				<type>input_contacts_installed</type>
-				<unit></unit>
-				<updated_date>2022-03-10T19:02:55.802+01:00</updated_date>
-				<last_consecutive_log_date>2020-07-09T14:28:38.738+02:00</last_consecutive_log_date>
-				<interval/>
-				<dip_switch id='4d79c04aa75340519aca29545955bf76'/>
-				<period start_date="2022-03-10T19:02:55.802+01:00" end_date="2022-03-10T19:02:55.802+01:00">
-					<measurement log_date="2022-03-10T19:02:55.802+01:00">on</measurement>
-				</period>
-			</point_log>
-			<point_log id='8bbc4ca809b84a41b6c6115a8ccacecf'>
-				<type>night_reduction_setpoint</type>
-				<unit>C</unit>
-				<updated_date>2022-03-10T18:52:04.533+01:00</updated_date>
-				<last_consecutive_log_date>2020-07-10T05:28:59.268+02:00</last_consecutive_log_date>
-				<interval/>
-				<thermostat id='7c4e5837e0474ad3888e97cf21a51670'/>
-				<period start_date="2022-03-10T18:52:04.533+01:00" end_date="2022-03-10T18:52:04.533+01:00">
-					<measurement log_date="2022-03-10T18:52:04.533+01:00">19.00</measurement>
-				</period>
-			</point_log>
-			<point_log id='9556ad80c44b48459e297eeca0720cc3'>
-				<type>boiler_temperature</type>
-				<unit>C</unit>
-				<updated_date>2022-03-10T19:02:40.695+01:00</updated_date>
-				<last_consecutive_log_date>2022-03-10T19:02:40.695+01:00</last_consecutive_log_date>
-				<interval>PT1H</interval>
-				<thermo_meter id='8eafb561fafb42ef8305eae670851e4a'/>
-				<period start_date="2022-03-10T19:02:40.695+01:00" end_date="2022-03-10T19:02:40.695+01:00">
-					<measurement log_date="2022-03-10T19:02:40.695+01:00">22.79</measurement>
-				</period>
-			</point_log>
-			<point_log id='a45bc7ff672748328d3f83e6a4808ea3'>
-				<type>open_therm_slave_oem_fault_code</type>
-				<unit></unit>
-				<updated_date>2022-03-10T19:03:21.028+01:00</updated_date>
-				<last_consecutive_log_date>2021-06-18T20:05:30.832+02:00</last_consecutive_log_date>
-				<interval/>
-				<fault_code id='3af7b55915d841808e61d89a7663b7a2'/>
-				<period start_date="2022-03-10T19:03:21.028+01:00" end_date="2022-03-10T19:03:21.028+01:00">
-					<measurement log_date="2022-03-10T19:03:21.028+01:00">0</measurement>
-				</period>
-			</point_log>
-			<point_log id='a6e3ad5afe8e4c6c9feafbd95f221a3a'>
-				<type>second_fan_enabled</type>
-				<unit></unit>
-				<updated_date>2022-03-10T19:02:55.808+01:00</updated_date>
-				<last_consecutive_log_date>2020-07-09T14:28:41.739+02:00</last_consecutive_log_date>
-				<interval/>
-				<dip_switch id='769ba34f091e4fe4a0718ed34defea99'/>
-				<period start_date="2022-03-10T19:02:55.808+01:00" end_date="2022-03-10T19:02:55.808+01:00">
-					<measurement log_date="2022-03-10T19:02:55.808+01:00">off</measurement>
-				</period>
-			</point_log>
-			<point_log id='acedb4c2dd3d49039768c23832f7b599'>
-				<type>refrigerent_out_temperature</type>
-				<unit>C</unit>
-				<updated_date>2022-03-10T19:03:33.179+01:00</updated_date>
-				<last_consecutive_log_date>2020-07-09T14:27:08.393+02:00</last_consecutive_log_date>
-				<interval/>
-				<thermo_meter id='ce44bfc81c5b4f2d82331c48b548aae7'/>
-				<period start_date="2022-03-10T19:03:33.179+01:00" end_date="2022-03-10T19:03:33.179+01:00">
-					<measurement log_date="2022-03-10T19:03:33.179+01:00">0.00</measurement>
-				</period>
-			</point_log>
-			<point_log id='af12fd7e384c4081b3700f7fc424ac79'>
-				<type>domestic_hot_water_setpoint</type>
-				<unit>C</unit>
-				<updated_date>2022-03-02T17:48:18.016+01:00</updated_date>
-				<last_consecutive_log_date>2020-07-10T05:28:53.712+02:00</last_consecutive_log_date>
-				<interval/>
-				<thermo_meter id='dec96976f5f14d97a6cc290f9110e5ee'/>
-				<period start_date="2022-03-02T17:48:18.016+01:00" end_date="2022-03-02T17:48:18.016+01:00">
-					<measurement log_date="2022-03-02T17:48:18.016+01:00">60.00</measurement>
-				</period>
-			</point_log>
-			<point_log id='b4629113c7b44a43a3ba634fc054279c'>
-				<type>boiler_enabled</type>
-				<unit></unit>
-				<updated_date>2022-03-10T19:03:27.614+01:00</updated_date>
-				<last_consecutive_log_date>2020-07-09T14:28:20.699+02:00</last_consecutive_log_date>
-				<interval/>
-				<dip_switch id='a8d50bc1b02c4453acbf78c484da2ed0'/>
-				<period start_date="2022-03-10T19:03:27.614+01:00" end_date="2022-03-10T19:03:27.614+01:00">
-					<measurement log_date="2022-03-10T19:03:27.614+01:00">off</measurement>
-				</period>
-			</point_log>
-			<point_log id='bbfaf21ad4e14ca3be4ba9b508047d6b'>
-				<type>cooling_state</type>
-				<unit></unit>
-				<updated_date>2022-03-02T17:48:17.865+01:00</updated_date>
-				<last_consecutive_log_date>2021-08-13T16:16:06.313+02:00</last_consecutive_log_date>
-				<interval/>
-				<boiler_state id='f613e055261943f4987856badb3fb0ae'/>
-				<period start_date="2022-03-02T17:48:17.865+01:00" end_date="2022-03-02T17:48:17.865+01:00">
-					<measurement log_date="2022-03-02T17:48:17.865+01:00">off</measurement>
-				</period>
-			</point_log>
-			<point_log id='bf9870695c254ead9edc22f9abe52260'>
-				<type>minimum_boiler_off_time</type>
-				<unit>s</unit>
-				<updated_date>2022-03-10T18:51:42.554+01:00</updated_date>
-				<last_consecutive_log_date>2020-07-09T14:28:00.562+02:00</last_consecutive_log_date>
-				<interval/>
-				<timer id='a783fff6c496488cbee3d8b43fd5be7e'/>
-				<period start_date="2022-03-10T18:51:42.554+01:00" end_date="2022-03-10T18:51:42.554+01:00">
-					<measurement log_date="2022-03-10T18:51:42.554+01:00">20</measurement>
-				</period>
-			</point_log>
-			<point_log id='c0a8e16b4efd465a88ed471330a99046'>
-				<type>maximum_outdoor_unit_steady_temperature</type>
-				<unit>C</unit>
-				<updated_date>2022-03-10T18:51:32.735+01:00</updated_date>
-				<last_consecutive_log_date>2020-07-09T14:28:04.609+02:00</last_consecutive_log_date>
-				<interval/>
-				<thermostat id='07c7b619be4242d6919733e6098a5b5e'/>
-				<period start_date="2022-03-10T18:51:32.735+01:00" end_date="2022-03-10T18:51:32.735+01:00">
-					<measurement log_date="2022-03-10T18:51:32.735+01:00">45.00</measurement>
-				</period>
-			</point_log>
-			<point_log id='c49b3ce126314dca848d51429a0ef2ea'>
-				<type>indoor_temperature_transition_time</type>
-				<unit>min</unit>
-				<updated_date>2022-03-10T18:52:06.142+01:00</updated_date>
-				<last_consecutive_log_date>2020-07-09T14:27:45.834+02:00</last_consecutive_log_date>
-				<interval/>
-				<timer id='1b79f533784742c796c973856b30909d'/>
-				<period start_date="2022-03-10T18:52:06.142+01:00" end_date="2022-03-10T18:52:06.142+01:00">
-					<measurement log_date="2022-03-10T18:52:06.142+01:00">5</measurement>
-				</period>
-			</point_log>
-			<point_log id='c65f2f2e30df4e1cb48bff1afc6bfaf5'>
-				<type>simultaneous_boiler_operation</type>
-				<unit></unit>
-				<updated_date>2022-03-10T19:03:27.637+01:00</updated_date>
-				<last_consecutive_log_date>2020-07-09T14:28:24.774+02:00</last_consecutive_log_date>
-				<interval/>
-				<dip_switch id='8eeb17de38da4b37992c7ef910592306'/>
-				<period start_date="2022-03-10T19:03:27.637+01:00" end_date="2022-03-10T19:03:27.637+01:00">
-					<measurement log_date="2022-03-10T19:03:27.637+01:00">on</measurement>
-				</period>
-			</point_log>
-			<point_log id='d368799910734cc89ed1e3d5d60363fc'>
-				<type>maximum_boiler_temperature</type>
-				<unit>C</unit>
-				<updated_date>2022-03-02T17:48:17.773+01:00</updated_date>
-				<last_consecutive_log_date>2020-07-10T05:28:53.525+02:00</last_consecutive_log_date>
-				<interval/>
-				<thermostat id='f7512e547d1c40f18d8911bd8bd1cce7'/>
-				<period start_date="2022-03-02T17:48:17.773+01:00" end_date="2022-03-02T17:48:17.773+01:00">
-					<measurement log_date="2022-03-02T17:48:17.773+01:00">60.00</measurement>
-				</period>
-			</point_log>
-			<point_log id='d517c9c0c3254926bd881c61b41f2185'>
-				<type>weather_dependent_maximum_supply_temperature</type>
-				<unit>C</unit>
-				<updated_date>2022-03-10T18:51:21.045+01:00</updated_date>
-				<last_consecutive_log_date>2021-07-15T15:55:13.072+02:00</last_consecutive_log_date>
-				<interval/>
-				<thermostat id='3636e8c24b764f9dae52ba36695ed476'/>
-				<period start_date="2022-03-10T18:51:21.045+01:00" end_date="2022-03-10T18:51:21.045+01:00">
-					<measurement log_date="2022-03-10T18:51:21.045+01:00">60.00</measurement>
-				</period>
-			</point_log>
-			<point_log id='d6e5970949cc4c48a1e20d830e3f9856'>
-				<type>central_heating_state</type>
-				<unit></unit>
-				<updated_date>2022-03-10T18:58:45.858+01:00</updated_date>
-				<last_consecutive_log_date>2022-03-10T18:58:45.858+01:00</last_consecutive_log_date>
-				<interval/>
-				<boiler_state id='93242446d05a443fa31dc19c56fef767'/>
-				<period start_date="2022-03-10T18:58:45.858+01:00" end_date="2022-03-10T18:58:45.858+01:00">
-					<measurement log_date="2022-03-10T18:58:45.858+01:00">off</measurement>
-				</period>
-			</point_log>
-			<point_log id='d703b335844c4d789b707534cb5dbd3e'>
-				<type>pump_lag_time</type>
-				<unit>s</unit>
-				<updated_date>2022-03-10T18:52:07.779+01:00</updated_date>
-				<last_consecutive_log_date>2021-07-15T15:56:51.601+02:00</last_consecutive_log_date>
-				<interval/>
-				<timer id='4ac8d9303b644429b5c5bae03a79470a'/>
-				<period start_date="2022-03-10T18:52:07.779+01:00" end_date="2022-03-10T18:52:07.779+01:00">
-					<measurement log_date="2022-03-10T18:52:07.779+01:00">30</measurement>
-				</period>
-			</point_log>
-			<point_log id='daac6bf095ce472082653bd4a57c58f9'>
-				<type>heatpump_minimum_outdoor_temperature</type>
-				<unit>C</unit>
-				<updated_date>2022-03-10T18:52:04.726+01:00</updated_date>
-				<last_consecutive_log_date>2021-06-02T15:40:22.531+02:00</last_consecutive_log_date>
-				<interval/>
-				<thermostat id='211f6996e8394d12a1f2cdb23b420a2c'/>
-				<period start_date="2022-03-10T18:52:04.726+01:00" end_date="2022-03-10T18:52:04.726+01:00">
-					<measurement log_date="2022-03-10T18:52:04.726+01:00">2.00</measurement>
-				</period>
-			</point_log>
-			<point_log id='db8123f44611441095c67a6c2ff84ec7'>
-				<type>open_therm_application_specific_fault_code</type>
-				<unit></unit>
-				<updated_date>2022-03-02T17:48:17.665+01:00</updated_date>
-				<last_consecutive_log_date>2019-07-22T11:08:35.538+02:00</last_consecutive_log_date>
-				<interval/>
-				<fault_code id='a649c0c0731b4efe8f971a2174d95901'/>
-				<period start_date="2022-03-02T17:48:17.665+01:00" end_date="2022-03-02T17:48:17.665+01:00">
-					<measurement log_date="2022-03-02T17:48:17.665+01:00">0</measurement>
-				</period>
-			</point_log>
-			<point_log id='dd64bb930f484e2e8047c5020ef9c185'>
-				<type>night_reduction</type>
-				<unit></unit>
-				<updated_date>2022-03-10T19:03:27.630+01:00</updated_date>
-				<last_consecutive_log_date>2020-07-09T14:28:23.418+02:00</last_consecutive_log_date>
-				<interval/>
-				<dip_switch id='ebf84b976e4e4cb39c5b553e7a9e5fc1'/>
-				<period start_date="2022-03-10T19:03:27.630+01:00" end_date="2022-03-10T19:03:27.630+01:00">
-					<measurement log_date="2022-03-10T19:03:27.630+01:00">off</measurement>
-				</period>
-			</point_log>
-			<point_log id='e5f051ef9b1542f2bf1b340fb6ba26d2'>
-				<type>cooling_upper_offset</type>
-				<unit>C</unit>
-				<updated_date>2022-03-10T18:51:55.065+01:00</updated_date>
-				<last_consecutive_log_date>2020-07-10T05:28:59.437+02:00</last_consecutive_log_date>
-				<interval/>
-				<temperature_offset id='7c77a680bb0645aeb325f196e4a3df57'/>
-				<period start_date="2022-03-10T18:51:55.065+01:00" end_date="2022-03-10T18:51:55.065+01:00">
-					<measurement log_date="2022-03-10T18:51:55.065+01:00">3.00</measurement>
-				</period>
-			</point_log>
-			<point_log id='e799a764479a4c4586179dd0760fe54e'>
-				<type>central_heater_water_pressure</type>
-				<unit>bar</unit>
-				<updated_date>2022-03-10T18:52:23.773+01:00</updated_date>
-				<last_consecutive_log_date>2022-03-10T07:52:15.530+01:00</last_consecutive_log_date>
-				<interval/>
-				<pressure_gauge id='01d551e4bb2b475a9463912a3fd887da'/>
-				<period start_date="2022-03-10T18:52:23.773+01:00" end_date="2022-03-10T18:52:23.773+01:00">
-					<measurement log_date="2022-03-10T18:52:23.773+01:00">0.50</measurement>
-				</period>
-			</point_log>
-			<point_log id='e7b09f30833c458c9291c7cf761f0068'>
-				<type>minimum_boiler_run_time</type>
-				<unit>s</unit>
-				<updated_date>2022-03-10T18:50:49.023+01:00</updated_date>
-				<last_consecutive_log_date>2020-07-10T05:29:01.284+02:00</last_consecutive_log_date>
-				<interval/>
-				<timer id='ecbec078612949e6aa050f2ad9b55958'/>
-				<period start_date="2022-03-10T18:50:49.023+01:00" end_date="2022-03-10T18:50:49.023+01:00">
-					<measurement log_date="2022-03-10T18:50:49.023+01:00">20</measurement>
-				</period>
-			</point_log>
-			<point_log id='e809f761a4c14287a852a8c727bbdc40'>
-				<type>boiler_activation_threshold</type>
-				<unit>Cmin</unit>
-				<updated_date>2022-03-10T18:51:14.452+01:00</updated_date>
-				<last_consecutive_log_date>2020-07-09T14:28:09.472+02:00</last_consecutive_log_date>
-				<interval/>
-				<threshold id='38eadee2fac04aaab6f8fac793560c82'/>
-				<period start_date="2022-03-10T18:51:14.452+01:00" end_date="2022-03-10T18:51:14.452+01:00">
-					<measurement log_date="2022-03-10T18:51:14.452+01:00">30</measurement>
-				</period>
-			</point_log>
-			<point_log id='e86e337316754960bca3bd5c3efe87c4'>
-				<type>heating_curve</type>
-				<unit></unit>
-				<updated_date>2022-03-10T19:03:27.610+01:00</updated_date>
-				<last_consecutive_log_date>2020-07-09T14:28:19.383+02:00</last_consecutive_log_date>
-				<interval/>
-				<dip_switch id='bc0af70f6ee24c6b9a48542b4e1cb7f0'/>
-				<period start_date="2022-03-10T19:03:27.610+01:00" end_date="2022-03-10T19:03:27.610+01:00">
-					<measurement log_date="2022-03-10T19:03:27.610+01:00">off</measurement>
-				</period>
-			</point_log>
-			<point_log id='f3eaebe5868840099b2f6eea9763dec3'>
-				<type>maximum_heating_supply_temperature</type>
-				<unit>C</unit>
-				<updated_date>2022-03-10T18:50:56.638+01:00</updated_date>
-				<last_consecutive_log_date>2020-07-10T05:29:00.729+02:00</last_consecutive_log_date>
-				<interval/>
-				<thermostat id='4b8a974d347f4cf1872a5bc07f613068'/>
-				<period start_date="2022-03-10T18:50:56.638+01:00" end_date="2022-03-10T18:50:56.638+01:00">
-					<measurement log_date="2022-03-10T18:50:56.638+01:00">70.00</measurement>
-				</period>
-			</point_log>
-			<point_log id='f9aff78878654f84a8344c0851d7cb33'>
-				<type>return_water_temperature</type>
-				<unit>C</unit>
-				<updated_date>2022-03-10T19:02:40.475+01:00</updated_date>
-				<last_consecutive_log_date>2022-03-10T19:02:40.475+01:00</last_consecutive_log_date>
-				<interval>PT1H</interval>
-				<thermo_meter id='a2847eec8a634ccdb70d3c1a79c60df7'/>
-				<period start_date="2022-03-10T19:02:40.475+01:00" end_date="2022-03-10T19:02:40.475+01:00">
-					<measurement log_date="2022-03-10T19:02:40.475+01:00">23.39</measurement>
-				</period>
-			</point_log>
-			<point_log id='fa0e3334f8d941cbbb040c5bf52fb2df'>
-				<type>outdoor_temperature</type>
-				<unit>C</unit>
-				<updated_date>2022-03-10T19:03:14.258+01:00</updated_date>
-				<last_consecutive_log_date>2022-03-10T19:03:14.258+01:00</last_consecutive_log_date>
-				<interval>PT3H</interval>
-				<thermo_meter id='8609fbdcab4b46e387953184f9878c28'/>
-				<period start_date="2022-03-10T19:03:14.258+01:00" end_date="2022-03-10T19:03:14.258+01:00">
-					<measurement log_date="2022-03-10T19:03:14.258+01:00">14.00</measurement>
-				</period>
-			</point_log>
-			<point_log id='9257714483e4423a8a3423072eda3d40'>
-				<type>cooling_enabled</type>
-				<unit></unit>
-				<updated_date>2022-11-02T03:57:23.207+01:00</updated_date>
-				<last_consecutive_log_date>2022-11-02T03:57:23.207+01:00</last_consecutive_log_date>
-				<interval/>
-				<cooling_toggle id='b556a934246f4d99979288841e7ee58a'/>
-				<period start_date="2022-11-02T03:57:23.207+01:00" end_date="2022-11-02T03:57:23.207+01:00">
-					<measurement log_date="2022-11-02T03:57:23.207+01:00">off</measurement>
-				</period>
-			</point_log>
-		</logs>
-		<actuator_functionalities>
-			<timer_functionality id='00a41642a7764d1d80fe37b0cd493730'>
-				<timer id='a783fff6c496488cbee3d8b43fd5be7e'/>
-				<updated_date>2022-03-10T18:51:42.554+01:00</updated_date>
-				<type>minimum_boiler_off_time</type>
-				<duration>20</duration>
-				<lower_bound>0</lower_bound>
-				<upper_bound>60</upper_bound>
-				<resolution>5</resolution>
-			</timer_functionality>
-			<timer_functionality id='0646e6e1204147668157d2a7c59ef3ee'>
-				<timer id='881f3c1377bc4efda8c78409a18ebe55'/>
-				<updated_date>2022-03-10T18:51:11.992+01:00</updated_date>
-				<type>internal_pump_heating_lead_time</type>
-				<duration>60</duration>
-				<lower_bound>10</lower_bound>
-				<upper_bound>240</upper_bound>
-				<resolution>10</resolution>
-			</timer_functionality>
-			<thermostat_functionality id='07699ce0bdd6491db490f0e15642ca43'>
-				<updated_date>2022-03-10T18:52:04.533+01:00</updated_date>
-				<type>night_reduction_setpoint</type>
-				<setpoint>19</setpoint>
-				<lower_bound>1</lower_bound>
-				<upper_bound>30</upper_bound>
-				<resolution>1</resolution>
-				<regulations/>
-				<thermostat id='7c4e5837e0474ad3888e97cf21a51670'/>
-			</thermostat_functionality>
-			<offset_functionality id='08ca8e47df01477ebfc92442fc327ba8'>
-				<temperature_offset id='c2c422292b904217a49eb2ebb64139fa'/>
-				<updated_date>2022-03-10T18:51:54.652+01:00</updated_date>
-				<type>cooling_lower_offset</type>
-				<offset>1</offset>
-			</offset_functionality>
-			<timer_functionality id='4538146f706d42098e9e233b0ef4d1bd'>
-				<timer id='cd3755b4f6454aa482f5603edc7c7019'/>
-				<updated_date>2022-03-10T18:51:00.507+01:00</updated_date>
-				<type>external_pump_heating_lead_time</type>
-				<duration>60</duration>
-				<lower_bound>10</lower_bound>
-				<upper_bound>240</upper_bound>
-				<resolution>10</resolution>
-			</timer_functionality>
-			<timer_functionality id='4823c26f51bc4b07928acbb5ef056ca1'>
-				<timer id='397304cc8cbe47798f41930b1d62b009'/>
-				<updated_date>2022-03-10T18:50:56.200+01:00</updated_date>
-				<type>hibernation_lead_time</type>
-				<duration>10</duration>
-				<lower_bound>1</lower_bound>
-				<upper_bound>24</upper_bound>
-				<resolution>1</resolution>
-			</timer_functionality>
-			<timer_functionality id='4d846b97eca946d78e6f3c0ae70f9db4'>
-				<timer id='ecbec078612949e6aa050f2ad9b55958'/>
-				<updated_date>2022-03-10T18:50:49.023+01:00</updated_date>
-				<type>minimum_boiler_run_time</type>
-				<duration>20</duration>
-				<lower_bound>0</lower_bound>
-				<upper_bound>60</upper_bound>
-				<resolution>5</resolution>
-			</timer_functionality>
-			<timer_functionality id='4e627a99dcf94bc086b31aa3a6de44b2'>
-				<timer id='1b79f533784742c796c973856b30909d'/>
-				<updated_date>2022-03-10T18:52:06.142+01:00</updated_date>
-				<type>indoor_temperature_transition_time</type>
-				<duration>5</duration>
-				<lower_bound>0</lower_bound>
-				<upper_bound>30</upper_bound>
-				<resolution>1</resolution>
-			</timer_functionality>
-			<threshold_functionality id='57fb489e615a46888a051712ca8954f2'>
-				<threshold id='38eadee2fac04aaab6f8fac793560c82'/>
-				<updated_date>2022-03-10T18:51:14.452+01:00</updated_date>
-				<type>boiler_activation_threshold</type>
-				<threshold>30</threshold>
-				<lower_bound>10</lower_bound>
-				<upper_bound>120</upper_bound>
-				<resolution>10</resolution>
-			</threshold_functionality>
-			<thermostat_functionality id='5b6c3a3cf0de4adc92e4aac0d93e1962'>
-				<updated_date>2022-03-10T18:51:45.258+01:00</updated_date>
-				<type>minimum_heating_supply_temperature</type>
-				<setpoint>40</setpoint>
-				<lower_bound>20</lower_bound>
-				<upper_bound>90</upper_bound>
-				<resolution>5</resolution>
-				<regulations/>
-				<thermostat id='9d9f24a42c514c99887d85091ba46d74'/>
-			</thermostat_functionality>
-			<timer_functionality id='631c67b8e2f2411d83ffa5a687f3b79b'>
-				<timer id='4ac8d9303b644429b5c5bae03a79470a'/>
-				<updated_date>2022-03-10T18:52:07.779+01:00</updated_date>
-				<type>pump_lag_time</type>
-				<duration>30</duration>
-				<lower_bound>10</lower_bound>
-				<upper_bound>240</upper_bound>
-				<resolution>10</resolution>
-			</timer_functionality>
-			<thermostat_functionality id='6385d825e10545bfabc3cd3574920b68'>
-				<updated_date>2022-03-10T18:51:53.457+01:00</updated_date>
-				<type>maximum_cooling_supply_temperature</type>
-				<setpoint>21</setpoint>
-				<lower_bound>5</lower_bound>
-				<upper_bound>25</upper_bound>
-				<resolution>1</resolution>
-				<regulations/>
-				<thermostat id='82b1c7dcc6674568af1dbace5e64af8b'/>
-			</thermostat_functionality>
-			<offset_functionality id='69ed60c3bc3846449e61dba62e71da40'>
-				<temperature_offset id='7c77a680bb0645aeb325f196e4a3df57'/>
-				<updated_date>2022-03-10T18:51:55.065+01:00</updated_date>
-				<type>cooling_upper_offset</type>
-				<offset>3</offset>
-			</offset_functionality>
-			<toggle_functionality id='700bd52a8729461bb0fdf6d055c08710'>
-				<domestic_hot_water_toggle id='29fb663d576a46c79d629826edff95f0'/>
-				<updated_date>2022-03-02T17:48:17.871+01:00</updated_date>
-				<type>domestic_hot_water_comfort_mode</type>
-				<state>on</state>
-			</toggle_functionality>
-			<timer_functionality id='8dcd68a78d704da8b0a61083d376223f'>
-				<timer id='68a4b6945cbb49e0b1629ae6a44da34b'/>
-				<updated_date>2022-03-10T18:50:29.536+01:00</updated_date>
-				<type>external_pump_cooling_lead_time</type>
-				<duration>120</duration>
-				<lower_bound>120</lower_bound>
-				<upper_bound>240</upper_bound>
-				<resolution>10</resolution>
-			</timer_functionality>
-			<thermostat_functionality id='965f1d814e594fb191268c47ff527022'>
-				<updated_date>2022-03-10T18:52:08.027+01:00</updated_date>
-				<type>boiler_minimum_outdoor_temperature</type>
-				<setpoint>11</setpoint>
-				<lower_bound>-10</lower_bound>
-				<upper_bound>40</upper_bound>
-				<resolution>1</resolution>
-				<regulations/>
-				<thermostat id='bfe6665d0f05467b977b077b7b787cf1'/>
-			</thermostat_functionality>
-			<thermostat_functionality id='9cee766c36c843288b9bc17628e2a5a7'>
-				<updated_date>2022-03-10T18:51:32.735+01:00</updated_date>
-				<type>maximum_outdoor_unit_steady_temperature</type>
-				<setpoint>45</setpoint>
-				<lower_bound>25</lower_bound>
-				<upper_bound>45</upper_bound>
-				<resolution>1</resolution>
-				<regulations/>
-				<thermostat id='07c7b619be4242d6919733e6098a5b5e'/>
-			</thermostat_functionality>
-			<thermostat_functionality id='9cfae18be05b4509b32d52571107f0ff'>
-				<updated_date>2022-03-10T18:51:21.045+01:00</updated_date>
-				<type>weather_dependent_maximum_supply_temperature</type>
-				<setpoint>60</setpoint>
-				<lower_bound>30</lower_bound>
-				<upper_bound>90</upper_bound>
-				<resolution>10</resolution>
-				<regulations/>
-				<thermostat id='3636e8c24b764f9dae52ba36695ed476'/>
-			</thermostat_functionality>
-			<thermostat_functionality id='a1f29fd4edae4894a74c0b8c523f8ef3'>
-				<updated_date>2022-03-10T18:51:54.508+01:00</updated_date>
-				<type>minimum_cooling_supply_temperature</type>
-				<setpoint>17</setpoint>
-				<lower_bound>5</lower_bound>
-				<upper_bound>25</upper_bound>
-				<resolution>1</resolution>
-				<regulations/>
-				<thermostat id='5304a8c3c39e42b990c9b057e880f8a4'/>
-			</thermostat_functionality>
-			<thermostat_functionality id='a67b1c7b6d2f403aba383a56ad3d8e0a'>
-				<updated_date>2022-03-10T18:51:25.148+01:00</updated_date>
-				<type>maximum_outdoor_unit_temperature</type>
-				<setpoint>47</setpoint>
-				<lower_bound>25</lower_bound>
-				<upper_bound>47</upper_bound>
-				<resolution>1</resolution>
-				<regulations/>
-				<thermostat id='333ef91f62d94f78ad7b9bedaecc71f2'/>
-			</thermostat_functionality>
-			<thermostat_functionality id='b6579ded90e7489ca51a48768c721eb0'>
-				<updated_date>2022-03-10T18:50:56.638+01:00</updated_date>
-				<type>maximum_heating_supply_temperature</type>
-				<setpoint>70</setpoint>
-				<lower_bound>20</lower_bound>
-				<upper_bound>90</upper_bound>
-				<resolution>5</resolution>
-				<regulations/>
-				<thermostat id='4b8a974d347f4cf1872a5bc07f613068'/>
-			</thermostat_functionality>
-			<thermostat_functionality id='c0d682baec2b45979720a0c4253665b0'>
-				<updated_date>2022-03-02T17:48:17.773+01:00</updated_date>
-				<type>maximum_boiler_temperature</type>
-				<setpoint>60</setpoint>
-				<lower_bound>0</lower_bound>
-				<upper_bound>100</upper_bound>
-				<resolution>1</resolution>
-				<regulations/>
-				<thermostat id='f7512e547d1c40f18d8911bd8bd1cce7'/>
-			</thermostat_functionality>
-			<thermostat_functionality id='c9b707c378b04420a55bdffe00e4f8f6'>
-				<updated_date>2022-03-10T18:52:04.726+01:00</updated_date>
-				<type>heatpump_minimum_outdoor_temperature</type>
-				<setpoint>2</setpoint>
-				<lower_bound>-16</lower_bound>
-				<upper_bound>4</upper_bound>
-				<resolution>1</resolution>
-				<regulations/>
-				<thermostat id='211f6996e8394d12a1f2cdb23b420a2c'/>
-			</thermostat_functionality>
-			<timer_functionality id='d24d209910e34533a95e361c8c66352c'>
-				<timer id='7ccb6bc94f1948ee9f16ecfb5c80d719'/>
-				<updated_date>2022-03-10T18:50:38.763+01:00</updated_date>
-				<type>internal_pump_cooling_lead_time</type>
-				<duration>120</duration>
-				<lower_bound>120</lower_bound>
-				<upper_bound>240</upper_bound>
-				<resolution>10</resolution>
-			</timer_functionality>
-			<thermostat_functionality id='f8b9ad4b594846628e305fdf7ff26b3e'>
-				<updated_date>2022-03-10T18:51:35.435+01:00</updated_date>
-				<type>maximum_outdoor_unit_power_increase_temperature</type>
-				<setpoint>43</setpoint>
-				<lower_bound>25</lower_bound>
-				<upper_bound>43</upper_bound>
-				<resolution>1</resolution>
-				<regulations/>
-				<thermostat id='564f724946434905b7d2b6c142e4ba67'/>
-			</thermostat_functionality>
-		</actuator_functionalities>
-	</appliance>
-	<appliance id='fb49af122f6e4b0f91267e1cf7666d6f'>
-		<name>Gateway</name>
-		<description>Container for variables logged about the Gateway in general.</description>
-		<type>gateway</type>
-		<created_date>2018-07-12T11:13:24.488+02:00</created_date>
-		<modified_date>2022-03-10T18:59:50.737+01:00</modified_date>
-		<deleted_date></deleted_date>
-		<groups/>
-		<logs>
-			<point_log id='170726b59a1c45f395dbc3d2920f9217'>
-				<type>lan_ip_address</type>
-				<unit></unit>
-				<updated_date>2022-03-10T18:58:30.167+01:00</updated_date>
-				<last_consecutive_log_date>2021-10-28T04:56:27+02:00</last_consecutive_log_date>
-				<interval/>
-				<network_address id='b4124ec2cee84ae182a6612e610e1690'/>
-				<period start_date="2022-03-10T18:58:30.167+01:00" end_date="2022-03-10T18:58:30.167+01:00">
-					<measurement log_date="2022-03-10T18:58:30.167+01:00">0.0.0.0</measurement>
-				</period>
-			</point_log>
-			<point_log id='2dfe41f254c74ce9a9e9aaff6be9dbe7'>
-				<type>signal_strength</type>
-				<unit>dBm</unit>
-				<updated_date>2022-03-10T18:59:50.695+01:00</updated_date>
-				<last_consecutive_log_date>2022-03-10T18:59:50.695+01:00</last_consecutive_log_date>
-				<interval/>
-				<signal_strength id='c61cb1657e7046f78f77f3a6a8bd4e01'/>
-				<period start_date="2022-03-10T18:59:50.695+01:00" end_date="2022-03-10T18:59:50.695+01:00">
-					<measurement log_date="2022-03-10T18:59:50.695+01:00">-56.00</measurement>
-				</period>
-			</point_log>
-			<point_log id='43466b056f2f457493b720430ba254c5'>
-				<type>wlan_state</type>
-				<unit></unit>
-				<updated_date>2022-03-10T18:59:50.696+01:00</updated_date>
-				<last_consecutive_log_date>2022-03-10T02:56:55.858+01:00</last_consecutive_log_date>
-				<interval/>
-				<network_state id='6fbd440a76444188adfcce9366e5e800'/>
-				<period start_date="2022-03-10T18:59:50.696+01:00" end_date="2022-03-10T18:59:50.696+01:00">
-					<measurement log_date="2022-03-10T18:59:50.696+01:00">up</measurement>
-				</period>
-			</point_log>
-			<point_log id='856cc738696245d1a580706b6db5574e'>
-				<type>wlan_ip_address</type>
-				<unit></unit>
-				<updated_date>2022-03-10T18:59:50.696+01:00</updated_date>
-				<last_consecutive_log_date>2022-03-10T02:56:55+01:00</last_consecutive_log_date>
-				<interval/>
-				<network_address id='936a423321184cf88cfc6c700e872230'/>
-				<period start_date="2022-03-10T18:59:50.696+01:00" end_date="2022-03-10T18:59:50.696+01:00">
-					<measurement log_date="2022-03-10T18:59:50.696+01:00">127.0.0.2</measurement>
-				</period>
-			</point_log>
-			<point_log id='aa949dbf9f654ba09d3f8bff22f91cd3'>
-				<type>gateway_mode</type>
-				<unit></unit>
-				<updated_date></updated_date>
-				<last_consecutive_log_date></last_consecutive_log_date>
-				<interval/>
-				<gateway_mode_control id='bfa38e00cc3d405b80dadfc05bea8a9b'/>
-			</point_log>
-			<point_log id='b41f590d2c06410dbe8be8e9f7b74deb'>
-				<type>link_quality</type>
-				<unit></unit>
-				<updated_date>2022-03-10T18:59:50.695+01:00</updated_date>
-				<last_consecutive_log_date>2022-03-10T18:59:50.695+01:00</last_consecutive_log_date>
-				<interval/>
-				<link_quality id='af0f81cc5ca844c492ef164e2c114508'/>
-				<period start_date="2022-03-10T18:59:50.695+01:00" end_date="2022-03-10T18:59:50.695+01:00">
-					<measurement log_date="2022-03-10T18:59:50.695+01:00">54</measurement>
-				</period>
-			</point_log>
-			<point_log id='e523c94b2efc445ba8bb26ec27152d6a'>
-				<type>lan_state</type>
-				<unit></unit>
-				<updated_date>2022-03-10T18:58:30.167+01:00</updated_date>
-				<last_consecutive_log_date>2019-07-22T11:03:31.494+02:00</last_consecutive_log_date>
-				<interval/>
-				<network_state id='af06c116bc7e4e7bbcac5b4d235bd2c8'/>
-				<period start_date="2022-03-10T18:58:30.167+01:00" end_date="2022-03-10T18:58:30.167+01:00">
-					<measurement log_date="2022-03-10T18:58:30.167+01:00">down</measurement>
-				</period>
-			</point_log>
-		</logs>
-		<actuator_functionalities>
-			<gateway_mode_control_functionality id='43a20461689e4536bcf02758b6a2c340'>
-				<gateway_mode_control id='bfa38e00cc3d405b80dadfc05bea8a9b'/>
-				<updated_date></updated_date>
-				<type>gateway_mode</type>
-				<mode>full</mode>
-				<allowed_modes>
-					<mode>setup</mode>
-					<mode>light</mode>
-					<mode>away</mode>
-					<mode>vacation</mode>
-					<mode/>
-					<mode>full</mode>
-					<mode>secure</mode>
-				</allowed_modes>
-			</gateway_mode_control_functionality>
-		</actuator_functionalities>
-	</appliance>
-	<template id='69699f9e8e584a12b5a803e724547ad2' tag="zone_preset_based_on_time_and_presence_with_override">
-		<name>Zone preset schedule template</name>
-		<description>Template for scheduling presets on a presence or time basis with the option to override the preset&apos;s setpoint/state.</description>
-		<single_actor>true</single_actor>
-		<created_date>2017-10-25T14:55:02.566+02:00</created_date>
-		<modified_date>2022-03-02T17:47:56.643+01:00</modified_date>
-		<deleted_date></deleted_date>
-		<objects>
-			<object name="zone" type="Location"/>
-		</objects>
-		<parameters>
-			<parameter name="presence" source="zone.presence" type="Boolean"/>
-			<parameter name="time" source="clock.weekTime" type="WeekTime"/>
-		</parameters>
-		<results>
-			<result name="state" type="OnOff" action="zone.iterateFunctionalities('RelayFunctionality')().switch(clock.addSeconds(null, 1), state)"/>
-			<result name="preset" type="Preset" action="zone.preset = preset"/>
-			<result name="setpoint" type="Number" action="zone.iterateFunctionalities('ThermostatFunctionality', 'thermostat')().setSetpoint(clock.addSeconds(null, 1), setpoint, setpoint)"/>
-			<result name="domestic_hot_water_state" type="OnOff" action="zone.iterateFunctionalities('ToggleFunctionality', 'domestic_hot_water_state')().switch(clock.addSeconds(null, 1), domestic_hot_water_state)"/>
-		</results>
-	</template>
-	<location id='d3ce834534114348be628b61b26d9220'>
-		<name>Living room</name>
-		<description>The room containing the (central) home thermostat.</description>
-		<type>livingroom</type>
-		<created_date>2019-07-22T11:03:38.853+02:00</created_date>
-		<modified_date>2022-03-10T19:01:01.344+01:00</modified_date>
-		<deleted_date></deleted_date>
-		<preset>home</preset>
-		<clients/>
-		<appliances>
-			<appliance id='ebd90df1ab334565b5895f37590ccff4'/>
-		</appliances>
-		<logs>
-			<point_log id='17367e62a10641f09c62555259917230'>
-				<type>thermostat</type>
-				<unit>C</unit>
-				<updated_date>2022-03-10T06:45:00.389+01:00</updated_date>
-				<last_consecutive_log_date>2022-03-02T06:45:00.397+01:00</last_consecutive_log_date>
-				<interval/>
-				<period start_date="2022-03-10T06:45:00.389+01:00" end_date="2022-03-10T06:45:00.389+01:00">
-					<measurement log_date="2022-03-10T06:45:00.389+01:00">19.50</measurement>
-				</period>
-			</point_log>
-			<point_log id='de702fce210440f488cc8269e3d10723'>
-				<type>temperature</type>
-				<unit></unit>
-				<updated_date>2022-03-10T19:01:01.330+01:00</updated_date>
-				<last_consecutive_log_date>2022-03-02T17:29:58.913+01:00</last_consecutive_log_date>
-				<interval>PT3H</interval>
-				<period start_date="2022-03-10T19:01:01.330+01:00" end_date="2022-03-10T19:01:01.330+01:00">
-					<measurement log_date="2022-03-10T19:01:01.330+01:00">20.93</measurement>
-				</period>
-			</point_log>
-		</logs>
-		<actuator_functionalities>
-			<thermostat_functionality id='913c4634ffce4cd8b2b921b148aae838'>
-				<updated_date>2022-03-10T06:45:00.348+01:00</updated_date>
-				<type>thermostat</type>
-				<setpoint>19.5</setpoint>
-				<lower_bound>4</lower_bound>
-				<upper_bound>30</upper_bound>
-				<resolution>0.1</resolution>
-				<regulations><ame_regulation id='1c8b1a395ed848a2a67d65996bf0bb75'/></regulations>
-				<cooling_allowed>true</cooling_allowed>
-				<preheating_allowed>true</preheating_allowed>
-				<control_state>off</control_state>
-				<regulation_control>active</regulation_control>
-			</thermostat_functionality>
-		</actuator_functionalities>
-	</location>
-	<ame_regulation id='1c8b1a395ed848a2a67d65996bf0bb75'>
-		<created_date>2019-07-22T11:03:37.635+02:00</created_date>
-		<modified_date>2022-03-02T17:48:09.912+01:00</modified_date>
-		<deleted_date></deleted_date>
-		<thermostat_functionalities>
-			<thermostat_functionality id='913c4634ffce4cd8b2b921b148aae838'/>
-			<thermostat_functionality id='9d718e17024446f296adecf2a1da9e18'/>
-		</thermostat_functionalities>
-		<heating_mode>economy</heating_mode>
-		<preheating>on</preheating>
-		<installation_size>unknown</installation_size>
-		<heating_type>unknown</heating_type>
-		<preheating_time_escalation_limit>120</preheating_time_escalation_limit>
-		<calculate_decentral_heat_demand>off</calculate_decentral_heat_demand>
-		<decentral_heat_demand_maximum_temperature>24</decentral_heat_demand_maximum_temperature>
-		<open_therm_boiler_activation_threshold>10</open_therm_boiler_activation_threshold>
-		<onoff_boiler_temperature_deadband>0.5</onoff_boiler_temperature_deadband>
-		<decentral_heat_demand_deadband>0.5</decentral_heat_demand_deadband>
-		<gradual_adhoc_heating_rate>1.5</gradual_adhoc_heating_rate>
-		<open_therm_low_outdoors_temperature_boiler_temperature_maximum>85</open_therm_low_outdoors_temperature_boiler_temperature_maximum>
-		<open_therm_high_outdoors_temperature_boiler_temperature_maximum>55</open_therm_high_outdoors_temperature_boiler_temperature_maximum>
-		<derivative_coefficient>0</derivative_coefficient>
-		<minimum_boiler_temperature>25</minimum_boiler_temperature>
-		<integral_coefficient_reduction_factor_during_preheating>7</integral_coefficient_reduction_factor_during_preheating>
-	</ame_regulation>
-	<rule id='dbc823ce5fa54eee85a8a822507a1de4'>
-		<name>Thermostat presets</name>
-		<description>Provides presets for a Location.</description>
-		<template id="c9a9744aad4646f5a1b02ed9d72191a3" tag="zone_setpoint_and_state_based_on_preset"/>
-		<active>true</active>
-		<created_date>2019-07-22T11:03:39.299+02:00</created_date>
-		<modified_date>2020-12-02T22:26:36.050+01:00</modified_date>
-		<deleted_date></deleted_date>
-		<directives>
-			<when preset="away"><then heating_setpoint="15" cooling_setpoint="25"/></when>
-			<when preset="no_frost"><then heating_setpoint="10" cooling_setpoint="30"/></when>
-			<when preset="vacation"><then heating_setpoint="15" cooling_setpoint="27"/></when>
-			<when preset="home"><then heating_setpoint="19.5" cooling_setpoint="23"/></when>
-			<when preset="asleep"><then heating_setpoint="19" cooling_setpoint="23"/></when>
-		</directives>
-		<contexts>
-			<context>
-				<zone><location id="d3ce834534114348be628b61b26d9220"/></zone>
-			</context>
-		</contexts>
-	</rule>
-	<module id='ef8f01b00b0945d28b42b12ae44eeb1b'>
-		<vendor_name>Plugwise</vendor_name>
-		<vendor_model>ThermoExtension</vendor_model>
-		<hardware_version>6539-1301-2304</hardware_version>
-		<firmware_version>2018-02-08T11:15:57+01:00</firmware_version>
-		<created_date>2017-08-29T08:24:38.164+02:00</created_date>
-		<modified_date>2019-07-22T11:08:07.986+02:00</modified_date>
-		<deleted_date></deleted_date>
-		<services/>
-		<protocols>
-			<thermo_extension id='668c0412fb2b420a80de9642b9f8a2f1'><thermo_touch id='af43990b4ca744cf8e9f9b5996190f6f'/><open_therm_boiler id='b2481333821543b0994b280c60395ba5'/></thermo_extension>
-		</protocols>
-	</module>
-	<location id='d34dfe6ab90b410c98068e75de3eb631'>
-		<name>Home</name>
-		<description></description>
-		<type>building</type>
-		<created_date>2017-10-25T14:55:03.100+02:00</created_date>
-		<modified_date>2022-03-10T18:52:07.240+01:00</modified_date>
-		<deleted_date></deleted_date>
-		<preset>home</preset>
-		<clients/>
-		<appliances/>
-		<logs>
-			<point_log id='19080fb9d9a94bd88a319419d285a56d'>
-				<type>weather_description</type>
-				<unit></unit>
-				<updated_date>2022-03-10T18:52:05+01:00</updated_date>
-				<last_consecutive_log_date>2022-03-10T18:52:05+01:00</last_consecutive_log_date>
-				<interval/>
-				<weather_descriptor id='acdffd53f1984f96b571bb4d6b7c6095'/>
-				<period start_date="2022-03-10T18:52:05+01:00" end_date="2022-03-10T18:52:05+01:00">
-					<measurement log_date="2022-03-10T18:52:05+01:00">cloudy</measurement>
-				</period>
-			</point_log>
-			<point_log id='67f6e7e97f6b47368f61460226ead4cb'>
-				<type>humidity</type>
-				<unit>RH</unit>
-				<updated_date>2022-03-10T18:52:05+01:00</updated_date>
-				<last_consecutive_log_date>2022-03-10T18:52:05+01:00</last_consecutive_log_date>
-				<interval>PT3H</interval>
-				<hygro_meter id='ec0d5294e3bf4e5e96054901fe25835a'/>
-				<period start_date="2022-03-10T18:52:05+01:00" end_date="2022-03-10T18:52:05+01:00">
-					<measurement log_date="2022-03-10T18:52:05+01:00">42.00</measurement>
-				</period>
-			</point_log>
-			<point_log id='837b147f4ce547388f76f7404cf1b6cc'>
-				<type>outdoor_temperature</type>
-				<unit>C</unit>
-				<updated_date>2022-03-10T18:52:05+01:00</updated_date>
-				<last_consecutive_log_date>2022-03-10T18:52:05+01:00</last_consecutive_log_date>
-				<interval>PT3H</interval>
-				<thermo_meter id='5702932dadad4591b77f8f30971ea0bf'/>
-				<period start_date="2022-03-10T18:52:05+01:00" end_date="2022-03-10T18:52:05+01:00">
-					<measurement log_date="2022-03-10T18:52:05+01:00">13.00</measurement>
-				</period>
-			</point_log>
-			<point_log id='a17661da905149eca734ba8b047fe177'>
-				<type>wind_vector</type>
-				<unit>m_s</unit>
-				<updated_date>2022-03-10T18:52:05+01:00</updated_date>
-				<last_consecutive_log_date>2022-03-10T18:52:05+01:00</last_consecutive_log_date>
-				<interval/>
-				<wind_vector id='b790ed1f2a0a4b629d13e0cd02f88821'/>
-				<period start_date="2022-03-10T18:52:05+01:00" end_date="2022-03-10T18:52:05+01:00">
-					<measurement log_date="2022-03-10T18:52:05+01:00">(3.60,120.00)</measurement>
-				</period>
-			</point_log>
-			<point_log id='e8d96f806c9746e9a47a3bc809e2438c'>
-				<type>solar_irradiance</type>
-				<unit>W_m2</unit>
-				<updated_date>2022-03-10T18:52:05+01:00</updated_date>
-				<last_consecutive_log_date>2022-03-10T18:52:05+01:00</last_consecutive_log_date>
-				<interval/>
-				<irradiance_meter id='3860fb2704834c3ba2bf9eb1840c7ca7'/>
-				<period start_date="2022-03-10T18:52:05+01:00" end_date="2022-03-10T18:52:05+01:00">
-					<measurement log_date="2022-03-10T18:52:05+01:00">0.00</measurement>
-				</period>
-			</point_log>
-		</logs>
-		<actuator_functionalities/>
-	</location>
-	<rule id='40e484ccfd644f1fa8b82f669091144a'>
-		<name>Thermostat schedule</name>
-		<description>Provides a week schedule for a Location.</description>
-		<template id="69699f9e8e584a12b5a803e724547ad2" tag="zone_preset_based_on_time_and_presence_with_override"/>
-		<active>true</active>
-		<created_date>2019-07-22T11:03:39.072+02:00</created_date>
-		<modified_date>2021-06-04T12:39:09.405+02:00</modified_date>
-		<deleted_date></deleted_date>
-		<directives>
-			<when time="[sa 23:00,mo 06:45)"><then preset="asleep"/></when>
-			<when time="[mo 06:45,tu 06:45)"><then preset="home"/></when>
-			<when time="[tu 06:45,we 06:45)"><then preset="home"/></when>
-			<when time="[we 06:45,th 06:45)"><then preset="home"/></when>
-			<when time="[th 06:45,fr 06:45)"><then preset="home"/></when>
-			<when time="[fr 06:45,su 08:30)"><then setpoint="21.5"/></when>
-			<when time="[su 22:45,mo 23:00)"><then preset="asleep"/></when>
-			<when time="[mo 23:00,th 23:00)"><then preset="asleep"/></when>
-			<when time="[th 23:00,fr 23:00)"><then preset="asleep"/></when>
-			<when time="[fr 23:00,we 23:00)"><then preset="asleep"/></when>
-			<when time="[we 23:00,tu 23:00)"><then preset="asleep"/></when>
-			<when time="[su 08:30,su 22:45)"><then preset="home"/></when>
-			<when time="[tu 23:00,sa 08:30)"><then preset="asleep"/></when>
-			<when time="[sa 08:30,sa 23:00)"><then preset="home"/></when>
-		</directives>
-		<contexts>
-			<context>
-				<zone><location id="d3ce834534114348be628b61b26d9220"/></zone>
-			</context>
-		</contexts>
-	</rule>
-	<template id='adb00662ec9c406fa75839cbd8d090da' tag="relay_state_based_on_time_and_preset">
-		<name>Relay schedule template</name>
-		<description>Template for scheduling relays on a time and preset basis.</description>
-		<single_actor>false</single_actor>
-		<created_date>2017-10-25T14:55:02.453+02:00</created_date>
-		<modified_date>2022-03-02T17:47:56.614+01:00</modified_date>
-		<deleted_date></deleted_date>
-		<objects>
-			<object name="direct_object" type="DirectObject"/>
-			<object name="zone" type="Location"/>
-		</objects>
-		<parameters>
-			<parameter name="preset" source="zone.preset" type="Preset"/>
-			<parameter name="time" source="clock.weekTime" type="WeekTime"/>
-		</parameters>
-		<results>
-			<result name="state" type="OnOff" action="direct_object.iterateFunctionalities('RelayFunctionality')().state = state"/>
-		</results>
-	</template>
-	<template id='3ad9f4216ff14ed794b3198871b6a9dc' tag="relay_state_based_on_time_preset_temperature_and_humidity">
-		<name>Relay schedule template</name>
-		<description>Template for scheduling relays on a time, solar time, preset, temperature and humidity basis.</description>
-		<single_actor>false</single_actor>
-		<created_date>2021-10-28T04:56:49.928+02:00</created_date>
-		<modified_date>2022-03-02T17:47:56.618+01:00</modified_date>
-		<deleted_date></deleted_date>
-		<objects>
-			<object name="direct_object" type="DirectObject"/>
-			<object name="zone" type="Location"/>
-		</objects>
-		<parameters>
-			<parameter name="time" source="clock.weekTime" type="WeekTime"/>
-			<parameter name="humidity" source="zone.humidity" type="Number"/>
-			<parameter name="preset" source="zone.preset" type="Preset"/>
-			<parameter name="temperature" source="zone.temperature" type="Number"/>
-		</parameters>
-		<results>
-			<result name="state" type="OnOff" action="direct_object.iterateFunctionalities('RelayFunctionality')().state = state"/>
-		</results>
-	</template>
-	<template id='53ef215f5cb44e8fb2895c6945d86586' tag="default_client_presence_based_on_pointlog">
-		<name>Client, Pointlog presence template</name>
-		<description>Template for setting default client presence based on point_logs</description>
-		<single_actor>false</single_actor>
-		<created_date>2017-10-25T14:55:02.608+02:00</created_date>
-		<modified_date>2022-03-02T17:47:56.649+01:00</modified_date>
-		<deleted_date></deleted_date>
-		<objects>
-			<object name="client" type="Client"/>
-			<object name="point_log" type="PointLogFunctionality"/>
-		</objects>
-		<parameters>
-			<parameter name="point_log_recently_used" source="point_log.wasRecentlyOn(null, 1800)" type="Boolean"/>
-		</parameters>
-		<results>
-			<result name="presence" type="Boolean" action="client.setPresence(presence, 'rule')"/>
-		</results>
-	</template>
-	<module id='c5539bb850ea40cab886354b10bec43b'>
-		<vendor_name></vendor_name>
-		<vendor_model></vendor_model>
-		<hardware_version></hardware_version>
-		<firmware_version></firmware_version>
-		<created_date>2017-10-25T14:55:02.841+02:00</created_date>
-		<modified_date>2020-07-10T05:28:40.857+02:00</modified_date>
-		<deleted_date></deleted_date>
-		<services>
-			<irradiance_meter id='3860fb2704834c3ba2bf9eb1840c7ca7' log_type='solar_irradiance'>
-				<functionalities><point_log id='e8d96f806c9746e9a47a3bc809e2438c'/></functionalities>
-			</irradiance_meter>
-			<thermo_meter id='5702932dadad4591b77f8f30971ea0bf' log_type='outdoor_temperature'>
-				<functionalities><point_log id='837b147f4ce547388f76f7404cf1b6cc'/></functionalities>
-			</thermo_meter>
-			<weather_descriptor id='acdffd53f1984f96b571bb4d6b7c6095' log_type='weather_description'>
-				<functionalities><point_log id='19080fb9d9a94bd88a319419d285a56d'/></functionalities>
-			</weather_descriptor>
-			<wind_vector id='b790ed1f2a0a4b629d13e0cd02f88821' log_type='wind_vector'>
-				<functionalities><point_log id='a17661da905149eca734ba8b047fe177'/></functionalities>
-			</wind_vector>
-			<hygro_meter id='ec0d5294e3bf4e5e96054901fe25835a' log_type='humidity'>
-				<functionalities><point_log id='67f6e7e97f6b47368f61460226ead4cb'/></functionalities>
-			</hygro_meter>
-		</services>
-		<protocols>
-			<weather_feed id='5b75838ca51c48f1853f71b23f9c4191'/>
-		</protocols>
-	</module>
+    <location id="d3ce834534114348be628b61b26d9220">
+        <name>Living room</name>
+        <description>The room containing the (central) home thermostat.</description>
+        <type>livingroom</type>
+        <created_date>2019-07-22T11:03:38.853+02:00</created_date>
+        <modified_date>2024-12-06T18:35:17.976+01:00</modified_date>
+        <deleted_date/>
+        <preset>home</preset>
+        <clients/>
+        <appliances>
+            <appliance id="ebd90df1ab334565b5895f37590ccff4"/>
+        </appliances>
+        <logs>
+            <point_log id="17367e62a10641f09c62555259917230">
+                <type>thermostat</type>
+                <unit>C</unit>
+                <updated_date>2024-12-06T16:49:32.589+01:00</updated_date>
+                <last_consecutive_log_date>2024-07-29T15:00:01.283+02:00</last_consecutive_log_date>
+                <interval/>
+                <period start_date="2024-12-06T16:49:32.589+01:00" end_date="2024-12-06T16:49:32.589+01:00">
+                    <measurement log_date="2024-12-06T16:49:32.589+01:00">19.50</measurement>
+                </period>
+            </point_log>
+            <point_log id="de702fce210440f488cc8269e3d10723">
+                <type>temperature</type>
+                <unit/>
+                <updated_date>2024-12-06T18:35:17.962+01:00</updated_date>
+                <last_consecutive_log_date>2024-07-29T15:27:58.165+02:00</last_consecutive_log_date>
+                <interval>PT3H</interval>
+                <period start_date="2024-12-06T18:35:17.962+01:00" end_date="2024-12-06T18:35:17.962+01:00">
+                    <measurement log_date="2024-12-06T18:35:17.962+01:00">19.23</measurement>
+                </period>
+            </point_log>
+        </logs>
+        <actuator_functionalities>
+            <thermostat_functionality id="913c4634ffce4cd8b2b921b148aae838">
+                <updated_date>2024-12-06T16:49:32.590+01:00</updated_date>
+                <type>thermostat</type>
+                <lower_bound>4</lower_bound>
+                <upper_bound>30</upper_bound>
+                <resolution>0.1</resolution>
+                <setpoint>19.5</setpoint>
+                <regulations>
+                    <ame_regulation id="1c8b1a395ed848a2a67d65996bf0bb75"/>
+                </regulations>
+                <cooling_allowed>true</cooling_allowed>
+                <preheating_allowed>true</preheating_allowed>
+                <control_state>off</control_state>
+                <regulation_control>active</regulation_control>
+            </thermostat_functionality>
+        </actuator_functionalities>
+    </location>
+    <ame_regulation id="1c8b1a395ed848a2a67d65996bf0bb75">
+        <created_date>2019-07-22T11:03:37.635+02:00</created_date>
+        <modified_date>2024-07-29T15:46:27.012+02:00</modified_date>
+        <deleted_date/>
+        <thermostat_functionalities>
+            <thermostat_functionality id="913c4634ffce4cd8b2b921b148aae838"/>
+            <thermostat_functionality id="9d718e17024446f296adecf2a1da9e18"/>
+        </thermostat_functionalities>
+        <heating_mode>economy</heating_mode>
+        <preheating>on</preheating>
+        <installation_size>unknown</installation_size>
+        <heating_type>unknown</heating_type>
+        <preheating_time_escalation_limit>120</preheating_time_escalation_limit>
+        <calculate_decentral_heat_demand>off</calculate_decentral_heat_demand>
+        <decentral_heat_demand_maximum_temperature>24</decentral_heat_demand_maximum_temperature>
+        <open_therm_boiler_activation_threshold>0</open_therm_boiler_activation_threshold>
+        <onoff_boiler_temperature_deadband>0.5</onoff_boiler_temperature_deadband>
+        <decentral_heat_demand_deadband>0.5</decentral_heat_demand_deadband>
+        <gradual_adhoc_heating_rate>1.5</gradual_adhoc_heating_rate>
+        <open_therm_low_outdoors_temperature_boiler_temperature_maximum>85</open_therm_low_outdoors_temperature_boiler_temperature_maximum>
+        <open_therm_high_outdoors_temperature_boiler_temperature_maximum>55</open_therm_high_outdoors_temperature_boiler_temperature_maximum>
+        <derivative_coefficient>0</derivative_coefficient>
+        <minimum_boiler_temperature>20</minimum_boiler_temperature>
+        <integral_coefficient_reduction_factor_during_preheating>7</integral_coefficient_reduction_factor_during_preheating>
+    </ame_regulation>
+    <template id="53ef215f5cb44e8fb2895c6945d86586" tag="default_client_presence_based_on_pointlog">
+        <name>Client, Pointlog presence template</name>
+        <description>Template for setting default client presence based on point_logs</description>
+        <single_actor>false</single_actor>
+        <created_date>2017-10-25T14:55:02.608+02:00</created_date>
+        <modified_date>2024-07-29T15:46:14.547+02:00</modified_date>
+        <deleted_date/>
+        <objects>
+            <object name="point_log" type="PointLogFunctionality"/>
+            <object name="client" type="Client"/>
+        </objects>
+        <parameters>
+            <parameter name="point_log_recently_used" source="point_log.wasRecentlyOn(null, 1800)" type="Boolean"/>
+        </parameters>
+        <results>
+            <result name="presence" type="Boolean" action="client.setPresence(presence, 'rule')"/>
+        </results>
+    </template>
+    <appliance id="fb49af122f6e4b0f91267e1cf7666d6f">
+        <name>Gateway</name>
+        <description>Container for variables logged about the Gateway in general.</description>
+        <type>gateway</type>
+        <created_date>2018-07-12T11:13:24.488+02:00</created_date>
+        <modified_date>2024-12-06T18:44:25.768+01:00</modified_date>
+        <deleted_date/>
+        <groups/>
+        <logs>
+            <point_log id="170726b59a1c45f395dbc3d2920f9217">
+                <type>lan_ip_address</type>
+                <unit/>
+                <updated_date>2024-12-06T18:44:25+01:00</updated_date>
+                <last_consecutive_log_date>2024-12-06T18:44:25+01:00</last_consecutive_log_date>
+                <interval/>
+                <network_address id="b4124ec2cee84ae182a6612e610e1690"/>
+                <period start_date="2024-12-06T18:44:25+01:00" end_date="2024-12-06T18:44:25+01:00">
+                    <measurement log_date="2024-12-06T18:44:25+01:00">0.0.0.0</measurement>
+                </period>
+            </point_log>
+            <point_log id="2dfe41f254c74ce9a9e9aaff6be9dbe7">
+                <type>signal_strength</type>
+                <unit>dBm</unit>
+                <updated_date>2024-12-06T18:44:25.710+01:00</updated_date>
+                <last_consecutive_log_date>2024-12-06T18:44:25.710+01:00</last_consecutive_log_date>
+                <interval/>
+                <signal_strength id="c61cb1657e7046f78f77f3a6a8bd4e01"/>
+                <period start_date="2024-12-06T18:44:25.710+01:00" end_date="2024-12-06T18:44:25.710+01:00">
+                    <measurement log_date="2024-12-06T18:44:25.710+01:00">-61.00</measurement>
+                </period>
+            </point_log>
+            <point_log id="43466b056f2f457493b720430ba254c5">
+                <type>wlan_state</type>
+                <unit/>
+                <updated_date>2024-12-06T18:44:25.711+01:00</updated_date>
+                <last_consecutive_log_date>2024-12-06T18:44:25.711+01:00</last_consecutive_log_date>
+                <interval/>
+                <network_state id="6fbd440a76444188adfcce9366e5e800"/>
+                <period start_date="2024-12-06T18:44:25.711+01:00" end_date="2024-12-06T18:44:25.711+01:00">
+                    <measurement log_date="2024-12-06T18:44:25.711+01:00">up</measurement>
+                </period>
+            </point_log>
+            <point_log id="856cc738696245d1a580706b6db5574e">
+                <type>wlan_ip_address</type>
+                <unit/>
+                <updated_date>2024-12-06T18:44:25+01:00</updated_date>
+                <last_consecutive_log_date>2024-12-06T18:44:25+01:00</last_consecutive_log_date>
+                <interval/>
+                <network_address id="936a423321184cf88cfc6c700e872230"/>
+                <period start_date="2024-12-06T18:44:25+01:00" end_date="2024-12-06T18:44:25+01:00">
+                    <measurement log_date="2024-12-06T18:44:25+01:00">127.0.0.1</measurement>
+                </period>
+            </point_log>
+            <point_log id="aa949dbf9f654ba09d3f8bff22f91cd3">
+                <type>gateway_mode</type>
+                <unit/>
+                <updated_date/>
+                <last_consecutive_log_date/>
+                <interval/>
+                <gateway_mode_control id="bfa38e00cc3d405b80dadfc05bea8a9b"/>
+            </point_log>
+            <point_log id="b41f590d2c06410dbe8be8e9f7b74deb">
+                <type>link_quality</type>
+                <unit/>
+                <updated_date>2024-12-06T18:44:25.710+01:00</updated_date>
+                <last_consecutive_log_date>2024-12-06T18:44:25.710+01:00</last_consecutive_log_date>
+                <interval/>
+                <link_quality id="af0f81cc5ca844c492ef164e2c114508"/>
+                <period start_date="2024-12-06T18:44:25.710+01:00" end_date="2024-12-06T18:44:25.710+01:00">
+                    <measurement log_date="2024-12-06T18:44:25.710+01:00">49</measurement>
+                </period>
+            </point_log>
+            <point_log id="e523c94b2efc445ba8bb26ec27152d6a">
+                <type>lan_state</type>
+                <unit/>
+                <updated_date>2024-12-06T18:44:25.750+01:00</updated_date>
+                <last_consecutive_log_date>2024-12-06T18:44:25.750+01:00</last_consecutive_log_date>
+                <interval/>
+                <network_state id="af06c116bc7e4e7bbcac5b4d235bd2c8"/>
+                <period start_date="2024-12-06T18:44:25.750+01:00" end_date="2024-12-06T18:44:25.750+01:00">
+                    <measurement log_date="2024-12-06T18:44:25.750+01:00">down</measurement>
+                </period>
+            </point_log>
+        </logs>
+        <actuator_functionalities>
+            <gateway_mode_control_functionality id="43a20461689e4536bcf02758b6a2c340">
+                <gateway_mode_control id="bfa38e00cc3d405b80dadfc05bea8a9b"/>
+                <updated_date/>
+                <type>gateway_mode</type>
+                <mode>full</mode>
+                <allowed_modes>
+                    <mode/>
+                    <mode>light</mode>
+                    <mode>secure</mode>
+                    <mode>full</mode>
+                    <mode>vacation</mode>
+                    <mode>away</mode>
+                    <mode>setup</mode>
+                </allowed_modes>
+            </gateway_mode_control_functionality>
+        </actuator_functionalities>
+    </appliance>
+    <template id="c9a9744aad4646f5a1b02ed9d72191a3" tag="zone_setpoint_and_state_based_on_preset">
+        <name>Zone preset template</name>
+        <description>Template for actuating thermostats and relays on a preset basis.</description>
+        <single_actor>true</single_actor>
+        <created_date>2017-10-25T14:55:02.526+02:00</created_date>
+        <modified_date>2024-07-29T15:46:14.530+02:00</modified_date>
+        <deleted_date/>
+        <objects>
+            <object name="zone" type="Location"/>
+        </objects>
+        <parameters>
+            <parameter name="preset" source="zone.preset" type="Preset"/>
+        </parameters>
+        <results>
+            <result name="heating_setpoint" type="Number" action="zone.iterateFunctionalities('ThermostatFunctionality', 'thermostat')().setSetpoint(null, heating_setpoint, null)"/>
+            <result name="state" type="OnOff" action="zone.iterateFunctionalities('RelayFunctionality')().state = state"/>
+            <result name="cooling_setpoint" type="Number" action="zone.iterateFunctionalities('ThermostatFunctionality', 'thermostat')().setSetpoint(null, null, cooling_setpoint)"/>
+            <result name="domestic_hot_water_state" type="OnOff" action="zone.iterateFunctionalities('ToggleFunctionality', 'domestic_hot_water_state')().state = domestic_hot_water_state"/>
+        </results>
+    </template>
+    <module id="0fb9b855195d4c90b7cb6fe3cdd12aa1">
+        <vendor_name>Plugwise</vendor_name>
+        <vendor_model>Gateway</vendor_model>
+        <hardware_version>AME Smile 2.0 board</hardware_version>
+        <firmware_version/>
+        <created_date>2018-07-12T11:13:19.719+02:00</created_date>
+        <modified_date>2021-10-28T04:56:48.081+02:00</modified_date>
+        <deleted_date/>
+        <services>
+            <network_state id="6fbd440a76444188adfcce9366e5e800" log_type="wlan_state">
+                <functionalities>
+                    <point_log id="43466b056f2f457493b720430ba254c5"/>
+                </functionalities>
+            </network_state>
+            <network_address id="936a423321184cf88cfc6c700e872230" log_type="wlan_ip_address">
+                <functionalities>
+                    <point_log id="856cc738696245d1a580706b6db5574e"/>
+                </functionalities>
+            </network_address>
+            <network_state id="af06c116bc7e4e7bbcac5b4d235bd2c8" log_type="lan_state">
+                <functionalities>
+                    <point_log id="e523c94b2efc445ba8bb26ec27152d6a"/>
+                </functionalities>
+            </network_state>
+            <link_quality id="af0f81cc5ca844c492ef164e2c114508" log_type="link_quality">
+                <functionalities>
+                    <point_log id="b41f590d2c06410dbe8be8e9f7b74deb"/>
+                </functionalities>
+            </link_quality>
+            <network_address id="b4124ec2cee84ae182a6612e610e1690" log_type="lan_ip_address">
+                <functionalities>
+                    <point_log id="170726b59a1c45f395dbc3d2920f9217"/>
+                </functionalities>
+            </network_address>
+            <gateway_mode_control id="bfa38e00cc3d405b80dadfc05bea8a9b" log_type="gateway_mode">
+                <functionalities>
+                    <gateway_mode_control_functionality id="43a20461689e4536bcf02758b6a2c340"/>
+                    <point_log id="aa949dbf9f654ba09d3f8bff22f91cd3"/>
+                </functionalities>
+            </gateway_mode_control>
+            <signal_strength id="c61cb1657e7046f78f77f3a6a8bd4e01" log_type="signal_strength">
+                <functionalities>
+                    <point_log id="2dfe41f254c74ce9a9e9aaff6be9dbe7"/>
+                </functionalities>
+            </signal_strength>
+        </services>
+        <protocols>
+            <local_area_network id="44bed71f40c742e584168b9d6b8735da"/>
+            <wireless_local_area_network id="95bd9155f73e4adf941b6b7f84f58468"/>
+        </protocols>
+    </module>
+    <template id="adb00662ec9c406fa75839cbd8d090da" tag="relay_state_based_on_time_and_preset">
+        <name>Relay schedule template</name>
+        <description>Template for scheduling relays on a time and preset basis.</description>
+        <single_actor>false</single_actor>
+        <created_date>2017-10-25T14:55:02.453+02:00</created_date>
+        <modified_date>2024-07-29T15:46:14.511+02:00</modified_date>
+        <deleted_date/>
+        <objects>
+            <object name="zone" type="Location"/>
+            <object name="direct_object" type="DirectObject"/>
+        </objects>
+        <parameters>
+            <parameter name="time" source="clock.weekTime" type="WeekTime"/>
+            <parameter name="preset" source="zone.preset" type="Preset"/>
+        </parameters>
+        <results>
+            <result name="state" type="OnOff" action="direct_object.iterateFunctionalities('RelayFunctionality')().state = state"/>
+        </results>
+    </template>
+    <template id="2e42e58553c14cbbb764dc6fe0a12c65" tag="domestic_hot_water_based_on_time">
+        <name>DHW schedule template</name>
+        <description>Template for scheduling DHW mode and state on a time basis.</description>
+        <single_actor>true</single_actor>
+        <created_date>2023-08-17T06:29:48.495+02:00</created_date>
+        <modified_date>2024-07-29T15:46:14.585+02:00</modified_date>
+        <deleted_date/>
+        <objects>
+            <object name="direct_object" type="DirectObject"/>
+        </objects>
+        <parameters>
+            <parameter name="time" source="clock.weekTime" type="WeekTime"/>
+        </parameters>
+        <results>
+            <result name="domestic_hot_water_comfort_mode" type="OnOff" action="direct_object.iterateFunctionalities('ToggleFunctionality', 'domestic_hot_water_comfort_mode')().setState(clock.addSeconds(null, 1), domestic_hot_water_comfort_mode)"/>
+            <result name="domestic_hot_water_mode" type="DomesticHotWaterMode" action="direct_object.iterateFunctionalities('DomesticHotWaterModeControlFunctionality', 'domestic_hot_water_mode')().setMode(clock.addSeconds(null, 1), domestic_hot_water_mode)"/>
+            <result name="domestic_hot_water_setpoint" type="Number" action="direct_object.iterateFunctionalities('ThermostatFunctionality', 'domestic_hot_water_setpoint')().setSetpoint(clock.addSeconds(null, 1), domestic_hot_water_setpoint)"/>
+        </results>
+    </template>
+    <template id="3ad9f4216ff14ed794b3198871b6a9dc" tag="relay_state_based_on_time_preset_temperature_and_humidity">
+        <name>Relay schedule template</name>
+        <description>Template for scheduling relays on a time, solar time, preset, temperature and humidity basis.</description>
+        <single_actor>false</single_actor>
+        <created_date>2021-10-28T04:56:49.928+02:00</created_date>
+        <modified_date>2024-07-29T15:46:14.516+02:00</modified_date>
+        <deleted_date/>
+        <objects>
+            <object name="zone" type="Location"/>
+            <object name="direct_object" type="DirectObject"/>
+        </objects>
+        <parameters>
+            <parameter name="time" source="clock.weekTime" type="WeekTime"/>
+            <parameter name="temperature" source="zone.temperature" type="Number"/>
+            <parameter name="humidity" source="zone.humidity" type="Number"/>
+            <parameter name="preset" source="zone.preset" type="Preset"/>
+        </parameters>
+        <results>
+            <result name="state" type="OnOff" action="direct_object.iterateFunctionalities('RelayFunctionality')().state = state"/>
+        </results>
+    </template>
+    <module id="c53888603af34264bbed2a05998ee572">
+        <vendor_name>Techneco</vendor_name>
+        <vendor_model/>
+        <hardware_version/>
+        <firmware_version/>
+        <created_date>2019-07-22T11:08:27.495+02:00</created_date>
+        <modified_date>2024-06-07T16:48:11.312+02:00</modified_date>
+        <deleted_date/>
+        <services>
+            <pressure_gauge id="01d551e4bb2b475a9463912a3fd887da" log_type="central_heater_water_pressure">
+                <functionalities>
+                    <point_log id="e799a764479a4c4586179dd0760fe54e"/>
+                </functionalities>
+            </pressure_gauge>
+            <thermostat id="07c7b619be4242d6919733e6098a5b5e" log_type="maximum_outdoor_unit_steady_temperature">
+                <functionalities>
+                    <thermostat_functionality id="9cee766c36c843288b9bc17628e2a5a7"/>
+                    <point_log id="c0a8e16b4efd465a88ed471330a99046"/>
+                </functionalities>
+            </thermostat>
+            <thermo_meter id="167efda4780e4fa8bbc8f588f4708fa2" log_type="temperature">
+                <functionalities>
+                    <point_log id="48f202225fb94f0b96540d97e65397c7"/>
+                </functionalities>
+            </thermo_meter>
+            <timer id="1b79f533784742c796c973856b30909d" log_type="indoor_temperature_transition_time">
+                <functionalities>
+                    <timer_functionality id="4e627a99dcf94bc086b31aa3a6de44b2"/>
+                    <point_log id="c49b3ce126314dca848d51429a0ef2ea"/>
+                </functionalities>
+            </timer>
+            <thermo_meter id="1d0d91857e4042ec9180e2bc78898d13" log_type="intended_boiler_temperature">
+                <functionalities>
+                    <point_log id="0b1f4d8bbbbd451bb5214a7f592124e5"/>
+                </functionalities>
+            </thermo_meter>
+            <boiler_state id="1efb6c04052e4defbe429d6440c285c6" log_type="compressor_state">
+                <functionalities>
+                    <point_log id="40e35727c7b947f48099b5221633474c"/>
+                </functionalities>
+            </boiler_state>
+            <thermostat id="211f6996e8394d12a1f2cdb23b420a2c" log_type="heatpump_minimum_outdoor_temperature">
+                <functionalities>
+                    <thermostat_functionality id="c9b707c378b04420a55bdffe00e4f8f6"/>
+                    <point_log id="daac6bf095ce472082653bd4a57c58f9"/>
+                </functionalities>
+            </thermostat>
+            <domestic_hot_water_toggle id="29fb663d576a46c79d629826edff95f0" log_type="domestic_hot_water_comfort_mode">
+                <functionalities>
+                    <point_log id="2e0289df2c7f4b66b8a4f562658a6903"/>
+                    <toggle_functionality id="700bd52a8729461bb0fdf6d055c08710"/>
+                </functionalities>
+            </domestic_hot_water_toggle>
+            <fault_code id="310985c85e5e42238c4ae63180e8ed2c" log_type="elga_outdoor_unit_fault_code">
+                <functionalities>
+                    <point_log id="24b48396d2c24a7089fd3a3f0476fe3d"/>
+                </functionalities>
+            </fault_code>
+            <thermostat id="333ef91f62d94f78ad7b9bedaecc71f2" log_type="maximum_outdoor_unit_temperature">
+                <functionalities>
+                    <point_log id="10cea8565cd343768a6867c47c0300c6"/>
+                    <thermostat_functionality id="a67b1c7b6d2f403aba383a56ad3d8e0a"/>
+                </functionalities>
+            </thermostat>
+            <thermostat id="3636e8c24b764f9dae52ba36695ed476" log_type="weather_dependent_maximum_supply_temperature">
+                <functionalities>
+                    <thermostat_functionality id="9cfae18be05b4509b32d52571107f0ff"/>
+                    <point_log id="d517c9c0c3254926bd881c61b41f2185"/>
+                </functionalities>
+            </thermostat>
+            <threshold id="38eadee2fac04aaab6f8fac793560c82" log_type="boiler_activation_threshold">
+                <functionalities>
+                    <threshold_functionality id="57fb489e615a46888a051712ca8954f2"/>
+                    <point_log id="e809f761a4c14287a852a8c727bbdc40"/>
+                </functionalities>
+            </threshold>
+            <timer id="397304cc8cbe47798f41930b1d62b009" log_type="hibernation_lead_time">
+                <functionalities>
+                    <point_log id="02b66447758049fab71cfc396d0b4423"/>
+                    <timer_functionality id="4823c26f51bc4b07928acbb5ef056ca1"/>
+                </functionalities>
+            </timer>
+            <fault_code id="3af7b55915d841808e61d89a7663b7a2" log_type="open_therm_slave_oem_fault_code">
+                <functionalities>
+                    <point_log id="a45bc7ff672748328d3f83e6a4808ea3"/>
+                </functionalities>
+            </fault_code>
+            <timer id="4ac8d9303b644429b5c5bae03a79470a" log_type="pump_lag_time">
+                <functionalities>
+                    <timer_functionality id="631c67b8e2f2411d83ffa5a687f3b79b"/>
+                    <point_log id="d703b335844c4d789b707534cb5dbd3e"/>
+                </functionalities>
+            </timer>
+            <thermostat id="4b8a974d347f4cf1872a5bc07f613068" log_type="maximum_heating_supply_temperature">
+                <functionalities>
+                    <thermostat_functionality id="b6579ded90e7489ca51a48768c721eb0"/>
+                    <point_log id="f3eaebe5868840099b2f6eea9763dec3"/>
+                </functionalities>
+            </thermostat>
+            <dip_switch id="4d79c04aa75340519aca29545955bf76" log_type="input_contacts_installed">
+                <functionalities>
+                    <point_log id="80737def763544d797ce2ecebbaaf606"/>
+                </functionalities>
+            </dip_switch>
+            <thermostat id="5304a8c3c39e42b990c9b057e880f8a4" log_type="minimum_cooling_supply_temperature">
+                <functionalities>
+                    <point_log id="705e0e0f37574caabd69dd6a9db1620d"/>
+                    <thermostat_functionality id="a1f29fd4edae4894a74c0b8c523f8ef3"/>
+                </functionalities>
+            </thermostat>
+            <dip_switch id="53a892b70e7a4f01a6174415509e8590" log_type="hibernation_enabled">
+                <functionalities>
+                    <point_log id="188ba49897614157a0b2723087058010"/>
+                </functionalities>
+            </dip_switch>
+            <thermostat id="564f724946434905b7d2b6c142e4ba67" log_type="maximum_outdoor_unit_power_increase_temperature">
+                <functionalities>
+                    <point_log id="083ba290a88245f3bd56957d6695dd55"/>
+                    <thermostat_functionality id="f8b9ad4b594846628e305fdf7ff26b3e"/>
+                </functionalities>
+            </thermostat>
+            <thermo_meter id="59c732e79efc4be6af8a469dba16b40c" log_type="domestic_hot_water_setpoint">
+                <functionalities>
+                    <point_log id="af12fd7e384c4081b3700f7fc424ac79"/>
+                </functionalities>
+            </thermo_meter>
+            <dip_switch id="5f729e9aa96c4e33ad866f2efe41e694" log_type="thermostat_enabled">
+                <functionalities>
+                    <point_log id="7e6f7d5dfdd84b5ca8287d0f30944e8b"/>
+                </functionalities>
+            </dip_switch>
+            <dip_switch id="60c6512c9b9249199ca4adb48ab30e4e" log_type="weather_dependent_regulation">
+                <functionalities>
+                    <point_log id="56c09638ead640a5a7b6864a6a1db81b"/>
+                </functionalities>
+            </dip_switch>
+            <timer id="68a4b6945cbb49e0b1629ae6a44da34b" log_type="external_pump_cooling_lead_time">
+                <functionalities>
+                    <point_log id="78125fc1129b404782f7cf08c1a72401"/>
+                    <timer_functionality id="8dcd68a78d704da8b0a61083d376223f"/>
+                </functionalities>
+            </timer>
+            <fault_code id="6e268f4aa86e4cc0a29c084d00c8319b" log_type="open_therm_oem_fault_code">
+                <functionalities>
+                    <point_log id="7d79610e27234506b0220b7e1a14eb3a"/>
+                </functionalities>
+            </fault_code>
+            <boiler_state id="72ac57601ea7410381c889a1f58b191c" log_type="intended_central_heating_state">
+                <functionalities>
+                    <point_log id="5f0c73d239254abea42bdf1cf02bd7de"/>
+                </functionalities>
+            </boiler_state>
+            <dip_switch id="74fab0d973c049e09f3514141f58c0ef" log_type="temperature_sensor_enabled">
+                <functionalities>
+                    <point_log id="7a90e2fb40a34176a94e408957c5c27c"/>
+                </functionalities>
+            </dip_switch>
+            <dip_switch id="769ba34f091e4fe4a0718ed34defea99" log_type="second_fan_enabled">
+                <functionalities>
+                    <point_log id="a6e3ad5afe8e4c6c9feafbd95f221a3a"/>
+                </functionalities>
+            </dip_switch>
+            <thermostat id="7c4e5837e0474ad3888e97cf21a51670" log_type="night_reduction_setpoint">
+                <functionalities>
+                    <thermostat_functionality id="07699ce0bdd6491db490f0e15642ca43"/>
+                    <point_log id="8bbc4ca809b84a41b6c6115a8ccacecf"/>
+                </functionalities>
+            </thermostat>
+            <temperature_offset id="7c77a680bb0645aeb325f196e4a3df57" log_type="cooling_upper_offset">
+                <functionalities>
+                    <offset_functionality id="69ed60c3bc3846449e61dba62e71da40"/>
+                    <point_log id="e5f051ef9b1542f2bf1b340fb6ba26d2"/>
+                </functionalities>
+            </temperature_offset>
+            <timer id="7ccb6bc94f1948ee9f16ecfb5c80d719" log_type="internal_pump_cooling_lead_time">
+                <functionalities>
+                    <point_log id="72e0439587ac443c8880f35543c12834"/>
+                    <timer_functionality id="d24d209910e34533a95e361c8c66352c"/>
+                </functionalities>
+            </timer>
+            <thermostat id="82b1c7dcc6674568af1dbace5e64af8b" log_type="maximum_cooling_supply_temperature">
+                <functionalities>
+                    <point_log id="292c77f567194b14a0e7c3d63b340e66"/>
+                    <thermostat_functionality id="6385d825e10545bfabc3cd3574920b68"/>
+                </functionalities>
+            </thermostat>
+            <thermo_meter id="8609fbdcab4b46e387953184f9878c28" log_type="outdoor_temperature">
+                <functionalities>
+                    <point_log id="fa0e3334f8d941cbbb040c5bf52fb2df"/>
+                </functionalities>
+            </thermo_meter>
+            <timer id="881f3c1377bc4efda8c78409a18ebe55" log_type="internal_pump_heating_lead_time">
+                <functionalities>
+                    <timer_functionality id="0646e6e1204147668157d2a7c59ef3ee"/>
+                    <point_log id="1365f71019794971bbb06ebd881b7c84"/>
+                </functionalities>
+            </timer>
+            <modulation_level id="8862e6a7a98842928028e3f14493de8b" log_type="modulation_level">
+                <functionalities>
+                    <point_log id="1a94ecad909b40848efdce89197bae6d"/>
+                </functionalities>
+            </modulation_level>
+            <cooling_toggle id="8a13768d922b439a9535b50a4c35d5c8" log_type="cooling_enabled">
+                <functionalities>
+                    <point_log id="0ff1cafe432f43efae4fa50d2ede4a00"/>
+                    <toggle_functionality id="d93b629453934687bb3374ebeea82c0a"/>
+                </functionalities>
+            </cooling_toggle>
+            <thermo_meter id="8eafb561fafb42ef8305eae670851e4a" log_type="boiler_temperature">
+                <functionalities>
+                    <point_log id="9556ad80c44b48459e297eeca0720cc3"/>
+                </functionalities>
+            </thermo_meter>
+            <dip_switch id="8eeb17de38da4b37992c7ef910592306" log_type="simultaneous_boiler_operation">
+                <functionalities>
+                    <point_log id="c65f2f2e30df4e1cb48bff1afc6bfaf5"/>
+                </functionalities>
+            </dip_switch>
+            <status_code id="91eb08ab048d4f8c947399a64a2e618b" log_type="elga_status_code">
+                <functionalities>
+                    <point_log id="1d03fff43bf640f998150fabc2aa7522"/>
+                </functionalities>
+            </status_code>
+            <boiler_state id="93242446d05a443fa31dc19c56fef767" log_type="central_heating_state">
+                <functionalities>
+                    <point_log id="d6e5970949cc4c48a1e20d830e3f9856"/>
+                </functionalities>
+            </boiler_state>
+            <boiler_state id="9c0a03f4a7f94290997bef767e5a81c2" log_type="flame_state">
+                <functionalities>
+                    <point_log id="00c5146fe1a749e3925627d59700652a"/>
+                </functionalities>
+            </boiler_state>
+            <thermostat id="9d9f24a42c514c99887d85091ba46d74" log_type="minimum_heating_supply_temperature">
+                <functionalities>
+                    <thermostat_functionality id="5b6c3a3cf0de4adc92e4aac0d93e1962"/>
+                    <point_log id="5cd62cb4ac5a4067859f074a9a0eeb66"/>
+                </functionalities>
+            </thermostat>
+            <thermo_meter id="a2847eec8a634ccdb70d3c1a79c60df7" log_type="return_water_temperature">
+                <functionalities>
+                    <point_log id="f9aff78878654f84a8344c0851d7cb33"/>
+                </functionalities>
+            </thermo_meter>
+            <boiler_state id="a5d3ae6bd1474d4ebf506f405bb94b06" log_type="slave_boiler_state">
+                <functionalities>
+                    <point_log id="3ad82db986354586b9a0b63ffe9685d6"/>
+                </functionalities>
+            </boiler_state>
+            <fault_code id="a649c0c0731b4efe8f971a2174d95901" log_type="open_therm_application_specific_fault_code">
+                <functionalities>
+                    <point_log id="db8123f44611441095c67a6c2ff84ec7"/>
+                </functionalities>
+            </fault_code>
+            <timer id="a783fff6c496488cbee3d8b43fd5be7e" log_type="minimum_boiler_off_time">
+                <functionalities>
+                    <timer_functionality id="00a41642a7764d1d80fe37b0cd493730"/>
+                    <point_log id="bf9870695c254ead9edc22f9abe52260"/>
+                </functionalities>
+            </timer>
+            <thermo_meter id="a80c9f90f72944a8a50e41fac5b72126" log_type="maximum_boiler_temperature">
+                <functionalities>
+                    <point_log id="d368799910734cc89ed1e3d5d60363fc"/>
+                </functionalities>
+            </thermo_meter>
+            <dip_switch id="a8d50bc1b02c4453acbf78c484da2ed0" log_type="boiler_enabled">
+                <functionalities>
+                    <point_log id="b4629113c7b44a43a3ba634fc054279c"/>
+                </functionalities>
+            </dip_switch>
+            <boiler_state id="aad2f61001b345ca85e9dda8e0beba70" log_type="domestic_hot_water_state">
+                <functionalities>
+                    <point_log id="09e461faff3a4abc9259f7c6e26ffcf0"/>
+                </functionalities>
+            </boiler_state>
+            <dip_switch id="acc1480a9e1f4b02ad9d94f7cbd8c6d9" log_type="serial_boiler_installation">
+                <functionalities>
+                    <point_log id="6e461af3d33245ffb49ffeaa2752a340"/>
+                </functionalities>
+            </dip_switch>
+            <interval_chrono_meter id="afda7f45daef401d9a0b651846933815" log_type="burner_operation_time">
+                <functionalities>
+                    <interval_log id="38e63c9a554249a9848053ad0ef8f148"/>
+                </functionalities>
+            </interval_chrono_meter>
+            <dip_switch id="bc0af70f6ee24c6b9a48542b4e1cb7f0" log_type="heating_curve">
+                <functionalities>
+                    <point_log id="e86e337316754960bca3bd5c3efe87c4"/>
+                </functionalities>
+            </dip_switch>
+            <thermostat id="bfe6665d0f05467b977b077b7b787cf1" log_type="boiler_minimum_outdoor_temperature">
+                <functionalities>
+                    <point_log id="0444ed9ec551496fadbeb728ab619daa"/>
+                    <thermostat_functionality id="965f1d814e594fb191268c47ff527022"/>
+                </functionalities>
+            </thermostat>
+            <temperature_offset id="c2c422292b904217a49eb2ebb64139fa" log_type="cooling_lower_offset">
+                <functionalities>
+                    <offset_functionality id="08ca8e47df01477ebfc92442fc327ba8"/>
+                    <point_log id="6c6734ca9c52437ebdd012dc1c9237b6"/>
+                </functionalities>
+            </temperature_offset>
+            <dip_switch id="c90363c157d84f3cb34ec9fa0ad4a1b1" log_type="first_fan_enabled">
+                <functionalities>
+                    <point_log id="08b3982eb0e445e79001228b879db934"/>
+                </functionalities>
+            </dip_switch>
+            <dip_switch id="cbbc6155ab0945248c08fb6c08be2e64" log_type="outdoor_temperature_used">
+                <functionalities>
+                    <point_log id="1e2304cab4b14e80a91d30f733509659"/>
+                </functionalities>
+            </dip_switch>
+            <timer id="cd3755b4f6454aa482f5603edc7c7019" log_type="external_pump_heating_lead_time">
+                <functionalities>
+                    <timer_functionality id="4538146f706d42098e9e233b0ef4d1bd"/>
+                    <point_log id="7a088fe1ff4d44d5a03be6f1ddb69b1a"/>
+                </functionalities>
+            </timer>
+            <dip_switch id="cdcb69e61cf7452dad650f828827fc3c" log_type="thermostat_supports_cooling">
+                <functionalities>
+                    <point_log id="25e405154876410cbb760583417206bb"/>
+                </functionalities>
+            </dip_switch>
+            <thermo_meter id="ce44bfc81c5b4f2d82331c48b548aae7" log_type="refrigerent_out_temperature">
+                <functionalities>
+                    <point_log id="acedb4c2dd3d49039768c23832f7b599"/>
+                </functionalities>
+            </thermo_meter>
+            <dip_switch id="d127367c661c4c3582b544a08b0c68ad" log_type="underfloor_heating">
+                <functionalities>
+                    <point_log id="0a12b2e6991e4f42bf2912673547b156"/>
+                </functionalities>
+            </dip_switch>
+            <thermo_meter id="d26080b9f53246c08ff76d20e162670a" log_type="refrigerent_in_temperature">
+                <functionalities>
+                    <point_log id="375a05154d6647148cf393ac8b2c8b65"/>
+                </functionalities>
+            </thermo_meter>
+            <dip_switch id="d3abfcd0012e4b47af6d69911031f7ab" log_type="boiler_installed">
+                <functionalities>
+                    <point_log id="3f1313a814ec4614be4e709e659a4f8d"/>
+                </functionalities>
+            </dip_switch>
+            <dip_switch id="ebf84b976e4e4cb39c5b553e7a9e5fc1" log_type="night_reduction">
+                <functionalities>
+                    <point_log id="dd64bb930f484e2e8047c5020ef9c185"/>
+                </functionalities>
+            </dip_switch>
+            <timer id="ecbec078612949e6aa050f2ad9b55958" log_type="minimum_boiler_run_time">
+                <functionalities>
+                    <timer_functionality id="4d846b97eca946d78e6f3c0ae70f9db4"/>
+                    <point_log id="e7b09f30833c458c9291c7cf761f0068"/>
+                </functionalities>
+            </timer>
+            <boiler_state id="f613e055261943f4987856badb3fb0ae" log_type="cooling_state">
+                <functionalities>
+                    <point_log id="bbfaf21ad4e14ca3be4ba9b508047d6b"/>
+                </functionalities>
+            </boiler_state>
+        </services>
+        <protocols>
+            <open_therm_boiler id="b2481333821543b0994b280c60395ba5">
+                <thermo_extension id="668c0412fb2b420a80de9642b9f8a2f1"/>
+                <open_therm_version>0.0</open_therm_version>
+                <is_modulating>true</is_modulating>
+                <with_cooling>false</with_cooling>
+                <with_domestic_hot_water>false</with_domestic_hot_water>
+                <with_domestic_hot_water_storage>false</with_domestic_hot_water_storage>
+                <with_master_low_off_and_pump_control>true</with_master_low_off_and_pump_control>
+                <with_secondary_heating_circuit>false</with_secondary_heating_circuit>
+                <smartgrid_control>smart_grid_off</smartgrid_control>
+                <test_mode>off</test_mode>
+            </open_therm_boiler>
+        </protocols>
+    </module>
+    <module id="3b36454dda794c6faaed4053a89e80ce">
+        <vendor_name>Plugwise</vendor_name>
+        <vendor_model>ThermoTouch</vendor_model>
+        <hardware_version>6539-1301-5002</hardware_version>
+        <firmware_version>2018-02-08T11:15:53+01:00</firmware_version>
+        <created_date>2019-07-22T11:03:36.712+02:00</created_date>
+        <modified_date>2022-09-07T14:32:47.321+02:00</modified_date>
+        <deleted_date/>
+        <services>
+            <thermo_meter id="00426b5ea5584f91a1705c1baffde511" log_type="temperature">
+                <functionalities>
+                    <point_log id="9c2e08cbe1184ac9ae604d2c7a7c88cd"/>
+                </functionalities>
+            </thermo_meter>
+            <threshold id="06c97b7ed1504d498e09d1aa33240317" log_type="cooling_deactivation_threshold">
+                <functionalities>
+                    <threshold_functionality id="12c30fcd3ae0465c9a57661cbb6b5e22"/>
+                    <point_log id="5337865ab7f743388dca27d127deecb0"/>
+                </functionalities>
+            </threshold>
+            <modulation_level id="1573925c349941da86f630f58dff9ed8" log_type="maximum_modulation_level">
+                <functionalities>
+                    <point_log id="f29e26d6745b414e9f0439eed6b37a9f"/>
+                </functionalities>
+            </modulation_level>
+            <temperature_offset_meter id="1b662f928c4f4a739b521214d8539c47" log_type="decentral_heat_demand_offset">
+                <functionalities>
+                    <point_log id="19a51cc2909a42308846d07095089c48"/>
+                </functionalities>
+            </temperature_offset_meter>
+            <thermo_meter id="261d7f5dd4494c139cf30bcc20a87ebe" log_type="target_temperature">
+                <functionalities>
+                    <point_log id="dbb111e942c74bc3bdac40d228d58082"/>
+                </functionalities>
+            </thermo_meter>
+            <illuminance_meter id="4792764e63104d1691efa5bc966f5187" log_type="illuminance">
+                <functionalities>
+                    <point_log id="a5da72e538e94d0690a3491ea1f5c35a"/>
+                </functionalities>
+            </illuminance_meter>
+            <thermostat id="52b5a053e83446e6a11fde60a6c9ed11" log_type="thermostat">
+                <functionalities>
+                    <thermostat_functionality id="9d718e17024446f296adecf2a1da9e18"/>
+                    <point_log id="bfd9477530694a46bdc6749548fd218c"/>
+                </functionalities>
+            </thermostat>
+            <thermostat id="6be1fe5740ee44ada8faf4fe8c7b24b8" log_type="cooling_activation_outdoor_temperature">
+                <functionalities>
+                    <thermostat_functionality id="5dd948c45a004b02a43d032117fda550"/>
+                    <point_log id="e2e178a233174a1fa9268c5d90a43bfe"/>
+                </functionalities>
+            </thermostat>
+            <temperature_rate id="725cff112a2b4d839ce6b8229c461c66" log_type="preheating_target_temperature_rate">
+                <functionalities>
+                    <point_log id="fa88a8770fe846f3a11e1bdffc09b7b5"/>
+                </functionalities>
+            </temperature_rate>
+            <temperature_offset_meter id="725e6fbd7440407a99c3bf13cc22d870" log_type="onoff_boiler_temperature_deadband">
+                <functionalities>
+                    <point_log id="90c3a54e3a1c465eb81302fef57f4410"/>
+                </functionalities>
+            </temperature_offset_meter>
+            <frequency_meter id="894b17e281dd4429bb5982de7048d929" log_type="cpu_frequency">
+                <functionalities>
+                    <point_log id="cecd3059ab6d4ece9b419b7bf820b7f4"/>
+                </functionalities>
+            </frequency_meter>
+            <boiler_state id="90771c033acc44f481f194309e2ed032" log_type="intended_central_heating_state">
+                <functionalities>
+                    <point_log id="bed93c9f59cf445e8e796daba3f61df1"/>
+                </functionalities>
+            </boiler_state>
+            <coefficient id="9c5191459bfa42e2bc92a951886ca6c0" log_type="derivative_coefficient">
+                <functionalities>
+                    <point_log id="5c206e6a6fff4962b3e06d965c9caf4d"/>
+                </functionalities>
+            </coefficient>
+            <temperature_offset id="a7b6d9b100ac460eaa9316b20a4ac407" log_type="temperature_offset">
+                <functionalities>
+                    <point_log id="01a06384c7d449bba2725e8edf714584"/>
+                    <offset_functionality id="30ba5dff06a347938dbbcbef5a9b425d"/>
+                </functionalities>
+            </temperature_offset>
+            <temperature_offset_meter id="b107e4d0690c40e38f9519de498f80d0" log_type="open_therm_boiler_activation_threshold">
+                <functionalities>
+                    <point_log id="05cfa5d4403b42ddb2f0258dc76d6754"/>
+                </functionalities>
+            </temperature_offset_meter>
+            <button id="d349d6b8767c491991390ea199337223" log_type="button_left" position="left">
+                <functionalities>
+                    <point_log id="6b8756139eb34bab9692edb22d0bcd50"/>
+                </functionalities>
+            </button>
+            <boiler_state id="d67523ab0c934c4e9a0ec9262f7677b5" log_type="intended_domestic_hot_water_comfort_mode">
+                <functionalities>
+                    <point_log id="6c53a08fca4f44518247ca583f3f7741"/>
+                </functionalities>
+            </boiler_state>
+            <button id="d8d99db2d9214863a3c7e28bcd115b12" log_type="button_right" position="right">
+                <functionalities>
+                    <point_log id="87a32c244021436b88d59ae44af16378"/>
+                </functionalities>
+            </button>
+            <proximity_sensor id="ef39b2e2aacb40f08568a6fc638c242a" log_type="proximity_detection">
+                <functionalities>
+                    <point_log id="23544f8616644a87a971bb584cd2c926"/>
+                </functionalities>
+            </proximity_sensor>
+            <button id="f84d8f82ff114da995c4af377cecede7" log_type="button_top" position="top">
+                <functionalities>
+                    <point_log id="a406a1ebacf84ba2acde0a7bc37542e7"/>
+                </functionalities>
+            </button>
+            <proximity_sensor_toggle id="fbebb29bb7814191bae5c343567f4d8c" log_type="proximity_sensor_state">
+                <functionalities>
+                    <point_log id="a1041c7b4a0544ce84870460f4f7624a"/>
+                    <toggle_functionality id="e841103f04ae4e8184c9b3e6172c2266"/>
+                </functionalities>
+            </proximity_sensor_toggle>
+        </services>
+        <protocols>
+            <thermo_touch id="af43990b4ca744cf8e9f9b5996190f6f">
+                <thermo_extension id="668c0412fb2b420a80de9642b9f8a2f1"/>
+            </thermo_touch>
+        </protocols>
+    </module>
+    <appliance id="573c152e7d4f4720878222bd75638f5b">
+        <name>Central heating boiler</name>
+        <description/>
+        <type>heater_central</type>
+        <created_date>2019-07-22T11:08:27.693+02:00</created_date>
+        <modified_date>2024-12-06T18:47:01.941+01:00</modified_date>
+        <deleted_date/>
+        <groups/>
+        <logs>
+            <point_log id="00c5146fe1a749e3925627d59700652a">
+                <type>flame_state</type>
+                <unit/>
+                <updated_date>2024-12-06T12:47:07.274+01:00</updated_date>
+                <last_consecutive_log_date>2024-12-06T12:47:07.274+01:00</last_consecutive_log_date>
+                <interval/>
+                <boiler_state id="9c0a03f4a7f94290997bef767e5a81c2"/>
+                <period start_date="2024-12-06T12:47:07.274+01:00" end_date="2024-12-06T12:47:07.274+01:00">
+                    <measurement log_date="2024-12-06T12:47:07.274+01:00">on</measurement>
+                </period>
+            </point_log>
+            <point_log id="02b66447758049fab71cfc396d0b4423">
+                <type>hibernation_lead_time</type>
+                <unit>hr</unit>
+                <updated_date>2024-12-06T18:16:58.924+01:00</updated_date>
+                <last_consecutive_log_date>2024-12-06T18:16:58.924+01:00</last_consecutive_log_date>
+                <interval/>
+                <timer id="397304cc8cbe47798f41930b1d62b009"/>
+                <period start_date="2024-12-06T18:16:58.924+01:00" end_date="2024-12-06T18:16:58.924+01:00">
+                    <measurement log_date="2024-12-06T18:16:58.924+01:00">10</measurement>
+                </period>
+            </point_log>
+            <point_log id="0444ed9ec551496fadbeb728ab619daa">
+                <type>boiler_minimum_outdoor_temperature</type>
+                <unit>C</unit>
+                <updated_date>2024-12-06T18:24:43.358+01:00</updated_date>
+                <last_consecutive_log_date>2024-12-06T18:24:43.358+01:00</last_consecutive_log_date>
+                <interval/>
+                <thermostat id="bfe6665d0f05467b977b077b7b787cf1"/>
+                <period start_date="2024-12-06T18:24:43.358+01:00" end_date="2024-12-06T18:24:43.358+01:00">
+                    <measurement log_date="2024-12-06T18:24:43.358+01:00">14.00</measurement>
+                </period>
+            </point_log>
+            <point_log id="083ba290a88245f3bd56957d6695dd55">
+                <type>maximum_outdoor_unit_power_increase_temperature</type>
+                <unit>C</unit>
+                <updated_date>2024-12-06T18:20:13.452+01:00</updated_date>
+                <last_consecutive_log_date>2024-12-06T18:20:13.452+01:00</last_consecutive_log_date>
+                <interval/>
+                <thermostat id="564f724946434905b7d2b6c142e4ba67"/>
+                <period start_date="2024-12-06T18:20:13.452+01:00" end_date="2024-12-06T18:20:13.452+01:00">
+                    <measurement log_date="2024-12-06T18:20:13.452+01:00">43.00</measurement>
+                </period>
+            </point_log>
+            <point_log id="08b3982eb0e445e79001228b879db934">
+                <type>first_fan_enabled</type>
+                <unit/>
+                <updated_date>2024-12-06T18:46:53.769+01:00</updated_date>
+                <last_consecutive_log_date>2024-12-06T18:46:53.769+01:00</last_consecutive_log_date>
+                <interval/>
+                <dip_switch id="c90363c157d84f3cb34ec9fa0ad4a1b1"/>
+                <period start_date="2024-12-06T18:46:53.769+01:00" end_date="2024-12-06T18:46:53.769+01:00">
+                    <measurement log_date="2024-12-06T18:46:53.769+01:00">off</measurement>
+                </period>
+            </point_log>
+            <point_log id="09e461faff3a4abc9259f7c6e26ffcf0">
+                <type>domestic_hot_water_state</type>
+                <unit/>
+                <updated_date>2024-12-06T14:53:02.787+01:00</updated_date>
+                <last_consecutive_log_date>2024-12-06T14:53:02.787+01:00</last_consecutive_log_date>
+                <interval/>
+                <boiler_state id="aad2f61001b345ca85e9dda8e0beba70"/>
+                <period start_date="2024-12-06T14:53:02.787+01:00" end_date="2024-12-06T14:53:02.787+01:00">
+                    <measurement log_date="2024-12-06T14:53:02.787+01:00">off</measurement>
+                </period>
+            </point_log>
+            <point_log id="0a12b2e6991e4f42bf2912673547b156">
+                <type>underfloor_heating</type>
+                <unit/>
+                <updated_date>2024-12-06T18:46:58.677+01:00</updated_date>
+                <last_consecutive_log_date>2024-12-06T18:46:58.677+01:00</last_consecutive_log_date>
+                <interval/>
+                <dip_switch id="d127367c661c4c3582b544a08b0c68ad"/>
+                <period start_date="2024-12-06T18:46:58.677+01:00" end_date="2024-12-06T18:46:58.677+01:00">
+                    <measurement log_date="2024-12-06T18:46:58.677+01:00">off</measurement>
+                </period>
+            </point_log>
+            <point_log id="0b1f4d8bbbbd451bb5214a7f592124e5">
+                <type>intended_boiler_temperature</type>
+                <unit>C</unit>
+                <updated_date>2024-10-26T18:06:19.103+02:00</updated_date>
+                <last_consecutive_log_date>2024-10-26T18:06:19.102+02:00</last_consecutive_log_date>
+                <interval/>
+                <thermo_meter id="1d0d91857e4042ec9180e2bc78898d13"/>
+                <period start_date="2024-10-26T18:06:19.103+02:00" end_date="2024-10-26T18:06:19.103+02:00">
+                    <measurement log_date="2024-10-26T18:06:19.103+02:00">58.29</measurement>
+                </period>
+            </point_log>
+            <point_log id="0ff1cafe432f43efae4fa50d2ede4a00">
+                <type>cooling_enabled</type>
+                <unit/>
+                <updated_date>2024-07-29T15:45:52.224+02:00</updated_date>
+                <last_consecutive_log_date>2024-07-29T15:45:52.224+02:00</last_consecutive_log_date>
+                <interval/>
+                <cooling_toggle id="8a13768d922b439a9535b50a4c35d5c8"/>
+                <period start_date="2024-07-29T15:45:52.224+02:00" end_date="2024-07-29T15:45:52.224+02:00">
+                    <measurement log_date="2024-07-29T15:45:52.224+02:00">on</measurement>
+                </period>
+            </point_log>
+            <point_log id="10cea8565cd343768a6867c47c0300c6">
+                <type>maximum_outdoor_unit_temperature</type>
+                <unit>C</unit>
+                <updated_date>2024-12-06T18:17:54.726+01:00</updated_date>
+                <last_consecutive_log_date>2024-12-06T18:17:54.726+01:00</last_consecutive_log_date>
+                <interval/>
+                <thermostat id="333ef91f62d94f78ad7b9bedaecc71f2"/>
+                <period start_date="2024-12-06T18:17:54.726+01:00" end_date="2024-12-06T18:17:54.726+01:00">
+                    <measurement log_date="2024-12-06T18:17:54.726+01:00">47.00</measurement>
+                </period>
+            </point_log>
+            <point_log id="1365f71019794971bbb06ebd881b7c84">
+                <type>internal_pump_heating_lead_time</type>
+                <unit>s</unit>
+                <updated_date>2024-12-06T18:24:41.056+01:00</updated_date>
+                <last_consecutive_log_date>2024-12-06T18:24:41.056+01:00</last_consecutive_log_date>
+                <interval/>
+                <timer id="881f3c1377bc4efda8c78409a18ebe55"/>
+                <period start_date="2024-12-06T18:24:41.056+01:00" end_date="2024-12-06T18:24:41.056+01:00">
+                    <measurement log_date="2024-12-06T18:24:41.056+01:00">60</measurement>
+                </period>
+            </point_log>
+            <point_log id="188ba49897614157a0b2723087058010">
+                <type>hibernation_enabled</type>
+                <unit/>
+                <updated_date>2024-12-06T18:46:58.686+01:00</updated_date>
+                <last_consecutive_log_date>2024-12-06T18:46:58.686+01:00</last_consecutive_log_date>
+                <interval/>
+                <dip_switch id="53a892b70e7a4f01a6174415509e8590"/>
+                <period start_date="2024-12-06T18:46:58.686+01:00" end_date="2024-12-06T18:46:58.686+01:00">
+                    <measurement log_date="2024-12-06T18:46:58.686+01:00">off</measurement>
+                </period>
+            </point_log>
+            <point_log id="1a94ecad909b40848efdce89197bae6d">
+                <type>modulation_level</type>
+                <unit/>
+                <updated_date>2024-12-06T18:46:53.128+01:00</updated_date>
+                <last_consecutive_log_date>2024-12-06T18:46:53.128+01:00</last_consecutive_log_date>
+                <interval/>
+                <modulation_level id="8862e6a7a98842928028e3f14493de8b"/>
+                <period start_date="2024-12-06T18:46:53.128+01:00" end_date="2024-12-06T18:46:53.128+01:00">
+                    <measurement log_date="2024-12-06T18:46:53.128+01:00">0.55</measurement>
+                </period>
+            </point_log>
+            <point_log id="1d03fff43bf640f998150fabc2aa7522">
+                <type>elga_status_code</type>
+                <unit/>
+                <updated_date>2024-12-06T18:46:33.876+01:00</updated_date>
+                <last_consecutive_log_date>2024-12-06T18:46:33.876+01:00</last_consecutive_log_date>
+                <interval/>
+                <status_code id="91eb08ab048d4f8c947399a64a2e618b"/>
+                <period start_date="2024-12-06T18:46:33.876+01:00" end_date="2024-12-06T18:46:33.876+01:00">
+                    <measurement log_date="2024-12-06T18:46:33.876+01:00">4</measurement>
+                </period>
+            </point_log>
+            <point_log id="1e2304cab4b14e80a91d30f733509659">
+                <type>outdoor_temperature_used</type>
+                <unit/>
+                <updated_date>2024-12-06T18:46:53.749+01:00</updated_date>
+                <last_consecutive_log_date>2024-12-06T18:46:53.749+01:00</last_consecutive_log_date>
+                <interval/>
+                <dip_switch id="cbbc6155ab0945248c08fb6c08be2e64"/>
+                <period start_date="2024-12-06T18:46:53.749+01:00" end_date="2024-12-06T18:46:53.749+01:00">
+                    <measurement log_date="2024-12-06T18:46:53.749+01:00">on</measurement>
+                </period>
+            </point_log>
+            <point_log id="24b48396d2c24a7089fd3a3f0476fe3d">
+                <type>elga_outdoor_unit_fault_code</type>
+                <unit/>
+                <updated_date>2024-12-06T18:47:01.938+01:00</updated_date>
+                <last_consecutive_log_date>2024-12-06T18:47:01.938+01:00</last_consecutive_log_date>
+                <interval/>
+                <fault_code id="310985c85e5e42238c4ae63180e8ed2c"/>
+                <period start_date="2024-12-06T18:47:01.938+01:00" end_date="2024-12-06T18:47:01.938+01:00">
+                    <measurement log_date="2024-12-06T18:47:01.938+01:00">0</measurement>
+                </period>
+            </point_log>
+            <point_log id="25e405154876410cbb760583417206bb">
+                <type>thermostat_supports_cooling</type>
+                <unit/>
+                <updated_date>2024-12-06T18:46:58.690+01:00</updated_date>
+                <last_consecutive_log_date>2024-12-06T18:46:58.690+01:00</last_consecutive_log_date>
+                <interval/>
+                <dip_switch id="cdcb69e61cf7452dad650f828827fc3c"/>
+                <period start_date="2024-12-06T18:46:58.690+01:00" end_date="2024-12-06T18:46:58.690+01:00">
+                    <measurement log_date="2024-12-06T18:46:58.690+01:00">on</measurement>
+                </period>
+            </point_log>
+            <point_log id="292c77f567194b14a0e7c3d63b340e66">
+                <type>maximum_cooling_supply_temperature</type>
+                <unit>C</unit>
+                <updated_date>2024-12-06T18:22:36.519+01:00</updated_date>
+                <last_consecutive_log_date>2024-12-06T18:22:36.519+01:00</last_consecutive_log_date>
+                <interval/>
+                <thermostat id="82b1c7dcc6674568af1dbace5e64af8b"/>
+                <period start_date="2024-12-06T18:22:36.519+01:00" end_date="2024-12-06T18:22:36.519+01:00">
+                    <measurement log_date="2024-12-06T18:22:36.519+01:00">21.00</measurement>
+                </period>
+            </point_log>
+            <point_log id="2e0289df2c7f4b66b8a4f562658a6903">
+                <type>domestic_hot_water_comfort_mode</type>
+                <unit/>
+                <updated_date>2024-07-29T15:46:39.089+02:00</updated_date>
+                <last_consecutive_log_date>2024-07-29T15:46:39.089+02:00</last_consecutive_log_date>
+                <interval/>
+                <domestic_hot_water_toggle id="29fb663d576a46c79d629826edff95f0"/>
+                <period start_date="2024-07-29T15:46:39.089+02:00" end_date="2024-07-29T15:46:39.089+02:00">
+                    <measurement log_date="2024-07-29T15:46:39.089+02:00">off</measurement>
+                </period>
+            </point_log>
+            <point_log id="375a05154d6647148cf393ac8b2c8b65">
+                <type>refrigerent_in_temperature</type>
+                <unit>C</unit>
+                <updated_date>2024-12-06T18:46:37.822+01:00</updated_date>
+                <last_consecutive_log_date>2024-12-06T18:46:37.822+01:00</last_consecutive_log_date>
+                <interval/>
+                <thermo_meter id="d26080b9f53246c08ff76d20e162670a"/>
+                <period start_date="2024-12-06T18:46:37.822+01:00" end_date="2024-12-06T18:46:37.822+01:00">
+                    <measurement log_date="2024-12-06T18:46:37.822+01:00">36.00</measurement>
+                </period>
+            </point_log>
+            <interval_log id="38e63c9a554249a9848053ad0ef8f148">
+                <type>burner_operation_time</type>
+                <unit>s</unit>
+                <updated_date>2024-12-06T18:00:00+01:00</updated_date>
+                <last_consecutive_log_date>2024-12-06T17:00:00+01:00</last_consecutive_log_date>
+                <interval>PT1H</interval>
+                <interval_chrono_meter id="afda7f45daef401d9a0b651846933815"/>
+                <period start_date="2024-12-06T18:00:00+01:00" end_date="2024-12-06T18:00:00+01:00" interval="PT1H">
+                    <measurement log_date="2024-12-06T18:00:00+01:00">2813</measurement>
+                </period>
+            </interval_log>
+            <point_log id="3ad82db986354586b9a0b63ffe9685d6">
+                <type>slave_boiler_state</type>
+                <unit/>
+                <updated_date>2024-12-06T18:46:40.020+01:00</updated_date>
+                <last_consecutive_log_date>2024-12-06T18:46:40.020+01:00</last_consecutive_log_date>
+                <interval/>
+                <boiler_state id="a5d3ae6bd1474d4ebf506f405bb94b06"/>
+                <period start_date="2024-12-06T18:46:40.020+01:00" end_date="2024-12-06T18:46:40.020+01:00">
+                    <measurement log_date="2024-12-06T18:46:40.020+01:00">on</measurement>
+                </period>
+            </point_log>
+            <point_log id="3f1313a814ec4614be4e709e659a4f8d">
+                <type>boiler_installed</type>
+                <unit/>
+                <updated_date>2024-12-06T18:46:53.779+01:00</updated_date>
+                <last_consecutive_log_date>2024-12-06T18:46:53.779+01:00</last_consecutive_log_date>
+                <interval/>
+                <dip_switch id="d3abfcd0012e4b47af6d69911031f7ab"/>
+                <period start_date="2024-12-06T18:46:53.779+01:00" end_date="2024-12-06T18:46:53.779+01:00">
+                    <measurement log_date="2024-12-06T18:46:53.779+01:00">on</measurement>
+                </period>
+            </point_log>
+            <point_log id="40e35727c7b947f48099b5221633474c">
+                <type>compressor_state</type>
+                <unit/>
+                <updated_date>2024-12-06T18:46:37.154+01:00</updated_date>
+                <last_consecutive_log_date>2024-12-06T18:46:37.154+01:00</last_consecutive_log_date>
+                <interval/>
+                <boiler_state id="1efb6c04052e4defbe429d6440c285c6"/>
+                <period start_date="2024-12-06T18:46:37.154+01:00" end_date="2024-12-06T18:46:37.154+01:00">
+                    <measurement log_date="2024-12-06T18:46:37.154+01:00">on</measurement>
+                </period>
+            </point_log>
+            <point_log id="48f202225fb94f0b96540d97e65397c7">
+                <type>temperature</type>
+                <unit>C</unit>
+                <updated_date/>
+                <last_consecutive_log_date/>
+                <interval>PT3H</interval>
+                <thermo_meter id="167efda4780e4fa8bbc8f588f4708fa2"/>
+            </point_log>
+            <point_log id="56c09638ead640a5a7b6864a6a1db81b">
+                <type>weather_dependent_regulation</type>
+                <unit/>
+                <updated_date>2024-12-06T18:46:53.760+01:00</updated_date>
+                <last_consecutive_log_date>2024-12-06T18:46:53.760+01:00</last_consecutive_log_date>
+                <interval/>
+                <dip_switch id="60c6512c9b9249199ca4adb48ab30e4e"/>
+                <period start_date="2024-12-06T18:46:53.760+01:00" end_date="2024-12-06T18:46:53.760+01:00">
+                    <measurement log_date="2024-12-06T18:46:53.760+01:00">off</measurement>
+                </period>
+            </point_log>
+            <point_log id="5cd62cb4ac5a4067859f074a9a0eeb66">
+                <type>minimum_heating_supply_temperature</type>
+                <unit>C</unit>
+                <updated_date>2024-12-06T18:21:14.337+01:00</updated_date>
+                <last_consecutive_log_date>2024-12-06T18:21:14.337+01:00</last_consecutive_log_date>
+                <interval/>
+                <thermostat id="9d9f24a42c514c99887d85091ba46d74"/>
+                <period start_date="2024-12-06T18:21:14.337+01:00" end_date="2024-12-06T18:21:14.337+01:00">
+                    <measurement log_date="2024-12-06T18:21:14.337+01:00">40.00</measurement>
+                </period>
+            </point_log>
+            <point_log id="5f0c73d239254abea42bdf1cf02bd7de">
+                <type>intended_central_heating_state</type>
+                <unit/>
+                <updated_date>2024-12-06T09:36:44.386+01:00</updated_date>
+                <last_consecutive_log_date>2024-12-06T09:36:44.386+01:00</last_consecutive_log_date>
+                <interval/>
+                <boiler_state id="72ac57601ea7410381c889a1f58b191c"/>
+                <period start_date="2024-12-06T09:36:44.386+01:00" end_date="2024-12-06T09:36:44.386+01:00">
+                    <measurement log_date="2024-12-06T09:36:44.386+01:00">on</measurement>
+                </period>
+            </point_log>
+            <point_log id="6c6734ca9c52437ebdd012dc1c9237b6">
+                <type>cooling_lower_offset</type>
+                <unit>C</unit>
+                <updated_date>2024-12-06T18:23:02.498+01:00</updated_date>
+                <last_consecutive_log_date>2024-12-06T18:23:02.498+01:00</last_consecutive_log_date>
+                <interval/>
+                <temperature_offset id="c2c422292b904217a49eb2ebb64139fa"/>
+                <period start_date="2024-12-06T18:23:02.498+01:00" end_date="2024-12-06T18:23:02.498+01:00">
+                    <measurement log_date="2024-12-06T18:23:02.498+01:00">1.00</measurement>
+                </period>
+            </point_log>
+            <point_log id="6e461af3d33245ffb49ffeaa2752a340">
+                <type>serial_boiler_installation</type>
+                <unit/>
+                <updated_date>2024-12-06T18:46:53.765+01:00</updated_date>
+                <last_consecutive_log_date>2024-12-06T18:46:53.765+01:00</last_consecutive_log_date>
+                <interval/>
+                <dip_switch id="acc1480a9e1f4b02ad9d94f7cbd8c6d9"/>
+                <period start_date="2024-12-06T18:46:53.765+01:00" end_date="2024-12-06T18:46:53.765+01:00">
+                    <measurement log_date="2024-12-06T18:46:53.765+01:00">on</measurement>
+                </period>
+            </point_log>
+            <point_log id="705e0e0f37574caabd69dd6a9db1620d">
+                <type>minimum_cooling_supply_temperature</type>
+                <unit>C</unit>
+                <updated_date>2024-12-06T18:21:54.600+01:00</updated_date>
+                <last_consecutive_log_date>2024-12-06T18:21:54.600+01:00</last_consecutive_log_date>
+                <interval/>
+                <thermostat id="5304a8c3c39e42b990c9b057e880f8a4"/>
+                <period start_date="2024-12-06T18:21:54.600+01:00" end_date="2024-12-06T18:21:54.600+01:00">
+                    <measurement log_date="2024-12-06T18:21:54.600+01:00">17.00</measurement>
+                </period>
+            </point_log>
+            <point_log id="72e0439587ac443c8880f35543c12834">
+                <type>internal_pump_cooling_lead_time</type>
+                <unit>s</unit>
+                <updated_date>2024-12-06T18:23:55.959+01:00</updated_date>
+                <last_consecutive_log_date>2024-12-06T18:23:55.959+01:00</last_consecutive_log_date>
+                <interval/>
+                <timer id="7ccb6bc94f1948ee9f16ecfb5c80d719"/>
+                <period start_date="2024-12-06T18:23:55.959+01:00" end_date="2024-12-06T18:23:55.959+01:00">
+                    <measurement log_date="2024-12-06T18:23:55.959+01:00">120</measurement>
+                </period>
+            </point_log>
+            <point_log id="78125fc1129b404782f7cf08c1a72401">
+                <type>external_pump_cooling_lead_time</type>
+                <unit>s</unit>
+                <updated_date>2024-12-06T18:22:08.834+01:00</updated_date>
+                <last_consecutive_log_date>2024-12-06T18:22:08.834+01:00</last_consecutive_log_date>
+                <interval/>
+                <timer id="68a4b6945cbb49e0b1629ae6a44da34b"/>
+                <period start_date="2024-12-06T18:22:08.834+01:00" end_date="2024-12-06T18:22:08.834+01:00">
+                    <measurement log_date="2024-12-06T18:22:08.834+01:00">120</measurement>
+                </period>
+            </point_log>
+            <point_log id="7a088fe1ff4d44d5a03be6f1ddb69b1a">
+                <type>external_pump_heating_lead_time</type>
+                <unit>s</unit>
+                <updated_date>2024-12-06T18:24:26.710+01:00</updated_date>
+                <last_consecutive_log_date>2024-12-06T18:24:26.710+01:00</last_consecutive_log_date>
+                <interval/>
+                <timer id="cd3755b4f6454aa482f5603edc7c7019"/>
+                <period start_date="2024-12-06T18:24:26.710+01:00" end_date="2024-12-06T18:24:26.710+01:00">
+                    <measurement log_date="2024-12-06T18:24:26.710+01:00">60</measurement>
+                </period>
+            </point_log>
+            <point_log id="7a90e2fb40a34176a94e408957c5c27c">
+                <type>temperature_sensor_enabled</type>
+                <unit/>
+                <updated_date>2024-12-06T18:46:53.755+01:00</updated_date>
+                <last_consecutive_log_date>2024-12-06T18:46:53.755+01:00</last_consecutive_log_date>
+                <interval/>
+                <dip_switch id="74fab0d973c049e09f3514141f58c0ef"/>
+                <period start_date="2024-12-06T18:46:53.755+01:00" end_date="2024-12-06T18:46:53.755+01:00">
+                    <measurement log_date="2024-12-06T18:46:53.755+01:00">off</measurement>
+                </period>
+            </point_log>
+            <point_log id="7d79610e27234506b0220b7e1a14eb3a">
+                <type>open_therm_oem_fault_code</type>
+                <unit/>
+                <updated_date>2024-10-26T18:06:53.142+02:00</updated_date>
+                <last_consecutive_log_date>2024-10-26T18:06:53.141+02:00</last_consecutive_log_date>
+                <interval/>
+                <fault_code id="6e268f4aa86e4cc0a29c084d00c8319b"/>
+                <period start_date="2024-10-26T18:06:53.142+02:00" end_date="2024-10-26T18:06:53.142+02:00">
+                    <measurement log_date="2024-10-26T18:06:53.142+02:00">0</measurement>
+                </period>
+            </point_log>
+            <point_log id="7e6f7d5dfdd84b5ca8287d0f30944e8b">
+                <type>thermostat_enabled</type>
+                <unit/>
+                <updated_date>2024-12-06T18:46:58.695+01:00</updated_date>
+                <last_consecutive_log_date>2024-12-06T18:46:58.695+01:00</last_consecutive_log_date>
+                <interval/>
+                <dip_switch id="5f729e9aa96c4e33ad866f2efe41e694"/>
+                <period start_date="2024-12-06T18:46:58.695+01:00" end_date="2024-12-06T18:46:58.695+01:00">
+                    <measurement log_date="2024-12-06T18:46:58.695+01:00">off</measurement>
+                </period>
+            </point_log>
+            <point_log id="80737def763544d797ce2ecebbaaf606">
+                <type>input_contacts_installed</type>
+                <unit/>
+                <updated_date>2024-12-06T18:46:53.783+01:00</updated_date>
+                <last_consecutive_log_date>2024-12-06T18:46:53.783+01:00</last_consecutive_log_date>
+                <interval/>
+                <dip_switch id="4d79c04aa75340519aca29545955bf76"/>
+                <period start_date="2024-12-06T18:46:53.783+01:00" end_date="2024-12-06T18:46:53.783+01:00">
+                    <measurement log_date="2024-12-06T18:46:53.783+01:00">on</measurement>
+                </period>
+            </point_log>
+            <point_log id="8bbc4ca809b84a41b6c6115a8ccacecf">
+                <type>night_reduction_setpoint</type>
+                <unit>C</unit>
+                <updated_date>2024-12-06T18:23:54.964+01:00</updated_date>
+                <last_consecutive_log_date>2024-12-06T18:23:54.964+01:00</last_consecutive_log_date>
+                <interval/>
+                <thermostat id="7c4e5837e0474ad3888e97cf21a51670"/>
+                <period start_date="2024-12-06T18:23:54.964+01:00" end_date="2024-12-06T18:23:54.964+01:00">
+                    <measurement log_date="2024-12-06T18:23:54.964+01:00">19.00</measurement>
+                </period>
+            </point_log>
+            <point_log id="9556ad80c44b48459e297eeca0720cc3">
+                <type>boiler_temperature</type>
+                <unit>C</unit>
+                <updated_date>2024-10-26T18:07:07.908+02:00</updated_date>
+                <last_consecutive_log_date>2024-10-26T18:07:07.907+02:00</last_consecutive_log_date>
+                <interval>PT1H</interval>
+                <thermo_meter id="8eafb561fafb42ef8305eae670851e4a"/>
+                <period start_date="2024-10-26T18:07:07.908+02:00" end_date="2024-10-26T18:07:07.908+02:00">
+                    <measurement log_date="2024-10-26T18:07:07.908+02:00">42.59</measurement>
+                </period>
+            </point_log>
+            <point_log id="a45bc7ff672748328d3f83e6a4808ea3">
+                <type>open_therm_slave_oem_fault_code</type>
+                <unit/>
+                <updated_date>2024-12-06T18:46:52.722+01:00</updated_date>
+                <last_consecutive_log_date>2024-12-06T18:46:52.722+01:00</last_consecutive_log_date>
+                <interval/>
+                <fault_code id="3af7b55915d841808e61d89a7663b7a2"/>
+                <period start_date="2024-12-06T18:46:52.722+01:00" end_date="2024-12-06T18:46:52.722+01:00">
+                    <measurement log_date="2024-12-06T18:46:52.722+01:00">0</measurement>
+                </period>
+            </point_log>
+            <point_log id="a6e3ad5afe8e4c6c9feafbd95f221a3a">
+                <type>second_fan_enabled</type>
+                <unit/>
+                <updated_date>2024-12-06T18:46:53.774+01:00</updated_date>
+                <last_consecutive_log_date>2024-12-06T18:46:53.774+01:00</last_consecutive_log_date>
+                <interval/>
+                <dip_switch id="769ba34f091e4fe4a0718ed34defea99"/>
+                <period start_date="2024-12-06T18:46:53.774+01:00" end_date="2024-12-06T18:46:53.774+01:00">
+                    <measurement log_date="2024-12-06T18:46:53.774+01:00">off</measurement>
+                </period>
+            </point_log>
+            <point_log id="acedb4c2dd3d49039768c23832f7b599">
+                <type>refrigerent_out_temperature</type>
+                <unit>C</unit>
+                <updated_date>2024-12-06T18:46:37.609+01:00</updated_date>
+                <last_consecutive_log_date>2024-12-06T18:46:37.609+01:00</last_consecutive_log_date>
+                <interval/>
+                <thermo_meter id="ce44bfc81c5b4f2d82331c48b548aae7"/>
+                <period start_date="2024-12-06T18:46:37.609+01:00" end_date="2024-12-06T18:46:37.609+01:00">
+                    <measurement log_date="2024-12-06T18:46:37.609+01:00">0.00</measurement>
+                </period>
+            </point_log>
+            <point_log id="af12fd7e384c4081b3700f7fc424ac79">
+                <type>domestic_hot_water_setpoint</type>
+                <unit>C</unit>
+                <updated_date>2024-07-29T15:46:38.928+02:00</updated_date>
+                <last_consecutive_log_date>2024-07-29T15:46:38.928+02:00</last_consecutive_log_date>
+                <interval/>
+                <thermo_meter id="59c732e79efc4be6af8a469dba16b40c"/>
+                <period start_date="2024-07-29T15:46:38.928+02:00" end_date="2024-07-29T15:46:38.928+02:00">
+                    <measurement log_date="2024-07-29T15:46:38.928+02:00">60.00</measurement>
+                </period>
+            </point_log>
+            <point_log id="b4629113c7b44a43a3ba634fc054279c">
+                <type>boiler_enabled</type>
+                <unit/>
+                <updated_date>2024-12-06T18:46:58.663+01:00</updated_date>
+                <last_consecutive_log_date>2024-12-06T18:46:58.663+01:00</last_consecutive_log_date>
+                <interval/>
+                <dip_switch id="a8d50bc1b02c4453acbf78c484da2ed0"/>
+                <period start_date="2024-12-06T18:46:58.663+01:00" end_date="2024-12-06T18:46:58.663+01:00">
+                    <measurement log_date="2024-12-06T18:46:58.663+01:00">off</measurement>
+                </period>
+            </point_log>
+            <point_log id="bbfaf21ad4e14ca3be4ba9b508047d6b">
+                <type>cooling_state</type>
+                <unit/>
+                <updated_date>2024-09-08T20:28:38.719+02:00</updated_date>
+                <last_consecutive_log_date>2024-09-08T20:28:38.719+02:00</last_consecutive_log_date>
+                <interval/>
+                <boiler_state id="f613e055261943f4987856badb3fb0ae"/>
+                <period start_date="2024-09-08T20:28:38.719+02:00" end_date="2024-09-08T20:28:38.719+02:00">
+                    <measurement log_date="2024-09-08T20:28:38.719+02:00">off</measurement>
+                </period>
+            </point_log>
+            <point_log id="bf9870695c254ead9edc22f9abe52260">
+                <type>minimum_boiler_off_time</type>
+                <unit>s</unit>
+                <updated_date>2024-12-06T18:19:52.111+01:00</updated_date>
+                <last_consecutive_log_date>2024-12-06T18:19:52.111+01:00</last_consecutive_log_date>
+                <interval/>
+                <timer id="a783fff6c496488cbee3d8b43fd5be7e"/>
+                <period start_date="2024-12-06T18:19:52.111+01:00" end_date="2024-12-06T18:19:52.111+01:00">
+                    <measurement log_date="2024-12-06T18:19:52.111+01:00">20</measurement>
+                </period>
+            </point_log>
+            <point_log id="c0a8e16b4efd465a88ed471330a99046">
+                <type>maximum_outdoor_unit_steady_temperature</type>
+                <unit>C</unit>
+                <updated_date>2024-12-06T18:18:49.260+01:00</updated_date>
+                <last_consecutive_log_date>2024-12-06T18:18:49.260+01:00</last_consecutive_log_date>
+                <interval/>
+                <thermostat id="07c7b619be4242d6919733e6098a5b5e"/>
+                <period start_date="2024-12-06T18:18:49.260+01:00" end_date="2024-12-06T18:18:49.260+01:00">
+                    <measurement log_date="2024-12-06T18:18:49.260+01:00">45.00</measurement>
+                </period>
+            </point_log>
+            <point_log id="c49b3ce126314dca848d51429a0ef2ea">
+                <type>indoor_temperature_transition_time</type>
+                <unit>min</unit>
+                <updated_date>2024-12-06T18:24:24.657+01:00</updated_date>
+                <last_consecutive_log_date>2024-12-06T18:24:24.657+01:00</last_consecutive_log_date>
+                <interval/>
+                <timer id="1b79f533784742c796c973856b30909d"/>
+                <period start_date="2024-12-06T18:24:24.657+01:00" end_date="2024-12-06T18:24:24.657+01:00">
+                    <measurement log_date="2024-12-06T18:24:24.657+01:00">5</measurement>
+                </period>
+            </point_log>
+            <point_log id="c65f2f2e30df4e1cb48bff1afc6bfaf5">
+                <type>simultaneous_boiler_operation</type>
+                <unit/>
+                <updated_date>2024-12-06T18:46:58.672+01:00</updated_date>
+                <last_consecutive_log_date>2024-12-06T18:46:58.672+01:00</last_consecutive_log_date>
+                <interval/>
+                <dip_switch id="8eeb17de38da4b37992c7ef910592306"/>
+                <period start_date="2024-12-06T18:46:58.672+01:00" end_date="2024-12-06T18:46:58.672+01:00">
+                    <measurement log_date="2024-12-06T18:46:58.672+01:00">on</measurement>
+                </period>
+            </point_log>
+            <point_log id="d368799910734cc89ed1e3d5d60363fc">
+                <type>maximum_boiler_temperature</type>
+                <unit>C</unit>
+                <updated_date>2024-07-29T15:46:38.850+02:00</updated_date>
+                <last_consecutive_log_date>2024-07-29T15:46:38.850+02:00</last_consecutive_log_date>
+                <interval/>
+                <thermo_meter id="a80c9f90f72944a8a50e41fac5b72126"/>
+                <period start_date="2024-07-29T15:46:38.850+02:00" end_date="2024-07-29T15:46:38.850+02:00">
+                    <measurement log_date="2024-07-29T15:46:38.850+02:00">60.00</measurement>
+                </period>
+            </point_log>
+            <point_log id="d517c9c0c3254926bd881c61b41f2185">
+                <type>weather_dependent_maximum_supply_temperature</type>
+                <unit>C</unit>
+                <updated_date>2024-12-06T18:17:47.343+01:00</updated_date>
+                <last_consecutive_log_date>2024-12-06T18:17:47.343+01:00</last_consecutive_log_date>
+                <interval/>
+                <thermostat id="3636e8c24b764f9dae52ba36695ed476"/>
+                <period start_date="2024-12-06T18:17:47.343+01:00" end_date="2024-12-06T18:17:47.343+01:00">
+                    <measurement log_date="2024-12-06T18:17:47.343+01:00">60.00</measurement>
+                </period>
+            </point_log>
+            <point_log id="d6e5970949cc4c48a1e20d830e3f9856">
+                <type>central_heating_state</type>
+                <unit/>
+                <updated_date>2024-12-06T18:46:53.131+01:00</updated_date>
+                <last_consecutive_log_date>2024-12-06T18:46:53.131+01:00</last_consecutive_log_date>
+                <interval/>
+                <boiler_state id="93242446d05a443fa31dc19c56fef767"/>
+                <period start_date="2024-12-06T18:46:53.131+01:00" end_date="2024-12-06T18:46:53.131+01:00">
+                    <measurement log_date="2024-12-06T18:46:53.131+01:00">on</measurement>
+                </period>
+            </point_log>
+            <point_log id="d703b335844c4d789b707534cb5dbd3e">
+                <type>pump_lag_time</type>
+                <unit>s</unit>
+                <updated_date>2024-12-06T18:24:11.943+01:00</updated_date>
+                <last_consecutive_log_date>2024-12-06T18:24:11.943+01:00</last_consecutive_log_date>
+                <interval/>
+                <timer id="4ac8d9303b644429b5c5bae03a79470a"/>
+                <period start_date="2024-12-06T18:24:11.943+01:00" end_date="2024-12-06T18:24:11.943+01:00">
+                    <measurement log_date="2024-12-06T18:24:11.943+01:00">30</measurement>
+                </period>
+            </point_log>
+            <point_log id="daac6bf095ce472082653bd4a57c58f9">
+                <type>heatpump_minimum_outdoor_temperature</type>
+                <unit>C</unit>
+                <updated_date>2024-12-06T18:14:54.149+01:00</updated_date>
+                <last_consecutive_log_date>2024-12-06T18:14:54.149+01:00</last_consecutive_log_date>
+                <interval/>
+                <thermostat id="211f6996e8394d12a1f2cdb23b420a2c"/>
+                <period start_date="2024-12-06T18:14:54.149+01:00" end_date="2024-12-06T18:14:54.149+01:00">
+                    <measurement log_date="2024-12-06T18:14:54.149+01:00">1.00</measurement>
+                </period>
+            </point_log>
+            <point_log id="db8123f44611441095c67a6c2ff84ec7">
+                <type>open_therm_application_specific_fault_code</type>
+                <unit/>
+                <updated_date>2024-10-26T18:06:53.142+02:00</updated_date>
+                <last_consecutive_log_date>2024-10-26T18:06:53.141+02:00</last_consecutive_log_date>
+                <interval/>
+                <fault_code id="a649c0c0731b4efe8f971a2174d95901"/>
+                <period start_date="2024-10-26T18:06:53.142+02:00" end_date="2024-10-26T18:06:53.142+02:00">
+                    <measurement log_date="2024-10-26T18:06:53.142+02:00">0</measurement>
+                </period>
+            </point_log>
+            <point_log id="dd64bb930f484e2e8047c5020ef9c185">
+                <type>night_reduction</type>
+                <unit/>
+                <updated_date>2024-12-06T18:46:58.682+01:00</updated_date>
+                <last_consecutive_log_date>2024-12-06T18:46:58.682+01:00</last_consecutive_log_date>
+                <interval/>
+                <dip_switch id="ebf84b976e4e4cb39c5b553e7a9e5fc1"/>
+                <period start_date="2024-12-06T18:46:58.682+01:00" end_date="2024-12-06T18:46:58.682+01:00">
+                    <measurement log_date="2024-12-06T18:46:58.682+01:00">off</measurement>
+                </period>
+            </point_log>
+            <point_log id="e5f051ef9b1542f2bf1b340fb6ba26d2">
+                <type>cooling_upper_offset</type>
+                <unit>C</unit>
+                <updated_date>2024-12-06T18:22:23.582+01:00</updated_date>
+                <last_consecutive_log_date>2024-12-06T18:22:23.582+01:00</last_consecutive_log_date>
+                <interval/>
+                <temperature_offset id="7c77a680bb0645aeb325f196e4a3df57"/>
+                <period start_date="2024-12-06T18:22:23.582+01:00" end_date="2024-12-06T18:22:23.582+01:00">
+                    <measurement log_date="2024-12-06T18:22:23.582+01:00">3.00</measurement>
+                </period>
+            </point_log>
+            <point_log id="e799a764479a4c4586179dd0760fe54e">
+                <type>central_heater_water_pressure</type>
+                <unit>bar</unit>
+                <updated_date>2024-12-06T18:25:34.367+01:00</updated_date>
+                <last_consecutive_log_date>2024-12-06T12:25:29.950+01:00</last_consecutive_log_date>
+                <interval/>
+                <pressure_gauge id="01d551e4bb2b475a9463912a3fd887da"/>
+                <period start_date="2024-12-06T18:25:34.367+01:00" end_date="2024-12-06T18:25:34.367+01:00">
+                    <measurement log_date="2024-12-06T18:25:34.367+01:00">0.50</measurement>
+                </period>
+            </point_log>
+            <point_log id="e7b09f30833c458c9291c7cf761f0068">
+                <type>minimum_boiler_run_time</type>
+                <unit>s</unit>
+                <updated_date>2024-12-06T18:17:34.601+01:00</updated_date>
+                <last_consecutive_log_date>2024-12-06T18:17:34.601+01:00</last_consecutive_log_date>
+                <interval/>
+                <timer id="ecbec078612949e6aa050f2ad9b55958"/>
+                <period start_date="2024-12-06T18:17:34.601+01:00" end_date="2024-12-06T18:17:34.601+01:00">
+                    <measurement log_date="2024-12-06T18:17:34.601+01:00">20</measurement>
+                </period>
+            </point_log>
+            <point_log id="e809f761a4c14287a852a8c727bbdc40">
+                <type>boiler_activation_threshold</type>
+                <unit>Cmin</unit>
+                <updated_date>2024-12-06T18:15:12.173+01:00</updated_date>
+                <last_consecutive_log_date>2024-12-06T18:15:12.173+01:00</last_consecutive_log_date>
+                <interval/>
+                <threshold id="38eadee2fac04aaab6f8fac793560c82"/>
+                <period start_date="2024-12-06T18:15:12.173+01:00" end_date="2024-12-06T18:15:12.173+01:00">
+                    <measurement log_date="2024-12-06T18:15:12.173+01:00">30</measurement>
+                </period>
+            </point_log>
+            <point_log id="e86e337316754960bca3bd5c3efe87c4">
+                <type>heating_curve</type>
+                <unit/>
+                <updated_date>2024-12-06T18:46:58.668+01:00</updated_date>
+                <last_consecutive_log_date>2024-12-06T18:46:58.668+01:00</last_consecutive_log_date>
+                <interval/>
+                <dip_switch id="bc0af70f6ee24c6b9a48542b4e1cb7f0"/>
+                <period start_date="2024-12-06T18:46:58.668+01:00" end_date="2024-12-06T18:46:58.668+01:00">
+                    <measurement log_date="2024-12-06T18:46:58.668+01:00">off</measurement>
+                </period>
+            </point_log>
+            <point_log id="f3eaebe5868840099b2f6eea9763dec3">
+                <type>maximum_heating_supply_temperature</type>
+                <unit>C</unit>
+                <updated_date>2024-12-06T18:21:40.775+01:00</updated_date>
+                <last_consecutive_log_date>2024-12-06T18:21:40.775+01:00</last_consecutive_log_date>
+                <interval/>
+                <thermostat id="4b8a974d347f4cf1872a5bc07f613068"/>
+                <period start_date="2024-12-06T18:21:40.775+01:00" end_date="2024-12-06T18:21:40.775+01:00">
+                    <measurement log_date="2024-12-06T18:21:40.775+01:00">70.00</measurement>
+                </period>
+            </point_log>
+            <point_log id="f9aff78878654f84a8344c0851d7cb33">
+                <type>return_water_temperature</type>
+                <unit>C</unit>
+                <updated_date>2024-10-26T18:07:07.698+02:00</updated_date>
+                <last_consecutive_log_date>2024-10-26T18:07:07.697+02:00</last_consecutive_log_date>
+                <interval>PT1H</interval>
+                <thermo_meter id="a2847eec8a634ccdb70d3c1a79c60df7"/>
+                <period start_date="2024-10-26T18:07:07.698+02:00" end_date="2024-10-26T18:07:07.698+02:00">
+                    <measurement log_date="2024-10-26T18:07:07.698+02:00">35.50</measurement>
+                </period>
+            </point_log>
+            <point_log id="fa0e3334f8d941cbbb040c5bf52fb2df">
+                <type>outdoor_temperature</type>
+                <unit>C</unit>
+                <updated_date>2024-12-06T18:44:03.521+01:00</updated_date>
+                <last_consecutive_log_date>2024-12-06T18:03:55.153+01:00</last_consecutive_log_date>
+                <interval>PT3H</interval>
+                <thermo_meter id="8609fbdcab4b46e387953184f9878c28"/>
+                <period start_date="2024-12-06T18:44:03.521+01:00" end_date="2024-12-06T18:44:03.521+01:00">
+                    <measurement log_date="2024-12-06T18:44:03.521+01:00">6.00</measurement>
+                </period>
+            </point_log>
+        </logs>
+        <actuator_functionalities>
+            <timer_functionality id="00a41642a7764d1d80fe37b0cd493730">
+                <timer id="a783fff6c496488cbee3d8b43fd5be7e"/>
+                <updated_date>2024-12-06T18:19:52.112+01:00</updated_date>
+                <type>minimum_boiler_off_time</type>
+                <duration>20</duration>
+                <lower_bound>0</lower_bound>
+                <upper_bound>60</upper_bound>
+                <resolution>5</resolution>
+            </timer_functionality>
+            <timer_functionality id="0646e6e1204147668157d2a7c59ef3ee">
+                <timer id="881f3c1377bc4efda8c78409a18ebe55"/>
+                <updated_date>2024-12-06T18:24:41.057+01:00</updated_date>
+                <type>internal_pump_heating_lead_time</type>
+                <duration>60</duration>
+                <lower_bound>10</lower_bound>
+                <upper_bound>240</upper_bound>
+                <resolution>10</resolution>
+            </timer_functionality>
+            <thermostat_functionality id="07699ce0bdd6491db490f0e15642ca43">
+                <updated_date>2024-12-06T18:23:54.965+01:00</updated_date>
+                <type>night_reduction_setpoint</type>
+                <lower_bound>1</lower_bound>
+                <upper_bound>30</upper_bound>
+                <resolution>1</resolution>
+                <setpoint>19</setpoint>
+                <regulations/>
+                <thermostat id="7c4e5837e0474ad3888e97cf21a51670"/>
+            </thermostat_functionality>
+            <offset_functionality id="08ca8e47df01477ebfc92442fc327ba8">
+                <temperature_offset id="c2c422292b904217a49eb2ebb64139fa"/>
+                <updated_date>2024-12-06T18:23:02.499+01:00</updated_date>
+                <type>cooling_lower_offset</type>
+                <offset>1</offset>
+            </offset_functionality>
+            <timer_functionality id="4538146f706d42098e9e233b0ef4d1bd">
+                <timer id="cd3755b4f6454aa482f5603edc7c7019"/>
+                <updated_date>2024-12-06T18:24:26.711+01:00</updated_date>
+                <type>external_pump_heating_lead_time</type>
+                <duration>60</duration>
+                <lower_bound>10</lower_bound>
+                <upper_bound>240</upper_bound>
+                <resolution>10</resolution>
+            </timer_functionality>
+            <timer_functionality id="4823c26f51bc4b07928acbb5ef056ca1">
+                <timer id="397304cc8cbe47798f41930b1d62b009"/>
+                <updated_date>2024-12-06T18:16:58.925+01:00</updated_date>
+                <type>hibernation_lead_time</type>
+                <duration>10</duration>
+                <lower_bound>1</lower_bound>
+                <upper_bound>24</upper_bound>
+                <resolution>1</resolution>
+            </timer_functionality>
+            <timer_functionality id="4d846b97eca946d78e6f3c0ae70f9db4">
+                <timer id="ecbec078612949e6aa050f2ad9b55958"/>
+                <updated_date>2024-12-06T18:17:34.602+01:00</updated_date>
+                <type>minimum_boiler_run_time</type>
+                <duration>20</duration>
+                <lower_bound>0</lower_bound>
+                <upper_bound>60</upper_bound>
+                <resolution>5</resolution>
+            </timer_functionality>
+            <timer_functionality id="4e627a99dcf94bc086b31aa3a6de44b2">
+                <timer id="1b79f533784742c796c973856b30909d"/>
+                <updated_date>2024-12-06T18:24:24.658+01:00</updated_date>
+                <type>indoor_temperature_transition_time</type>
+                <duration>5</duration>
+                <lower_bound>0</lower_bound>
+                <upper_bound>30</upper_bound>
+                <resolution>1</resolution>
+            </timer_functionality>
+            <threshold_functionality id="57fb489e615a46888a051712ca8954f2">
+                <threshold id="38eadee2fac04aaab6f8fac793560c82"/>
+                <updated_date>2024-12-06T18:15:12.174+01:00</updated_date>
+                <type>boiler_activation_threshold</type>
+                <threshold>30</threshold>
+                <lower_bound>10</lower_bound>
+                <upper_bound>120</upper_bound>
+                <resolution>10</resolution>
+            </threshold_functionality>
+            <thermostat_functionality id="5b6c3a3cf0de4adc92e4aac0d93e1962">
+                <updated_date>2024-12-06T18:21:14.338+01:00</updated_date>
+                <type>minimum_heating_supply_temperature</type>
+                <lower_bound>20</lower_bound>
+                <upper_bound>90</upper_bound>
+                <resolution>5</resolution>
+                <setpoint>40</setpoint>
+                <regulations/>
+                <thermostat id="9d9f24a42c514c99887d85091ba46d74"/>
+            </thermostat_functionality>
+            <timer_functionality id="631c67b8e2f2411d83ffa5a687f3b79b">
+                <timer id="4ac8d9303b644429b5c5bae03a79470a"/>
+                <updated_date>2024-12-06T18:24:11.944+01:00</updated_date>
+                <type>pump_lag_time</type>
+                <duration>30</duration>
+                <lower_bound>10</lower_bound>
+                <upper_bound>240</upper_bound>
+                <resolution>10</resolution>
+            </timer_functionality>
+            <thermostat_functionality id="6385d825e10545bfabc3cd3574920b68">
+                <updated_date>2024-12-06T18:22:36.520+01:00</updated_date>
+                <type>maximum_cooling_supply_temperature</type>
+                <lower_bound>5</lower_bound>
+                <upper_bound>25</upper_bound>
+                <resolution>1</resolution>
+                <setpoint>21</setpoint>
+                <regulations/>
+                <thermostat id="82b1c7dcc6674568af1dbace5e64af8b"/>
+            </thermostat_functionality>
+            <offset_functionality id="69ed60c3bc3846449e61dba62e71da40">
+                <temperature_offset id="7c77a680bb0645aeb325f196e4a3df57"/>
+                <updated_date>2024-12-06T18:22:23.583+01:00</updated_date>
+                <type>cooling_upper_offset</type>
+                <offset>3</offset>
+            </offset_functionality>
+            <toggle_functionality id="700bd52a8729461bb0fdf6d055c08710">
+                <domestic_hot_water_toggle id="29fb663d576a46c79d629826edff95f0"/>
+                <updated_date>2024-07-29T15:46:39.089+02:00</updated_date>
+                <type>domestic_hot_water_comfort_mode</type>
+                <state>off</state>
+            </toggle_functionality>
+            <timer_functionality id="8dcd68a78d704da8b0a61083d376223f">
+                <timer id="68a4b6945cbb49e0b1629ae6a44da34b"/>
+                <updated_date>2024-12-06T18:22:08.835+01:00</updated_date>
+                <type>external_pump_cooling_lead_time</type>
+                <duration>120</duration>
+                <lower_bound>120</lower_bound>
+                <upper_bound>240</upper_bound>
+                <resolution>10</resolution>
+            </timer_functionality>
+            <thermostat_functionality id="965f1d814e594fb191268c47ff527022">
+                <updated_date>2024-12-06T18:24:43.359+01:00</updated_date>
+                <type>boiler_minimum_outdoor_temperature</type>
+                <lower_bound>-10</lower_bound>
+                <upper_bound>40</upper_bound>
+                <resolution>1</resolution>
+                <setpoint>14</setpoint>
+                <regulations/>
+                <thermostat id="bfe6665d0f05467b977b077b7b787cf1"/>
+            </thermostat_functionality>
+            <thermostat_functionality id="9cee766c36c843288b9bc17628e2a5a7">
+                <updated_date>2024-12-06T18:18:49.261+01:00</updated_date>
+                <type>maximum_outdoor_unit_steady_temperature</type>
+                <lower_bound>25</lower_bound>
+                <upper_bound>45</upper_bound>
+                <resolution>1</resolution>
+                <setpoint>45</setpoint>
+                <regulations/>
+                <thermostat id="07c7b619be4242d6919733e6098a5b5e"/>
+            </thermostat_functionality>
+            <thermostat_functionality id="9cfae18be05b4509b32d52571107f0ff">
+                <updated_date>2024-12-06T18:17:47.344+01:00</updated_date>
+                <type>weather_dependent_maximum_supply_temperature</type>
+                <lower_bound>30</lower_bound>
+                <upper_bound>90</upper_bound>
+                <resolution>10</resolution>
+                <setpoint>60</setpoint>
+                <regulations/>
+                <thermostat id="3636e8c24b764f9dae52ba36695ed476"/>
+            </thermostat_functionality>
+            <thermostat_functionality id="a1f29fd4edae4894a74c0b8c523f8ef3">
+                <updated_date>2024-12-06T18:21:54.601+01:00</updated_date>
+                <type>minimum_cooling_supply_temperature</type>
+                <lower_bound>5</lower_bound>
+                <upper_bound>25</upper_bound>
+                <resolution>1</resolution>
+                <setpoint>17</setpoint>
+                <regulations/>
+                <thermostat id="5304a8c3c39e42b990c9b057e880f8a4"/>
+            </thermostat_functionality>
+            <thermostat_functionality id="a67b1c7b6d2f403aba383a56ad3d8e0a">
+                <updated_date>2024-12-06T18:17:54.727+01:00</updated_date>
+                <type>maximum_outdoor_unit_temperature</type>
+                <lower_bound>25</lower_bound>
+                <upper_bound>47</upper_bound>
+                <resolution>1</resolution>
+                <setpoint>47</setpoint>
+                <regulations/>
+                <thermostat id="333ef91f62d94f78ad7b9bedaecc71f2"/>
+            </thermostat_functionality>
+            <thermostat_functionality id="b6579ded90e7489ca51a48768c721eb0">
+                <updated_date>2024-12-06T18:21:40.776+01:00</updated_date>
+                <type>maximum_heating_supply_temperature</type>
+                <lower_bound>20</lower_bound>
+                <upper_bound>90</upper_bound>
+                <resolution>5</resolution>
+                <setpoint>70</setpoint>
+                <regulations/>
+                <thermostat id="4b8a974d347f4cf1872a5bc07f613068"/>
+            </thermostat_functionality>
+            <thermostat_functionality id="c9b707c378b04420a55bdffe00e4f8f6">
+                <updated_date>2024-12-06T18:14:54.150+01:00</updated_date>
+                <type>heatpump_minimum_outdoor_temperature</type>
+                <lower_bound>-16</lower_bound>
+                <upper_bound>4</upper_bound>
+                <resolution>1</resolution>
+                <setpoint>1</setpoint>
+                <regulations/>
+                <thermostat id="211f6996e8394d12a1f2cdb23b420a2c"/>
+            </thermostat_functionality>
+            <timer_functionality id="d24d209910e34533a95e361c8c66352c">
+                <timer id="7ccb6bc94f1948ee9f16ecfb5c80d719"/>
+                <updated_date>2024-12-06T18:23:55.960+01:00</updated_date>
+                <type>internal_pump_cooling_lead_time</type>
+                <duration>120</duration>
+                <lower_bound>120</lower_bound>
+                <upper_bound>240</upper_bound>
+                <resolution>10</resolution>
+            </timer_functionality>
+            <toggle_functionality id="d93b629453934687bb3374ebeea82c0a">
+                <cooling_toggle id="8a13768d922b439a9535b50a4c35d5c8"/>
+                <updated_date>2024-07-29T15:45:52.224+02:00</updated_date>
+                <type>cooling_enabled</type>
+                <state>on</state>
+            </toggle_functionality>
+            <thermostat_functionality id="f8b9ad4b594846628e305fdf7ff26b3e">
+                <updated_date>2024-12-06T18:20:13.453+01:00</updated_date>
+                <type>maximum_outdoor_unit_power_increase_temperature</type>
+                <lower_bound>25</lower_bound>
+                <upper_bound>43</upper_bound>
+                <resolution>1</resolution>
+                <setpoint>43</setpoint>
+                <regulations/>
+                <thermostat id="564f724946434905b7d2b6c142e4ba67"/>
+            </thermostat_functionality>
+        </actuator_functionalities>
+    </appliance>
+    <template id="7d09a1b96cc14c109b8abeb2c1c5a66e" tag="electricity_triggered_actions">
+        <name>Electricity action trigger template</name>
+        <description>Template for triggering actions based on time and electricity production or consumption.</description>
+        <single_actor>true</single_actor>
+        <created_date>2022-09-07T00:50:52.536+02:00</created_date>
+        <modified_date>2024-07-29T15:46:14.568+02:00</modified_date>
+        <deleted_date/>
+        <objects>
+            <object name="meter" type="DirectObject"/>
+            <object name="direct_object" type="DirectObject"/>
+        </objects>
+        <parameters>
+            <parameter name="averaged_electricity_produced" source="meter.averaged_electricity_produced" type="Number"/>
+            <parameter name="time" source="clock.weekTime" type="WeekTime"/>
+            <parameter name="averaged_electricity_consumed" source="meter.averaged_electricity_consumed" type="Number"/>
+            <parameter name="electricity_produced" source="meter.electricity_produced" type="Number"/>
+            <parameter name="electricity_consumed" source="meter.electricity_consumed" type="Number"/>
+        </parameters>
+        <results>
+            <result name="state" type="OnOff" action="direct_object.iterateFunctionalities('RelayFunctionality')().switch(clock.addSeconds(null, 1), state)"/>
+            <result name="setpoint" type="Number" action="direct_object.iterateFunctionalities('ThermostatFunctionality', 'thermostat')().setSetpoint(clock.addSeconds(null, 1), setpoint, setpoint)"/>
+            <result name="domestic_hot_water_mode" type="DomesticHotWaterMode" action="direct_object.iterateFunctionalities('DomesticHotWaterModeControlFunctionality', 'domestic_hot_water_mode')().setMode(clock.addSeconds(null, 1), domestic_hot_water_mode)"/>
+            <result name="preset" type="Preset" action="direct_object.preset = preset"/>
+            <result name="domestic_hot_water_comfort_mode" type="OnOff" action="direct_object.iterateFunctionalities('ToggleFunctionality', 'domestic_hot_water_comfort_mode')().setState(clock.addSeconds(null, 1), domestic_hot_water_comfort_mode)"/>
+            <result name="domestic_hot_water_setpoint" type="Number" action="direct_object.iterateFunctionalities('ThermostatFunctionality', 'domestic_hot_water_setpoint')().setSetpoint(clock.addSeconds(null, 1), domestic_hot_water_setpoint)"/>
+        </results>
+    </template>
+    <template id="69699f9e8e584a12b5a803e724547ad2" tag="zone_preset_based_on_time_and_presence_with_override">
+        <name>Zone preset schedule template</name>
+        <description>Template for scheduling presets on a presence or time basis with the option to override the preset's setpoint/state.</description>
+        <single_actor>true</single_actor>
+        <created_date>2017-10-25T14:55:02.566+02:00</created_date>
+        <modified_date>2024-07-29T15:46:14.541+02:00</modified_date>
+        <deleted_date/>
+        <objects>
+            <object name="zone" type="Location"/>
+        </objects>
+        <parameters>
+            <parameter name="presence" source="zone.presence" type="Boolean"/>
+            <parameter name="time" source="clock.weekTime" type="WeekTime"/>
+        </parameters>
+        <results>
+            <result name="state" type="OnOff" action="zone.iterateFunctionalities('RelayFunctionality')().switch(clock.addSeconds(null, 1), state)"/>
+            <result name="setpoint" type="Number" action="zone.iterateFunctionalities('ThermostatFunctionality', 'thermostat')().setSetpoint(clock.addSeconds(null, 1), setpoint, setpoint)"/>
+            <result name="preset" type="Preset" action="zone.preset = preset"/>
+            <result name="domestic_hot_water_state" type="OnOff" action="zone.iterateFunctionalities('ToggleFunctionality', 'domestic_hot_water_state')().switch(clock.addSeconds(null, 1), domestic_hot_water_state)"/>
+        </results>
+    </template>
+    <gateway id="f65e90f31ac3496a9419f4b933e64c15">
+        <created_date>2017-10-25T14:55:02.060+02:00</created_date>
+        <modified_date>2024-12-06T16:25:28.771+01:00</modified_date>
+        <deleted_date/>
+        <name/>
+        <description/>
+        <enabled>true</enabled>
+        <firmware_locked>false</firmware_locked>
+        <prevent_default_update>false</prevent_default_update>
+        <last_reset_date>2017-08-29T08:24:38.164+02:00</last_reset_date>
+        <last_boot_date>2024-07-29T15:43:41.707+02:00</last_boot_date>
+        <vendor_name>Plugwise</vendor_name>
+        <vendor_model>smile_thermo</vendor_model>
+        <hardware_version>AME Smile 2.0 board</hardware_version>
+        <firmware_version>4.4.1</firmware_version>
+        <mac_address>C4930002FE76</mac_address>
+        <wifi_mac_address>C4930002FE77</wifi_mac_address>
+        <short_id>abcdefgh</short_id>
+        <send_data>true</send_data>
+        <anonymous>true</anonymous>
+        <lan_ip/>
+        <wifi_ip>127.0.0.2</wifi_ip>
+        <hostname>smile000000</hostname>
+        <time>2024-12-06T18:47:03+01:00</time>
+        <timezone>Europe/Amsterdam</timezone>
+        <ssh_relay>disabled</ssh_relay>
+        <project id="68e91423192a4093b6aaf3af0babe94f">
+            <description>Gateways voor Techneco</description>
+            <is_default>false</is_default>
+            <visible_in_production>false</visible_in_production>
+            <name>Techneco</name>
+            <created_date>2017-10-02T13:20:08+02:00</created_date>
+            <deleted_date/>
+            <modified_date>2018-07-12T11:13:23.436+02:00</modified_date>
+        </project>
+        <gateway_environment id="3034b99b7ec7493099e54d6d2849a86d">
+            <savings_result_value/>
+            <central_heating_brand/>
+            <central_heating_model/>
+            <central_heating_year_of_manufacture/>
+            <country>NL</country>
+            <thermostat_brand/>
+            <city>Sassenheim</city>
+            <modified_date>2022-03-09T21:47:09.009+01:00</modified_date>
+            <electricity_consumption_tariff_structure/>
+            <electricity_production_tariff_structure/>
+            <gas_consumption_tariff/>
+            <electricity_consumption_single_tariff/>
+            <electricity_consumption_peak_tariff/>
+            <electricity_consumption_off_peak_tariff/>
+            <electricity_production_single_tariff/>
+            <electricity_production_peak_tariff/>
+            <electricity_production_off_peak_tariff/>
+            <currency>EUR</currency>
+            <tariff_region>NL</tariff_region>
+            <postal_code>2171</postal_code>
+            <thermostat_model/>
+            <longitude>4.49</longitude>
+            <central_heating_installation_date/>
+            <housing_construction_period>after_1990</housing_construction_period>
+            <household_children>2</household_children>
+            <housing_type>detached</housing_type>
+            <latitude>52.21</latitude>
+            <household_adults>3</household_adults>
+            <savings_result_unit/>
+            <created_date>2024-12-05T05:41:22+01:00</created_date>
+            <deleted_date/>
+            <modified_date>2022-03-09T21:47:09.009+01:00</modified_date>
+        </gateway_environment>
+        <features>
+            <elga_support id="2a37ce7426b144688f2d09614ba20c36">
+                <grace_period/>
+                <valid_from/>
+                <valid_to/>
+                <expiration_date>2038-01-19T04:14:07+01:00</expiration_date>
+                <validity_period/>
+                <activation_date/>
+                <created_date>2017-10-31T15:37:07+01:00</created_date>
+                <deleted_date/>
+                <modified_date>2018-07-12T11:13:23.659+02:00</modified_date>
+            </elga_support>
+            <remote_control id="70b914220d974189ad03327c3ef023d6">
+                <grace_period/>
+                <valid_from/>
+                <valid_to/>
+                <expiration_date>2038-01-19T04:14:07+01:00</expiration_date>
+                <validity_period/>
+                <activation_date/>
+                <created_date>2017-10-31T15:37:07+01:00</created_date>
+                <deleted_date/>
+                <modified_date>2018-07-12T11:13:23.496+02:00</modified_date>
+            </remote_control>
+            <elga_support id="f23b22573edf4e928e0bf2f236c43aa6">
+                <grace_period/>
+                <valid_from/>
+                <valid_to/>
+                <expiration_date>2038-01-19T04:14:07+01:00</expiration_date>
+                <validity_period/>
+                <activation_date/>
+                <created_date>2017-10-31T15:38:09+01:00</created_date>
+                <deleted_date/>
+                <modified_date>2018-07-12T11:13:23.723+02:00</modified_date>
+            </elga_support>
+            <remote_control id="fcedcf651875495d8e7c89d75cc2c345">
+                <grace_period/>
+                <valid_from/>
+                <valid_to/>
+                <expiration_date>2038-01-19T04:14:07+01:00</expiration_date>
+                <validity_period/>
+                <activation_date/>
+                <created_date>2017-10-31T15:38:09+01:00</created_date>
+                <deleted_date/>
+                <modified_date>2018-07-12T11:13:23.554+02:00</modified_date>
+            </remote_control>
+        </features>
+    </gateway>
+    <location id="d34dfe6ab90b410c98068e75de3eb631">
+        <name>Home</name>
+        <description/>
+        <type>building</type>
+        <created_date>2017-10-25T14:55:03.100+02:00</created_date>
+        <modified_date>2024-12-06T18:35:21.882+01:00</modified_date>
+        <deleted_date/>
+        <preset>home</preset>
+        <clients/>
+        <appliances/>
+        <logs>
+            <point_log id="19080fb9d9a94bd88a319419d285a56d">
+                <type>weather_description</type>
+                <unit/>
+                <updated_date>2024-12-06T18:35:21+01:00</updated_date>
+                <last_consecutive_log_date>2024-12-06T18:35:21+01:00</last_consecutive_log_date>
+                <interval/>
+                <weather_descriptor id="acdffd53f1984f96b571bb4d6b7c6095"/>
+                <period start_date="2024-12-06T18:35:21+01:00" end_date="2024-12-06T18:35:21+01:00">
+                    <measurement log_date="2024-12-06T18:35:21+01:00">overcast</measurement>
+                </period>
+            </point_log>
+            <point_log id="67f6e7e97f6b47368f61460226ead4cb">
+                <type>humidity</type>
+                <unit>RH</unit>
+                <updated_date>2024-12-06T18:35:21+01:00</updated_date>
+                <last_consecutive_log_date>2024-12-06T18:35:21+01:00</last_consecutive_log_date>
+                <interval>PT3H</interval>
+                <hygro_meter id="ec0d5294e3bf4e5e96054901fe25835a"/>
+                <period start_date="2024-12-06T18:35:21+01:00" end_date="2024-12-06T18:35:21+01:00">
+                    <measurement log_date="2024-12-06T18:35:21+01:00">81.00</measurement>
+                </period>
+            </point_log>
+            <point_log id="837b147f4ce547388f76f7404cf1b6cc">
+                <type>outdoor_temperature</type>
+                <unit>C</unit>
+                <updated_date>2024-12-06T18:35:21+01:00</updated_date>
+                <last_consecutive_log_date>2024-12-06T18:35:21+01:00</last_consecutive_log_date>
+                <interval>PT3H</interval>
+                <thermo_meter id="5702932dadad4591b77f8f30971ea0bf"/>
+                <period start_date="2024-12-06T18:35:21+01:00" end_date="2024-12-06T18:35:21+01:00">
+                    <measurement log_date="2024-12-06T18:35:21+01:00">6.38</measurement>
+                </period>
+            </point_log>
+            <point_log id="a17661da905149eca734ba8b047fe177">
+                <type>wind_vector</type>
+                <unit>m_s</unit>
+                <updated_date>2024-12-06T18:35:21+01:00</updated_date>
+                <last_consecutive_log_date>2024-12-06T18:35:21+01:00</last_consecutive_log_date>
+                <interval/>
+                <wind_vector id="b790ed1f2a0a4b629d13e0cd02f88821"/>
+                <period start_date="2024-12-06T18:35:21+01:00" end_date="2024-12-06T18:35:21+01:00">
+                    <measurement log_date="2024-12-06T18:35:21+01:00">(3.09,240.00)</measurement>
+                </period>
+            </point_log>
+            <point_log id="e8d96f806c9746e9a47a3bc809e2438c">
+                <type>solar_irradiance</type>
+                <unit>W_m2</unit>
+                <updated_date>2024-12-06T18:35:21+01:00</updated_date>
+                <last_consecutive_log_date>2024-12-06T18:35:21+01:00</last_consecutive_log_date>
+                <interval/>
+                <irradiance_meter id="3860fb2704834c3ba2bf9eb1840c7ca7"/>
+                <period start_date="2024-12-06T18:35:21+01:00" end_date="2024-12-06T18:35:21+01:00">
+                    <measurement log_date="2024-12-06T18:35:21+01:00">0.00</measurement>
+                </period>
+            </point_log>
+        </logs>
+        <actuator_functionalities/>
+    </location>
+    <rule id="40e484ccfd644f1fa8b82f669091144a">
+        <name>Thermostat schedule</name>
+        <description>Provides a week schedule for a Location.</description>
+        <template id="69699f9e8e584a12b5a803e724547ad2" tag="zone_preset_based_on_time_and_presence_with_override"/>
+        <active>true</active>
+        <created_date>2019-07-22T11:03:39.072+02:00</created_date>
+        <modified_date>2024-10-07T23:00:09.274+02:00</modified_date>
+        <deleted_date/>
+        <directives>
+            <when time="[tu 23:00,we 10:00)">
+                <then preset="asleep"/>
+            </when>
+            <when time="[fr 23:00,sa 10:00)">
+                <then preset="asleep"/>
+            </when>
+            <when time="[sa 10:00,sa 23:00)">
+                <then preset="home"/>
+            </when>
+            <when time="[sa 23:00,su 10:00)">
+                <then preset="asleep"/>
+            </when>
+            <when time="[su 10:00,su 22:45)">
+                <then preset="home"/>
+            </when>
+            <when time="[th 23:00,fr 10:00)">
+                <then preset="asleep"/>
+            </when>
+            <when time="[mo 23:00,tu 10:00)">
+                <then preset="asleep"/>
+            </when>
+            <when time="[we 23:00,th 08:00)">
+                <then preset="asleep"/>
+            </when>
+            <when time="[su 22:45,mo 08:00)">
+                <then preset="asleep"/>
+            </when>
+            <when time="[mo 08:00,mo 15:00)">
+                <then preset="home"/>
+            </when>
+            <when time="[mo 15:00,mo 23:00)">
+                <then setpoint="19"/>
+            </when>
+            <when time="[tu 10:00,tu 15:00)">
+                <then preset="home"/>
+            </when>
+            <when time="[tu 15:00,tu 23:00)">
+                <then setpoint="19"/>
+            </when>
+            <when time="[we 10:00,we 15:00)">
+                <then preset="home"/>
+            </when>
+            <when time="[we 15:00,we 23:00)">
+                <then setpoint="19"/>
+            </when>
+            <when time="[th 08:00,th 15:00)">
+                <then preset="home"/>
+            </when>
+            <when time="[th 15:00,th 23:00)">
+                <then setpoint="19"/>
+            </when>
+            <when time="[fr 10:00,fr 15:00)">
+                <then preset="home"/>
+            </when>
+            <when time="[fr 15:00,fr 23:00)">
+                <then setpoint="19"/>
+            </when>
+        </directives>
+        <contexts>
+            <context>
+                <zone>
+                    <location id="d3ce834534114348be628b61b26d9220"/>
+                </zone>
+            </context>
+        </contexts>
+    </rule>
+    <template id="999adea416e84b9c96d9d198ed2005f8" tag="relay_state_based_on_time">
+        <name>Relay schedule template</name>
+        <description>Template for scheduling relays on a time basis.</description>
+        <single_actor>true</single_actor>
+        <created_date>2017-10-25T14:55:02.487+02:00</created_date>
+        <modified_date>2024-07-29T15:46:14.519+02:00</modified_date>
+        <deleted_date/>
+        <objects>
+            <object name="direct_object" type="DirectObject"/>
+        </objects>
+        <parameters>
+            <parameter name="time" source="clock.weekTime" type="WeekTime"/>
+        </parameters>
+        <results>
+            <result name="state" type="OnOff" action="direct_object.iterateFunctionalities('RelayFunctionality')().state = state"/>
+        </results>
+    </template>
+    <rule id="dbc823ce5fa54eee85a8a822507a1de4">
+        <name>Thermostat presets</name>
+        <description>Provides presets for a Location.</description>
+        <template id="c9a9744aad4646f5a1b02ed9d72191a3" tag="zone_setpoint_and_state_based_on_preset"/>
+        <active>true</active>
+        <created_date>2019-07-22T11:03:39.299+02:00</created_date>
+        <modified_date>2023-12-09T16:38:47.239+01:00</modified_date>
+        <deleted_date/>
+        <directives>
+            <when preset="away">
+                <then heating_setpoint="15" cooling_setpoint="25"/>
+            </when>
+            <when preset="no_frost">
+                <then heating_setpoint="10" cooling_setpoint="30"/>
+            </when>
+            <when preset="vacation">
+                <then heating_setpoint="15" cooling_setpoint="27"/>
+            </when>
+            <when preset="home">
+                <then heating_setpoint="18.5" cooling_setpoint="23"/>
+            </when>
+            <when preset="asleep">
+                <then heating_setpoint="18" cooling_setpoint="23"/>
+            </when>
+        </directives>
+        <contexts>
+            <context>
+                <zone>
+                    <location id="d3ce834534114348be628b61b26d9220"/>
+                </zone>
+            </context>
+        </contexts>
+    </rule>
+    <appliance id="ebd90df1ab334565b5895f37590ccff4">
+        <name>Anna</name>
+        <description>A thermostat</description>
+        <type>thermostat</type>
+        <created_date>2019-07-22T11:03:36.852+02:00</created_date>
+        <modified_date>2024-12-06T18:46:48.929+01:00</modified_date>
+        <deleted_date/>
+        <location id="d3ce834534114348be628b61b26d9220"/>
+        <groups/>
+        <logs>
+            <point_log id="01a06384c7d449bba2725e8edf714584">
+                <type>temperature_offset</type>
+                <unit>C</unit>
+                <updated_date>2024-07-29T15:46:39.119+02:00</updated_date>
+                <last_consecutive_log_date>2024-07-29T15:46:39.119+02:00</last_consecutive_log_date>
+                <interval/>
+                <temperature_offset id="a7b6d9b100ac460eaa9316b20a4ac407"/>
+                <period start_date="2024-07-29T15:46:39.119+02:00" end_date="2024-07-29T15:46:39.119+02:00">
+                    <measurement log_date="2024-07-29T15:46:39.119+02:00">0.00</measurement>
+                </period>
+            </point_log>
+            <point_log id="05cfa5d4403b42ddb2f0258dc76d6754">
+                <type>open_therm_boiler_activation_threshold</type>
+                <unit>C</unit>
+                <updated_date>2024-07-29T15:46:39.132+02:00</updated_date>
+                <last_consecutive_log_date>2024-07-29T15:46:39.132+02:00</last_consecutive_log_date>
+                <interval/>
+                <temperature_offset_meter id="b107e4d0690c40e38f9519de498f80d0"/>
+                <period start_date="2024-07-29T15:46:39.132+02:00" end_date="2024-07-29T15:46:39.132+02:00">
+                    <measurement log_date="2024-07-29T15:46:39.132+02:00">0.00</measurement>
+                </period>
+            </point_log>
+            <point_log id="19a51cc2909a42308846d07095089c48">
+                <type>decentral_heat_demand_offset</type>
+                <unit>C</unit>
+                <updated_date>2024-12-06T18:46:48.924+01:00</updated_date>
+                <last_consecutive_log_date>2024-12-06T18:46:48.924+01:00</last_consecutive_log_date>
+                <interval/>
+                <temperature_offset_meter id="1b662f928c4f4a739b521214d8539c47"/>
+                <period start_date="2024-12-06T18:46:48.924+01:00" end_date="2024-12-06T18:46:48.924+01:00">
+                    <measurement log_date="2024-12-06T18:46:48.924+01:00">0.00</measurement>
+                </period>
+            </point_log>
+            <point_log id="23544f8616644a87a971bb584cd2c926">
+                <type>proximity_detection</type>
+                <unit/>
+                <updated_date>2024-09-08T11:00:05.526+02:00</updated_date>
+                <last_consecutive_log_date>2024-09-08T11:00:05.526+02:00</last_consecutive_log_date>
+                <interval/>
+                <proximity_sensor id="ef39b2e2aacb40f08568a6fc638c242a"/>
+                <period start_date="2024-09-08T11:00:05.526+02:00" end_date="2024-09-08T11:00:05.526+02:00">
+                    <measurement log_date="2024-09-08T11:00:05.526+02:00">proximity_detected</measurement>
+                </period>
+            </point_log>
+            <point_log id="5337865ab7f743388dca27d127deecb0">
+                <type>cooling_deactivation_threshold</type>
+                <unit>C</unit>
+                <updated_date>2024-08-02T23:04:22.575+02:00</updated_date>
+                <last_consecutive_log_date>2024-08-02T23:04:22.575+02:00</last_consecutive_log_date>
+                <interval/>
+                <threshold id="06c97b7ed1504d498e09d1aa33240317"/>
+                <period start_date="2024-08-02T23:04:22.575+02:00" end_date="2024-08-02T23:04:22.575+02:00">
+                    <measurement log_date="2024-08-02T23:04:22.575+02:00">2</measurement>
+                </period>
+            </point_log>
+            <point_log id="5c206e6a6fff4962b3e06d965c9caf4d">
+                <type>derivative_coefficient</type>
+                <unit>s</unit>
+                <updated_date>2024-07-29T15:46:39.110+02:00</updated_date>
+                <last_consecutive_log_date>2024-07-29T15:46:39.110+02:00</last_consecutive_log_date>
+                <interval/>
+                <coefficient id="9c5191459bfa42e2bc92a951886ca6c0"/>
+                <period start_date="2024-07-29T15:46:39.110+02:00" end_date="2024-07-29T15:46:39.110+02:00">
+                    <measurement log_date="2024-07-29T15:46:39.110+02:00">0</measurement>
+                </period>
+            </point_log>
+            <point_log id="6b8756139eb34bab9692edb22d0bcd50">
+                <type>button_left</type>
+                <unit/>
+                <updated_date>2024-09-17T00:50:15.337+02:00</updated_date>
+                <last_consecutive_log_date>2024-09-17T00:50:15.337+02:00</last_consecutive_log_date>
+                <interval/>
+                <button id="d349d6b8767c491991390ea199337223"/>
+                <period start_date="2024-09-17T00:50:15.337+02:00" end_date="2024-09-17T00:50:15.337+02:00">
+                    <measurement log_date="2024-09-17T00:50:15.337+02:00">up</measurement>
+                </period>
+            </point_log>
+            <point_log id="6c53a08fca4f44518247ca583f3f7741">
+                <type>intended_domestic_hot_water_comfort_mode</type>
+                <unit/>
+                <updated_date>2024-12-06T14:53:02.765+01:00</updated_date>
+                <last_consecutive_log_date>2024-12-06T14:53:02.765+01:00</last_consecutive_log_date>
+                <interval/>
+                <boiler_state id="d67523ab0c934c4e9a0ec9262f7677b5"/>
+                <period start_date="2024-12-06T14:53:02.765+01:00" end_date="2024-12-06T14:53:02.765+01:00">
+                    <measurement log_date="2024-12-06T14:53:02.765+01:00">off</measurement>
+                </period>
+            </point_log>
+            <point_log id="87a32c244021436b88d59ae44af16378">
+                <type>button_right</type>
+                <unit/>
+                <updated_date>2024-09-17T00:50:14.797+02:00</updated_date>
+                <last_consecutive_log_date>2024-09-17T00:50:14.797+02:00</last_consecutive_log_date>
+                <interval/>
+                <button id="d8d99db2d9214863a3c7e28bcd115b12"/>
+                <period start_date="2024-09-17T00:50:14.797+02:00" end_date="2024-09-17T00:50:14.797+02:00">
+                    <measurement log_date="2024-09-17T00:50:14.797+02:00">up</measurement>
+                </period>
+            </point_log>
+            <point_log id="90c3a54e3a1c465eb81302fef57f4410">
+                <type>onoff_boiler_temperature_deadband</type>
+                <unit>C</unit>
+                <updated_date>2024-07-29T15:46:39.326+02:00</updated_date>
+                <last_consecutive_log_date>2024-07-29T15:46:39.326+02:00</last_consecutive_log_date>
+                <interval/>
+                <temperature_offset_meter id="725e6fbd7440407a99c3bf13cc22d870"/>
+                <period start_date="2024-07-29T15:46:39.326+02:00" end_date="2024-07-29T15:46:39.326+02:00">
+                    <measurement log_date="2024-07-29T15:46:39.326+02:00">0.50</measurement>
+                </period>
+            </point_log>
+            <point_log id="9c2e08cbe1184ac9ae604d2c7a7c88cd">
+                <type>temperature</type>
+                <unit>C</unit>
+                <updated_date>2024-12-06T18:46:33.643+01:00</updated_date>
+                <last_consecutive_log_date>2024-12-06T18:35:17.962+01:00</last_consecutive_log_date>
+                <interval>PT3H</interval>
+                <thermo_meter id="00426b5ea5584f91a1705c1baffde511"/>
+                <period start_date="2024-12-06T18:46:33.643+01:00" end_date="2024-12-06T18:46:33.643+01:00">
+                    <measurement log_date="2024-12-06T18:46:33.643+01:00">19.23</measurement>
+                </period>
+            </point_log>
+            <point_log id="a1041c7b4a0544ce84870460f4f7624a">
+                <type>proximity_sensor_state</type>
+                <unit/>
+                <updated_date>2024-07-29T15:46:39.394+02:00</updated_date>
+                <last_consecutive_log_date>2024-07-29T15:46:39.394+02:00</last_consecutive_log_date>
+                <interval/>
+                <proximity_sensor_toggle id="fbebb29bb7814191bae5c343567f4d8c"/>
+                <period start_date="2024-07-29T15:46:39.394+02:00" end_date="2024-07-29T15:46:39.394+02:00">
+                    <measurement log_date="2024-07-29T15:46:39.394+02:00">on</measurement>
+                </period>
+            </point_log>
+            <point_log id="a406a1ebacf84ba2acde0a7bc37542e7">
+                <type>button_top</type>
+                <unit/>
+                <updated_date>2024-09-15T17:49:20.641+02:00</updated_date>
+                <last_consecutive_log_date>2024-09-15T17:49:20.641+02:00</last_consecutive_log_date>
+                <interval/>
+                <button id="f84d8f82ff114da995c4af377cecede7"/>
+                <period start_date="2024-09-15T17:49:20.641+02:00" end_date="2024-09-15T17:49:20.641+02:00">
+                    <measurement log_date="2024-09-15T17:49:20.641+02:00">up</measurement>
+                </period>
+            </point_log>
+            <point_log id="a5da72e538e94d0690a3491ea1f5c35a">
+                <type>illuminance</type>
+                <unit>lx</unit>
+                <updated_date>2024-12-06T18:25:40.446+01:00</updated_date>
+                <last_consecutive_log_date>2024-12-06T18:25:40.446+01:00</last_consecutive_log_date>
+                <interval/>
+                <illuminance_meter id="4792764e63104d1691efa5bc966f5187"/>
+                <period start_date="2024-12-06T18:25:40.446+01:00" end_date="2024-12-06T18:25:40.446+01:00">
+                    <measurement log_date="2024-12-06T18:25:40.446+01:00">0.50</measurement>
+                </period>
+            </point_log>
+            <point_log id="bed93c9f59cf445e8e796daba3f61df1">
+                <type>intended_central_heating_state</type>
+                <unit/>
+                <updated_date>2024-12-06T14:53:02.765+01:00</updated_date>
+                <last_consecutive_log_date>2024-12-06T14:53:02.765+01:00</last_consecutive_log_date>
+                <interval/>
+                <boiler_state id="90771c033acc44f481f194309e2ed032"/>
+                <period start_date="2024-12-06T14:53:02.765+01:00" end_date="2024-12-06T14:53:02.765+01:00">
+                    <measurement log_date="2024-12-06T14:53:02.765+01:00">on</measurement>
+                </period>
+            </point_log>
+            <point_log id="bfd9477530694a46bdc6749548fd218c">
+                <type>thermostat</type>
+                <unit>C</unit>
+                <updated_date>2024-12-06T16:49:32.589+01:00</updated_date>
+                <last_consecutive_log_date>2024-12-06T16:49:32.589+01:00</last_consecutive_log_date>
+                <interval/>
+                <thermostat id="52b5a053e83446e6a11fde60a6c9ed11"/>
+                <period start_date="2024-12-06T16:49:32.589+01:00" end_date="2024-12-06T16:49:32.589+01:00">
+                    <measurement log_date="2024-12-06T16:49:32.589+01:00">19.50</measurement>
+                </period>
+            </point_log>
+            <point_log id="cecd3059ab6d4ece9b419b7bf820b7f4">
+                <type>cpu_frequency</type>
+                <unit>Hz</unit>
+                <updated_date>2024-12-06T18:23:45+01:00</updated_date>
+                <last_consecutive_log_date>2024-12-06T18:23:45+01:00</last_consecutive_log_date>
+                <interval/>
+                <frequency_meter id="894b17e281dd4429bb5982de7048d929"/>
+                <period start_date="2024-12-06T18:23:45+01:00" end_date="2024-12-06T18:23:45+01:00">
+                    <measurement log_date="2024-12-06T18:23:45+01:00">8000000</measurement>
+                </period>
+            </point_log>
+            <point_log id="dbb111e942c74bc3bdac40d228d58082">
+                <type>target_temperature</type>
+                <unit>C</unit>
+                <updated_date>2024-12-06T16:50:48.286+01:00</updated_date>
+                <last_consecutive_log_date>2024-12-06T16:50:48.286+01:00</last_consecutive_log_date>
+                <interval/>
+                <thermo_meter id="261d7f5dd4494c139cf30bcc20a87ebe"/>
+                <period start_date="2024-12-06T16:50:48.286+01:00" end_date="2024-12-06T16:50:48.286+01:00">
+                    <measurement log_date="2024-12-06T16:50:48.286+01:00">19.50</measurement>
+                </period>
+            </point_log>
+            <point_log id="e2e178a233174a1fa9268c5d90a43bfe">
+                <type>cooling_activation_outdoor_temperature</type>
+                <unit>C</unit>
+                <updated_date>2024-07-29T13:12:59.607+02:00</updated_date>
+                <last_consecutive_log_date>2024-07-29T13:12:59.607+02:00</last_consecutive_log_date>
+                <interval/>
+                <thermostat id="6be1fe5740ee44ada8faf4fe8c7b24b8"/>
+                <period start_date="2024-07-29T13:12:59.607+02:00" end_date="2024-07-29T13:12:59.607+02:00">
+                    <measurement log_date="2024-07-29T13:12:59.607+02:00">24.00</measurement>
+                </period>
+            </point_log>
+            <point_log id="f29e26d6745b414e9f0439eed6b37a9f">
+                <type>maximum_modulation_level</type>
+                <unit/>
+                <updated_date>2024-10-26T16:05:26.788+02:00</updated_date>
+                <last_consecutive_log_date>2024-07-29T15:46:40.076+02:00</last_consecutive_log_date>
+                <interval/>
+                <modulation_level id="1573925c349941da86f630f58dff9ed8"/>
+                <period start_date="2024-10-26T16:05:26.788+02:00" end_date="2024-10-26T16:05:26.788+02:00">
+                    <measurement log_date="2024-10-26T16:05:26.788+02:00">1.00</measurement>
+                </period>
+            </point_log>
+            <point_log id="fa88a8770fe846f3a11e1bdffc09b7b5">
+                <type>preheating_target_temperature_rate</type>
+                <unit>C_hr</unit>
+                <updated_date>2024-12-06T10:01:22.784+01:00</updated_date>
+                <last_consecutive_log_date>2024-12-06T10:01:22.784+01:00</last_consecutive_log_date>
+                <interval/>
+                <temperature_rate id="725cff112a2b4d839ce6b8229c461c66"/>
+                <period start_date="2024-12-06T10:01:22.784+01:00" end_date="2024-12-06T10:01:22.784+01:00">
+                    <measurement log_date="2024-12-06T10:01:22.784+01:00">2.59</measurement>
+                </period>
+            </point_log>
+        </logs>
+        <actuator_functionalities>
+            <threshold_functionality id="12c30fcd3ae0465c9a57661cbb6b5e22">
+                <threshold id="06c97b7ed1504d498e09d1aa33240317"/>
+                <updated_date>2024-08-02T23:04:22.576+02:00</updated_date>
+                <type>cooling_deactivation_threshold</type>
+                <threshold>2</threshold>
+                <lower_bound>1</lower_bound>
+                <upper_bound>40</upper_bound>
+                <resolution>0.1</resolution>
+            </threshold_functionality>
+            <offset_functionality id="30ba5dff06a347938dbbcbef5a9b425d">
+                <temperature_offset id="a7b6d9b100ac460eaa9316b20a4ac407"/>
+                <updated_date>2024-07-29T15:46:39.120+02:00</updated_date>
+                <type>temperature_offset</type>
+                <offset>0</offset>
+            </offset_functionality>
+            <thermostat_functionality id="5dd948c45a004b02a43d032117fda550">
+                <updated_date>2024-07-29T13:12:59.608+02:00</updated_date>
+                <type>cooling_activation_outdoor_temperature</type>
+                <lower_bound>1</lower_bound>
+                <upper_bound>40</upper_bound>
+                <resolution>0.1</resolution>
+                <setpoint>24</setpoint>
+                <regulations/>
+                <thermostat id="6be1fe5740ee44ada8faf4fe8c7b24b8"/>
+            </thermostat_functionality>
+            <thermostat_functionality id="9d718e17024446f296adecf2a1da9e18">
+                <updated_date>2024-12-06T16:49:32.590+01:00</updated_date>
+                <type>thermostat</type>
+                <lower_bound>4</lower_bound>
+                <upper_bound>30</upper_bound>
+                <resolution>0.1</resolution>
+                <setpoint>19.5</setpoint>
+                <regulations>
+                    <ame_regulation id="1c8b1a395ed848a2a67d65996bf0bb75"/>
+                </regulations>
+                <thermostat id="52b5a053e83446e6a11fde60a6c9ed11"/>
+            </thermostat_functionality>
+            <toggle_functionality id="e841103f04ae4e8184c9b3e6172c2266">
+                <proximity_sensor_toggle id="fbebb29bb7814191bae5c343567f4d8c"/>
+                <updated_date>2024-07-29T15:46:39.394+02:00</updated_date>
+                <type>proximity_sensor_state</type>
+                <state>on</state>
+            </toggle_functionality>
+        </actuator_functionalities>
+    </appliance>
+    <module id="ef8f01b00b0945d28b42b12ae44eeb1b">
+        <vendor_name>Plugwise</vendor_name>
+        <vendor_model>ThermoExtension</vendor_model>
+        <hardware_version>6539-1301-2304</hardware_version>
+        <firmware_version>2018-02-08T11:15:57+01:00</firmware_version>
+        <created_date>2017-08-29T08:24:38.164+02:00</created_date>
+        <modified_date>2019-07-22T11:08:07.986+02:00</modified_date>
+        <deleted_date/>
+        <services/>
+        <protocols>
+            <thermo_extension id="668c0412fb2b420a80de9642b9f8a2f1">
+                <thermo_touch id="af43990b4ca744cf8e9f9b5996190f6f"/>
+                <open_therm_boiler id="b2481333821543b0994b280c60395ba5"/>
+            </thermo_extension>
+        </protocols>
+    </module>
+    <module id="c5539bb850ea40cab886354b10bec43b">
+        <vendor_name/>
+        <vendor_model/>
+        <hardware_version/>
+        <firmware_version/>
+        <created_date>2017-10-25T14:55:02.841+02:00</created_date>
+        <modified_date>2020-07-10T05:28:40.857+02:00</modified_date>
+        <deleted_date/>
+        <services>
+            <irradiance_meter id="3860fb2704834c3ba2bf9eb1840c7ca7" log_type="solar_irradiance">
+                <functionalities>
+                    <point_log id="e8d96f806c9746e9a47a3bc809e2438c"/>
+                </functionalities>
+            </irradiance_meter>
+            <thermo_meter id="5702932dadad4591b77f8f30971ea0bf" log_type="outdoor_temperature">
+                <functionalities>
+                    <point_log id="837b147f4ce547388f76f7404cf1b6cc"/>
+                </functionalities>
+            </thermo_meter>
+            <weather_descriptor id="acdffd53f1984f96b571bb4d6b7c6095" log_type="weather_description">
+                <functionalities>
+                    <point_log id="19080fb9d9a94bd88a319419d285a56d"/>
+                </functionalities>
+            </weather_descriptor>
+            <wind_vector id="b790ed1f2a0a4b629d13e0cd02f88821" log_type="wind_vector">
+                <functionalities>
+                    <point_log id="a17661da905149eca734ba8b047fe177"/>
+                </functionalities>
+            </wind_vector>
+            <hygro_meter id="ec0d5294e3bf4e5e96054901fe25835a" log_type="humidity">
+                <functionalities>
+                    <point_log id="67f6e7e97f6b47368f61460226ead4cb"/>
+                </functionalities>
+            </hygro_meter>
+        </services>
+        <protocols>
+            <weather_feed id="5b75838ca51c48f1853f71b23f9c4191"/>
+        </protocols>
+    </module>
 </domain_objects>

--- a/userdata/anna_elga_2/old_core.domain_objects.xml
+++ b/userdata/anna_elga_2/old_core.domain_objects.xml
@@ -1,0 +1,2128 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<domain_objects>
+	<template id='c9a9744aad4646f5a1b02ed9d72191a3' tag="zone_setpoint_and_state_based_on_preset">
+		<name>Zone preset template</name>
+		<description>Template for actuating thermostats and relays on a preset basis.</description>
+		<single_actor>true</single_actor>
+		<created_date>2017-10-25T14:55:02.526+02:00</created_date>
+		<modified_date>2022-03-02T17:47:56.632+01:00</modified_date>
+		<deleted_date></deleted_date>
+		<objects>
+			<object name="zone" type="Location"/>
+		</objects>
+		<parameters>
+			<parameter name="preset" source="zone.preset" type="Preset"/>
+		</parameters>
+		<results>
+			<result name="cooling_setpoint" type="Number" action="zone.iterateFunctionalities('ThermostatFunctionality', 'thermostat')().setSetpoint(null, null, cooling_setpoint)"/>
+			<result name="domestic_hot_water_state" type="OnOff" action="zone.iterateFunctionalities('ToggleFunctionality', 'domestic_hot_water_state')().state = domestic_hot_water_state"/>
+			<result name="heating_setpoint" type="Number" action="zone.iterateFunctionalities('ThermostatFunctionality', 'thermostat')().setSetpoint(null, heating_setpoint, null)"/>
+			<result name="state" type="OnOff" action="zone.iterateFunctionalities('RelayFunctionality')().state = state"/>
+		</results>
+	</template>
+	<module id='0fb9b855195d4c90b7cb6fe3cdd12aa1'>
+		<vendor_name>Plugwise</vendor_name>
+		<vendor_model>Gateway</vendor_model>
+		<hardware_version>AME Smile 2.0 board</hardware_version>
+		<firmware_version></firmware_version>
+		<created_date>2018-07-12T11:13:19.719+02:00</created_date>
+		<modified_date>2021-10-28T04:56:48.081+02:00</modified_date>
+		<deleted_date></deleted_date>
+		<services>
+			<network_state id='6fbd440a76444188adfcce9366e5e800' log_type='wlan_state'>
+				<functionalities><point_log id='43466b056f2f457493b720430ba254c5'/></functionalities>
+			</network_state>
+			<network_address id='936a423321184cf88cfc6c700e872230' log_type='wlan_ip_address'>
+				<functionalities><point_log id='856cc738696245d1a580706b6db5574e'/></functionalities>
+			</network_address>
+			<network_state id='af06c116bc7e4e7bbcac5b4d235bd2c8' log_type='lan_state'>
+				<functionalities><point_log id='e523c94b2efc445ba8bb26ec27152d6a'/></functionalities>
+			</network_state>
+			<link_quality id='af0f81cc5ca844c492ef164e2c114508' log_type='link_quality'>
+				<functionalities><point_log id='b41f590d2c06410dbe8be8e9f7b74deb'/></functionalities>
+			</link_quality>
+			<network_address id='b4124ec2cee84ae182a6612e610e1690' log_type='lan_ip_address'>
+				<functionalities><point_log id='170726b59a1c45f395dbc3d2920f9217'/></functionalities>
+			</network_address>
+			<gateway_mode_control id='bfa38e00cc3d405b80dadfc05bea8a9b' log_type='gateway_mode'>
+				<functionalities><gateway_mode_control_functionality id='43a20461689e4536bcf02758b6a2c340'/><point_log id='aa949dbf9f654ba09d3f8bff22f91cd3'/></functionalities>
+			</gateway_mode_control>
+			<signal_strength id='c61cb1657e7046f78f77f3a6a8bd4e01' log_type='signal_strength'>
+				<functionalities><point_log id='2dfe41f254c74ce9a9e9aaff6be9dbe7'/></functionalities>
+			</signal_strength>
+		</services>
+		<protocols>
+			<local_area_network id='44bed71f40c742e584168b9d6b8735da'/>
+			<wireless_local_area_network id='95bd9155f73e4adf941b6b7f84f58468'/>
+		</protocols>
+	</module>
+	<module id='c53888603af34264bbed2a05998ee572'>
+		<vendor_name>Techneco</vendor_name>
+		<vendor_model></vendor_model>
+		<hardware_version></hardware_version>
+		<firmware_version></firmware_version>
+		<created_date>2019-07-22T11:08:27.495+02:00</created_date>
+		<modified_date>2021-10-28T04:56:25.609+02:00</modified_date>
+		<deleted_date></deleted_date>
+		<services>
+			<pressure_gauge id='01d551e4bb2b475a9463912a3fd887da' log_type='central_heater_water_pressure'>
+				<functionalities><point_log id='e799a764479a4c4586179dd0760fe54e'/></functionalities>
+			</pressure_gauge>
+			<thermostat id='07c7b619be4242d6919733e6098a5b5e' log_type='maximum_outdoor_unit_steady_temperature'>
+				<functionalities><thermostat_functionality id='9cee766c36c843288b9bc17628e2a5a7'/><point_log id='c0a8e16b4efd465a88ed471330a99046'/></functionalities>
+			</thermostat>
+			<thermo_meter id='167efda4780e4fa8bbc8f588f4708fa2' log_type='temperature'>
+				<functionalities><point_log id='48f202225fb94f0b96540d97e65397c7'/></functionalities>
+			</thermo_meter>
+			<timer id='1b79f533784742c796c973856b30909d' log_type='indoor_temperature_transition_time'>
+				<functionalities><timer_functionality id='4e627a99dcf94bc086b31aa3a6de44b2'/><point_log id='c49b3ce126314dca848d51429a0ef2ea'/></functionalities>
+			</timer>
+			<thermo_meter id='1d0d91857e4042ec9180e2bc78898d13' log_type='intended_boiler_temperature'>
+				<functionalities><point_log id='0b1f4d8bbbbd451bb5214a7f592124e5'/></functionalities>
+			</thermo_meter>
+			<boiler_state id='1efb6c04052e4defbe429d6440c285c6' log_type='compressor_state'>
+				<functionalities><point_log id='40e35727c7b947f48099b5221633474c'/></functionalities>
+			</boiler_state>
+			<thermostat id='211f6996e8394d12a1f2cdb23b420a2c' log_type='heatpump_minimum_outdoor_temperature'>
+				<functionalities><thermostat_functionality id='c9b707c378b04420a55bdffe00e4f8f6'/><point_log id='daac6bf095ce472082653bd4a57c58f9'/></functionalities>
+			</thermostat>
+			<domestic_hot_water_toggle id='29fb663d576a46c79d629826edff95f0' log_type='domestic_hot_water_comfort_mode'>
+				<functionalities><point_log id='2e0289df2c7f4b66b8a4f562658a6903'/><toggle_functionality id='700bd52a8729461bb0fdf6d055c08710'/></functionalities>
+			</domestic_hot_water_toggle>
+			<fault_code id='310985c85e5e42238c4ae63180e8ed2c' log_type='elga_outdoor_unit_fault_code'>
+				<functionalities><point_log id='24b48396d2c24a7089fd3a3f0476fe3d'/></functionalities>
+			</fault_code>
+			<thermostat id='333ef91f62d94f78ad7b9bedaecc71f2' log_type='maximum_outdoor_unit_temperature'>
+				<functionalities><point_log id='10cea8565cd343768a6867c47c0300c6'/><thermostat_functionality id='a67b1c7b6d2f403aba383a56ad3d8e0a'/></functionalities>
+			</thermostat>
+			<thermostat id='3636e8c24b764f9dae52ba36695ed476' log_type='weather_dependent_maximum_supply_temperature'>
+				<functionalities><thermostat_functionality id='9cfae18be05b4509b32d52571107f0ff'/><point_log id='d517c9c0c3254926bd881c61b41f2185'/></functionalities>
+			</thermostat>
+			<threshold id='38eadee2fac04aaab6f8fac793560c82' log_type='boiler_activation_threshold'>
+				<functionalities><threshold_functionality id='57fb489e615a46888a051712ca8954f2'/><point_log id='e809f761a4c14287a852a8c727bbdc40'/></functionalities>
+			</threshold>
+			<timer id='397304cc8cbe47798f41930b1d62b009' log_type='hibernation_lead_time'>
+				<functionalities><point_log id='02b66447758049fab71cfc396d0b4423'/><timer_functionality id='4823c26f51bc4b07928acbb5ef056ca1'/></functionalities>
+			</timer>
+			<fault_code id='3af7b55915d841808e61d89a7663b7a2' log_type='open_therm_slave_oem_fault_code'>
+				<functionalities><point_log id='a45bc7ff672748328d3f83e6a4808ea3'/></functionalities>
+			</fault_code>
+			<timer id='4ac8d9303b644429b5c5bae03a79470a' log_type='pump_lag_time'>
+				<functionalities><timer_functionality id='631c67b8e2f2411d83ffa5a687f3b79b'/><point_log id='d703b335844c4d789b707534cb5dbd3e'/></functionalities>
+			</timer>
+			<thermostat id='4b8a974d347f4cf1872a5bc07f613068' log_type='maximum_heating_supply_temperature'>
+				<functionalities><thermostat_functionality id='b6579ded90e7489ca51a48768c721eb0'/><point_log id='f3eaebe5868840099b2f6eea9763dec3'/></functionalities>
+			</thermostat>
+			<dip_switch id='4d79c04aa75340519aca29545955bf76' log_type='input_contacts_installed'>
+				<functionalities><point_log id='80737def763544d797ce2ecebbaaf606'/></functionalities>
+			</dip_switch>
+			<thermostat id='5304a8c3c39e42b990c9b057e880f8a4' log_type='minimum_cooling_supply_temperature'>
+				<functionalities><point_log id='705e0e0f37574caabd69dd6a9db1620d'/><thermostat_functionality id='a1f29fd4edae4894a74c0b8c523f8ef3'/></functionalities>
+			</thermostat>
+			<dip_switch id='53a892b70e7a4f01a6174415509e8590' log_type='hibernation_enabled'>
+				<functionalities><point_log id='188ba49897614157a0b2723087058010'/></functionalities>
+			</dip_switch>
+			<thermostat id='564f724946434905b7d2b6c142e4ba67' log_type='maximum_outdoor_unit_power_increase_temperature'>
+				<functionalities><point_log id='083ba290a88245f3bd56957d6695dd55'/><thermostat_functionality id='f8b9ad4b594846628e305fdf7ff26b3e'/></functionalities>
+			</thermostat>
+			<dip_switch id='5f729e9aa96c4e33ad866f2efe41e694' log_type='thermostat_enabled'>
+				<functionalities><point_log id='7e6f7d5dfdd84b5ca8287d0f30944e8b'/></functionalities>
+			</dip_switch>
+			<dip_switch id='60c6512c9b9249199ca4adb48ab30e4e' log_type='weather_dependent_regulation'>
+				<functionalities><point_log id='56c09638ead640a5a7b6864a6a1db81b'/></functionalities>
+			</dip_switch>
+			<timer id='68a4b6945cbb49e0b1629ae6a44da34b' log_type='external_pump_cooling_lead_time'>
+				<functionalities><point_log id='78125fc1129b404782f7cf08c1a72401'/><timer_functionality id='8dcd68a78d704da8b0a61083d376223f'/></functionalities>
+			</timer>
+			<fault_code id='6e268f4aa86e4cc0a29c084d00c8319b' log_type='open_therm_oem_fault_code'>
+				<functionalities><point_log id='7d79610e27234506b0220b7e1a14eb3a'/></functionalities>
+			</fault_code>
+			<boiler_state id='72ac57601ea7410381c889a1f58b191c' log_type='intended_central_heating_state'>
+				<functionalities><point_log id='5f0c73d239254abea42bdf1cf02bd7de'/></functionalities>
+			</boiler_state>
+			<dip_switch id='74fab0d973c049e09f3514141f58c0ef' log_type='temperature_sensor_enabled'>
+				<functionalities><point_log id='7a90e2fb40a34176a94e408957c5c27c'/></functionalities>
+			</dip_switch>
+			<dip_switch id='769ba34f091e4fe4a0718ed34defea99' log_type='second_fan_enabled'>
+				<functionalities><point_log id='a6e3ad5afe8e4c6c9feafbd95f221a3a'/></functionalities>
+			</dip_switch>
+			<thermostat id='7c4e5837e0474ad3888e97cf21a51670' log_type='night_reduction_setpoint'>
+				<functionalities><thermostat_functionality id='07699ce0bdd6491db490f0e15642ca43'/><point_log id='8bbc4ca809b84a41b6c6115a8ccacecf'/></functionalities>
+			</thermostat>
+			<temperature_offset id='7c77a680bb0645aeb325f196e4a3df57' log_type='cooling_upper_offset'>
+				<functionalities><offset_functionality id='69ed60c3bc3846449e61dba62e71da40'/><point_log id='e5f051ef9b1542f2bf1b340fb6ba26d2'/></functionalities>
+			</temperature_offset>
+			<timer id='7ccb6bc94f1948ee9f16ecfb5c80d719' log_type='internal_pump_cooling_lead_time'>
+				<functionalities><point_log id='72e0439587ac443c8880f35543c12834'/><timer_functionality id='d24d209910e34533a95e361c8c66352c'/></functionalities>
+			</timer>
+			<thermostat id='82b1c7dcc6674568af1dbace5e64af8b' log_type='maximum_cooling_supply_temperature'>
+				<functionalities><point_log id='292c77f567194b14a0e7c3d63b340e66'/><thermostat_functionality id='6385d825e10545bfabc3cd3574920b68'/></functionalities>
+			</thermostat>
+			<thermo_meter id='8609fbdcab4b46e387953184f9878c28' log_type='outdoor_temperature'>
+				<functionalities><point_log id='fa0e3334f8d941cbbb040c5bf52fb2df'/></functionalities>
+			</thermo_meter>
+			<timer id='881f3c1377bc4efda8c78409a18ebe55' log_type='internal_pump_heating_lead_time'>
+				<functionalities><timer_functionality id='0646e6e1204147668157d2a7c59ef3ee'/><point_log id='1365f71019794971bbb06ebd881b7c84'/></functionalities>
+			</timer>
+			<modulation_level id='8862e6a7a98842928028e3f14493de8b' log_type='modulation_level'>
+				<functionalities><point_log id='1a94ecad909b40848efdce89197bae6d'/></functionalities>
+			</modulation_level>
+			<thermo_meter id='8eafb561fafb42ef8305eae670851e4a' log_type='boiler_temperature'>
+				<functionalities><point_log id='9556ad80c44b48459e297eeca0720cc3'/></functionalities>
+			</thermo_meter>
+			<dip_switch id='8eeb17de38da4b37992c7ef910592306' log_type='simultaneous_boiler_operation'>
+				<functionalities><point_log id='c65f2f2e30df4e1cb48bff1afc6bfaf5'/></functionalities>
+			</dip_switch>
+			<status_code id='91eb08ab048d4f8c947399a64a2e618b' log_type='elga_status_code'>
+				<functionalities><point_log id='1d03fff43bf640f998150fabc2aa7522'/></functionalities>
+			</status_code>
+			<boiler_state id='93242446d05a443fa31dc19c56fef767' log_type='central_heating_state'>
+				<functionalities><point_log id='d6e5970949cc4c48a1e20d830e3f9856'/></functionalities>
+			</boiler_state>
+			<boiler_state id='9c0a03f4a7f94290997bef767e5a81c2' log_type='flame_state'>
+				<functionalities><point_log id='00c5146fe1a749e3925627d59700652a'/></functionalities>
+			</boiler_state>
+			<thermostat id='9d9f24a42c514c99887d85091ba46d74' log_type='minimum_heating_supply_temperature'>
+				<functionalities><thermostat_functionality id='5b6c3a3cf0de4adc92e4aac0d93e1962'/><point_log id='5cd62cb4ac5a4067859f074a9a0eeb66'/></functionalities>
+			</thermostat>
+			<thermo_meter id='a2847eec8a634ccdb70d3c1a79c60df7' log_type='return_water_temperature'>
+				<functionalities><point_log id='f9aff78878654f84a8344c0851d7cb33'/></functionalities>
+			</thermo_meter>
+			<boiler_state id='a5d3ae6bd1474d4ebf506f405bb94b06' log_type='slave_boiler_state'>
+				<functionalities><point_log id='3ad82db986354586b9a0b63ffe9685d6'/></functionalities>
+			</boiler_state>
+			<fault_code id='a649c0c0731b4efe8f971a2174d95901' log_type='open_therm_application_specific_fault_code'>
+				<functionalities><point_log id='db8123f44611441095c67a6c2ff84ec7'/></functionalities>
+			</fault_code>
+			<timer id='a783fff6c496488cbee3d8b43fd5be7e' log_type='minimum_boiler_off_time'>
+				<functionalities><timer_functionality id='00a41642a7764d1d80fe37b0cd493730'/><point_log id='bf9870695c254ead9edc22f9abe52260'/></functionalities>
+			</timer>
+			<dip_switch id='a8d50bc1b02c4453acbf78c484da2ed0' log_type='boiler_enabled'>
+				<functionalities><point_log id='b4629113c7b44a43a3ba634fc054279c'/></functionalities>
+			</dip_switch>
+			<boiler_state id='aad2f61001b345ca85e9dda8e0beba70' log_type='domestic_hot_water_state'>
+				<functionalities><point_log id='09e461faff3a4abc9259f7c6e26ffcf0'/></functionalities>
+			</boiler_state>
+			<dip_switch id='acc1480a9e1f4b02ad9d94f7cbd8c6d9' log_type='serial_boiler_installation'>
+				<functionalities><point_log id='6e461af3d33245ffb49ffeaa2752a340'/></functionalities>
+			</dip_switch>
+			<interval_chrono_meter id='afda7f45daef401d9a0b651846933815' log_type='burner_operation_time'>
+				<functionalities><interval_log id='38e63c9a554249a9848053ad0ef8f148'/></functionalities>
+			</interval_chrono_meter>
+			<dip_switch id='bc0af70f6ee24c6b9a48542b4e1cb7f0' log_type='heating_curve'>
+				<functionalities><point_log id='e86e337316754960bca3bd5c3efe87c4'/></functionalities>
+			</dip_switch>
+			<thermostat id='bfe6665d0f05467b977b077b7b787cf1' log_type='boiler_minimum_outdoor_temperature'>
+				<functionalities><point_log id='0444ed9ec551496fadbeb728ab619daa'/><thermostat_functionality id='965f1d814e594fb191268c47ff527022'/></functionalities>
+			</thermostat>
+			<temperature_offset id='c2c422292b904217a49eb2ebb64139fa' log_type='cooling_lower_offset'>
+				<functionalities><offset_functionality id='08ca8e47df01477ebfc92442fc327ba8'/><point_log id='6c6734ca9c52437ebdd012dc1c9237b6'/></functionalities>
+			</temperature_offset>
+			<dip_switch id='c90363c157d84f3cb34ec9fa0ad4a1b1' log_type='first_fan_enabled'>
+				<functionalities><point_log id='08b3982eb0e445e79001228b879db934'/></functionalities>
+			</dip_switch>
+			<dip_switch id='cbbc6155ab0945248c08fb6c08be2e64' log_type='outdoor_temperature_used'>
+				<functionalities><point_log id='1e2304cab4b14e80a91d30f733509659'/></functionalities>
+			</dip_switch>
+			<timer id='cd3755b4f6454aa482f5603edc7c7019' log_type='external_pump_heating_lead_time'>
+				<functionalities><timer_functionality id='4538146f706d42098e9e233b0ef4d1bd'/><point_log id='7a088fe1ff4d44d5a03be6f1ddb69b1a'/></functionalities>
+			</timer>
+			<dip_switch id='cdcb69e61cf7452dad650f828827fc3c' log_type='thermostat_supports_cooling'>
+				<functionalities><point_log id='25e405154876410cbb760583417206bb'/></functionalities>
+			</dip_switch>
+			<thermo_meter id='ce44bfc81c5b4f2d82331c48b548aae7' log_type='refrigerent_out_temperature'>
+				<functionalities><point_log id='acedb4c2dd3d49039768c23832f7b599'/></functionalities>
+			</thermo_meter>
+			<dip_switch id='d127367c661c4c3582b544a08b0c68ad' log_type='underfloor_heating'>
+				<functionalities><point_log id='0a12b2e6991e4f42bf2912673547b156'/></functionalities>
+			</dip_switch>
+			<thermo_meter id='d26080b9f53246c08ff76d20e162670a' log_type='refrigerent_in_temperature'>
+				<functionalities><point_log id='375a05154d6647148cf393ac8b2c8b65'/></functionalities>
+			</thermo_meter>
+			<dip_switch id='d3abfcd0012e4b47af6d69911031f7ab' log_type='boiler_installed'>
+				<functionalities><point_log id='3f1313a814ec4614be4e709e659a4f8d'/></functionalities>
+			</dip_switch>
+			<thermo_meter id='dec96976f5f14d97a6cc290f9110e5ee' log_type='domestic_hot_water_setpoint'>
+				<functionalities><point_log id='af12fd7e384c4081b3700f7fc424ac79'/></functionalities>
+			</thermo_meter>
+			<dip_switch id='ebf84b976e4e4cb39c5b553e7a9e5fc1' log_type='night_reduction'>
+				<functionalities><point_log id='dd64bb930f484e2e8047c5020ef9c185'/></functionalities>
+			</dip_switch>
+			<timer id='ecbec078612949e6aa050f2ad9b55958' log_type='minimum_boiler_run_time'>
+				<functionalities><timer_functionality id='4d846b97eca946d78e6f3c0ae70f9db4'/><point_log id='e7b09f30833c458c9291c7cf761f0068'/></functionalities>
+			</timer>
+			<boiler_state id='f613e055261943f4987856badb3fb0ae' log_type='cooling_state'>
+				<functionalities><point_log id='bbfaf21ad4e14ca3be4ba9b508047d6b'/></functionalities>
+			</boiler_state>
+			<thermostat id='f7512e547d1c40f18d8911bd8bd1cce7' log_type='maximum_boiler_temperature'>
+				<functionalities><thermostat_functionality id='c0d682baec2b45979720a0c4253665b0'/><point_log id='d368799910734cc89ed1e3d5d60363fc'/></functionalities>
+			</thermostat>
+		</services>
+		<protocols>
+			<open_therm_boiler id='b2481333821543b0994b280c60395ba5'>
+				<thermo_extension id='668c0412fb2b420a80de9642b9f8a2f1'/>
+				<open_therm_version>0.0</open_therm_version>
+				<is_modulating>true</is_modulating>
+				<with_cooling>false</with_cooling>
+				<with_domestic_hot_water>false</with_domestic_hot_water>
+				<with_domestic_hot_water_storage>false</with_domestic_hot_water_storage>
+				<with_master_low_off_and_pump_control>true</with_master_low_off_and_pump_control>
+				<with_secondary_heating_circuit>false</with_secondary_heating_circuit>
+				<smartgrid_control>smart_grid_off</smartgrid_control>
+				<test_mode>off</test_mode>
+			</open_therm_boiler>
+		</protocols>
+	</module>
+	<appliance id='ebd90df1ab334565b5895f37590ccff4'>
+		<name>Anna</name>
+		<description>A thermostat</description>
+		<type>thermostat</type>
+		<created_date>2019-07-22T11:03:36.852+02:00</created_date>
+		<modified_date>2022-03-10T19:01:01.334+01:00</modified_date>
+		<deleted_date></deleted_date>
+		<location id='d3ce834534114348be628b61b26d9220'/>
+		<groups/>
+		<logs>
+			<point_log id='01a06384c7d449bba2725e8edf714584'>
+				<type>temperature_offset</type>
+				<unit>C</unit>
+				<updated_date>2022-03-02T17:48:18.308+01:00</updated_date>
+				<last_consecutive_log_date>2019-07-22T11:08:14.705+02:00</last_consecutive_log_date>
+				<interval/>
+				<temperature_offset id='a7b6d9b100ac460eaa9316b20a4ac407'/>
+				<period start_date="2022-03-02T17:48:18.308+01:00" end_date="2022-03-02T17:48:18.308+01:00">
+					<measurement log_date="2022-03-02T17:48:18.308+01:00">0.00</measurement>
+				</period>
+			</point_log>
+			<point_log id='05cfa5d4403b42ddb2f0258dc76d6754'>
+				<type>open_therm_boiler_activation_threshold</type>
+				<unit>C</unit>
+				<updated_date>2022-03-02T17:48:18.199+01:00</updated_date>
+				<last_consecutive_log_date>2020-07-09T16:11:46.259+02:00</last_consecutive_log_date>
+				<interval/>
+				<temperature_offset_meter id='b107e4d0690c40e38f9519de498f80d0'/>
+				<period start_date="2022-03-02T17:48:18.199+01:00" end_date="2022-03-02T17:48:18.199+01:00">
+					<measurement log_date="2022-03-02T17:48:18.199+01:00">0.00</measurement>
+				</period>
+			</point_log>
+			<point_log id='19a51cc2909a42308846d07095089c48'>
+				<type>decentral_heat_demand_offset</type>
+				<unit>C</unit>
+				<updated_date>2022-03-10T19:01:39.262+01:00</updated_date>
+				<last_consecutive_log_date>2020-08-15T17:11:15.017+02:00</last_consecutive_log_date>
+				<interval/>
+				<temperature_offset_meter id='1b662f928c4f4a739b521214d8539c47'/>
+				<period start_date="2022-03-10T19:01:39.262+01:00" end_date="2022-03-10T19:01:39.262+01:00">
+					<measurement log_date="2022-03-10T19:01:39.262+01:00">0.00</measurement>
+				</period>
+			</point_log>
+			<point_log id='23544f8616644a87a971bb584cd2c926'>
+				<type>proximity_detection</type>
+				<unit></unit>
+				<updated_date>2021-11-20T23:26:01.029+01:00</updated_date>
+				<last_consecutive_log_date>2021-11-20T23:26:01.029+01:00</last_consecutive_log_date>
+				<interval/>
+				<proximity_sensor id='ef39b2e2aacb40f08568a6fc638c242a'/>
+				<period start_date="2021-11-20T23:26:01.029+01:00" end_date="2021-11-20T23:26:01.029+01:00">
+					<measurement log_date="2021-11-20T23:26:01.029+01:00">proximity_detected</measurement>
+				</period>
+			</point_log>
+			<point_log id='5337865ab7f743388dca27d127deecb0'>
+				<type>cooling_deactivation_threshold</type>
+				<unit>C</unit>
+				<updated_date>2020-09-07T19:07:13.679+02:00</updated_date>
+				<last_consecutive_log_date>2020-09-07T19:07:13.679+02:00</last_consecutive_log_date>
+				<interval/>
+				<threshold id='06c97b7ed1504d498e09d1aa33240317'/>
+				<period start_date="2020-09-07T19:07:13.679+02:00" end_date="2020-09-07T19:07:13.679+02:00">
+					<measurement log_date="2020-09-07T19:07:13.679+02:00">3</measurement>
+				</period>
+			</point_log>
+			<point_log id='5c206e6a6fff4962b3e06d965c9caf4d'>
+				<type>derivative_coefficient</type>
+				<unit>s</unit>
+				<updated_date>2022-03-02T17:48:18.207+01:00</updated_date>
+				<last_consecutive_log_date>2020-07-10T05:28:54.022+02:00</last_consecutive_log_date>
+				<interval/>
+				<coefficient id='9c5191459bfa42e2bc92a951886ca6c0'/>
+				<period start_date="2022-03-02T17:48:18.207+01:00" end_date="2022-03-02T17:48:18.207+01:00">
+					<measurement log_date="2022-03-02T17:48:18.207+01:00">0</measurement>
+				</period>
+			</point_log>
+			<point_log id='6b8756139eb34bab9692edb22d0bcd50'>
+				<type>button_left</type>
+				<unit></unit>
+				<updated_date>2022-03-09T18:38:03.814+01:00</updated_date>
+				<last_consecutive_log_date>2022-03-09T18:38:03.814+01:00</last_consecutive_log_date>
+				<interval/>
+				<button id='d349d6b8767c491991390ea199337223'/>
+				<period start_date="2022-03-09T18:38:03.814+01:00" end_date="2022-03-09T18:38:03.814+01:00">
+					<measurement log_date="2022-03-09T18:38:03.814+01:00">up</measurement>
+				</period>
+			</point_log>
+			<point_log id='6c53a08fca4f44518247ca583f3f7741'>
+				<type>intended_domestic_hot_water_comfort_mode</type>
+				<unit></unit>
+				<updated_date>2022-03-10T18:58:40.707+01:00</updated_date>
+				<last_consecutive_log_date>2021-06-18T19:48:06.020+02:00</last_consecutive_log_date>
+				<interval/>
+				<boiler_state id='d67523ab0c934c4e9a0ec9262f7677b5'/>
+				<period start_date="2022-03-10T18:58:40.707+01:00" end_date="2022-03-10T18:58:40.707+01:00">
+					<measurement log_date="2022-03-10T18:58:40.707+01:00">on</measurement>
+				</period>
+			</point_log>
+			<point_log id='87a32c244021436b88d59ae44af16378'>
+				<type>button_right</type>
+				<unit></unit>
+				<updated_date>2022-03-09T18:38:06.192+01:00</updated_date>
+				<last_consecutive_log_date>2022-03-09T18:38:06.192+01:00</last_consecutive_log_date>
+				<interval/>
+				<button id='d8d99db2d9214863a3c7e28bcd115b12'/>
+				<period start_date="2022-03-09T18:38:06.192+01:00" end_date="2022-03-09T18:38:06.192+01:00">
+					<measurement log_date="2022-03-09T18:38:06.192+01:00">up</measurement>
+				</period>
+			</point_log>
+			<point_log id='90c3a54e3a1c465eb81302fef57f4410'>
+				<type>onoff_boiler_temperature_deadband</type>
+				<unit>C</unit>
+				<updated_date>2022-03-02T17:48:18.201+01:00</updated_date>
+				<last_consecutive_log_date>2019-07-22T11:08:16.530+02:00</last_consecutive_log_date>
+				<interval/>
+				<temperature_offset_meter id='725e6fbd7440407a99c3bf13cc22d870'/>
+				<period start_date="2022-03-02T17:48:18.201+01:00" end_date="2022-03-02T17:48:18.201+01:00">
+					<measurement log_date="2022-03-02T17:48:18.201+01:00">0.50</measurement>
+				</period>
+			</point_log>
+			<point_log id='9c2e08cbe1184ac9ae604d2c7a7c88cd'>
+				<type>temperature</type>
+				<unit>C</unit>
+				<updated_date>2022-03-10T19:01:01.330+01:00</updated_date>
+				<last_consecutive_log_date>2022-03-10T19:01:01.330+01:00</last_consecutive_log_date>
+				<interval>PT3H</interval>
+				<thermo_meter id='00426b5ea5584f91a1705c1baffde511'/>
+				<period start_date="2022-03-10T19:01:01.330+01:00" end_date="2022-03-10T19:01:01.330+01:00">
+					<measurement log_date="2022-03-10T19:01:01.330+01:00">20.93</measurement>
+				</period>
+			</point_log>
+			<point_log id='a1041c7b4a0544ce84870460f4f7624a'>
+				<type>proximity_sensor_state</type>
+				<unit></unit>
+				<updated_date>2022-03-02T17:48:18.302+01:00</updated_date>
+				<last_consecutive_log_date>2020-09-05T10:05:15.387+02:00</last_consecutive_log_date>
+				<interval/>
+				<proximity_sensor_toggle id='fbebb29bb7814191bae5c343567f4d8c'/>
+				<period start_date="2022-03-02T17:48:18.302+01:00" end_date="2022-03-02T17:48:18.302+01:00">
+					<measurement log_date="2022-03-02T17:48:18.302+01:00">on</measurement>
+				</period>
+			</point_log>
+			<point_log id='a406a1ebacf84ba2acde0a7bc37542e7'>
+				<type>button_top</type>
+				<unit></unit>
+				<updated_date>2022-03-09T21:05:01.647+01:00</updated_date>
+				<last_consecutive_log_date>2022-03-09T21:05:01.647+01:00</last_consecutive_log_date>
+				<interval/>
+				<button id='f84d8f82ff114da995c4af377cecede7'/>
+				<period start_date="2022-03-09T21:05:01.647+01:00" end_date="2022-03-09T21:05:01.647+01:00">
+					<measurement log_date="2022-03-09T21:05:01.647+01:00">up</measurement>
+				</period>
+			</point_log>
+			<point_log id='a5da72e538e94d0690a3491ea1f5c35a'>
+				<type>illuminance</type>
+				<unit>lx</unit>
+				<updated_date>2022-03-10T18:47:34.152+01:00</updated_date>
+				<last_consecutive_log_date>2022-03-10T18:47:34.152+01:00</last_consecutive_log_date>
+				<interval/>
+				<illuminance_meter id='4792764e63104d1691efa5bc966f5187'/>
+				<period start_date="2022-03-10T18:47:34.152+01:00" end_date="2022-03-10T18:47:34.152+01:00">
+					<measurement log_date="2022-03-10T18:47:34.152+01:00">0.50</measurement>
+				</period>
+			</point_log>
+			<point_log id='bed93c9f59cf445e8e796daba3f61df1'>
+				<type>intended_central_heating_state</type>
+				<unit></unit>
+				<updated_date>2022-03-10T18:58:40.707+01:00</updated_date>
+				<last_consecutive_log_date>2022-03-10T07:14:23.476+01:00</last_consecutive_log_date>
+				<interval/>
+				<boiler_state id='90771c033acc44f481f194309e2ed032'/>
+				<period start_date="2022-03-10T18:58:40.707+01:00" end_date="2022-03-10T18:58:40.707+01:00">
+					<measurement log_date="2022-03-10T18:58:40.707+01:00">off</measurement>
+				</period>
+			</point_log>
+			<point_log id='bfd9477530694a46bdc6749548fd218c'>
+				<type>thermostat</type>
+				<unit>C</unit>
+				<updated_date>2022-03-10T06:45:00.389+01:00</updated_date>
+				<last_consecutive_log_date>2022-03-10T06:45:00.389+01:00</last_consecutive_log_date>
+				<interval/>
+				<thermostat id='52b5a053e83446e6a11fde60a6c9ed11'/>
+				<period start_date="2022-03-10T06:45:00.389+01:00" end_date="2022-03-10T06:45:00.389+01:00">
+					<measurement log_date="2022-03-10T06:45:00.389+01:00">19.50</measurement>
+				</period>
+			</point_log>
+			<point_log id='cecd3059ab6d4ece9b419b7bf820b7f4'>
+				<type>cpu_frequency</type>
+				<unit>Hz</unit>
+				<updated_date>2022-03-09T21:05:36+01:00</updated_date>
+				<last_consecutive_log_date>2022-03-09T21:05:36+01:00</last_consecutive_log_date>
+				<interval/>
+				<frequency_meter id='894b17e281dd4429bb5982de7048d929'/>
+				<period start_date="2022-03-09T21:05:36+01:00" end_date="2022-03-09T21:05:36+01:00">
+					<measurement log_date="2022-03-09T21:05:36+01:00">8000000</measurement>
+				</period>
+			</point_log>
+			<point_log id='dbb111e942c74bc3bdac40d228d58082'>
+				<type>target_temperature</type>
+				<unit>C</unit>
+				<updated_date>2022-03-10T07:21:30.916+01:00</updated_date>
+				<last_consecutive_log_date>2022-03-10T07:21:30.916+01:00</last_consecutive_log_date>
+				<interval/>
+				<thermo_meter id='261d7f5dd4494c139cf30bcc20a87ebe'/>
+				<period start_date="2022-03-10T07:21:30.916+01:00" end_date="2022-03-10T07:21:30.916+01:00">
+					<measurement log_date="2022-03-10T07:21:30.916+01:00">19.50</measurement>
+				</period>
+			</point_log>
+			<point_log id='e2e178a233174a1fa9268c5d90a43bfe'>
+				<type>cooling_activation_outdoor_temperature</type>
+				<unit>C</unit>
+				<updated_date>2021-06-18T20:48:58.071+02:00</updated_date>
+				<last_consecutive_log_date>2021-06-18T20:48:58.071+02:00</last_consecutive_log_date>
+				<interval/>
+				<thermostat id='6be1fe5740ee44ada8faf4fe8c7b24b8'/>
+				<period start_date="2021-06-18T20:48:58.071+02:00" end_date="2021-06-18T20:48:58.071+02:00">
+					<measurement log_date="2021-06-18T20:48:58.071+02:00">26.00</measurement>
+				</period>
+			</point_log>
+			<point_log id='fa88a8770fe846f3a11e1bdffc09b7b5'>
+				<type>preheating_target_temperature_rate</type>
+				<unit>C_hr</unit>
+				<updated_date>2022-03-02T17:48:18.072+01:00</updated_date>
+				<last_consecutive_log_date>2022-01-05T09:09:32.278+01:00</last_consecutive_log_date>
+				<interval/>
+				<temperature_rate id='725cff112a2b4d839ce6b8229c461c66'/>
+				<period start_date="2022-03-02T17:48:18.072+01:00" end_date="2022-03-02T17:48:18.072+01:00">
+					<measurement log_date="2022-03-02T17:48:18.072+01:00">9.97</measurement>
+				</period>
+			</point_log>
+		</logs>
+		<actuator_functionalities>
+			<threshold_functionality id='12c30fcd3ae0465c9a57661cbb6b5e22'>
+				<threshold id='06c97b7ed1504d498e09d1aa33240317'/>
+				<updated_date>2020-09-07T19:07:13.680+02:00</updated_date>
+				<type>cooling_deactivation_threshold</type>
+				<threshold>3</threshold>
+				<lower_bound>1</lower_bound>
+				<upper_bound>40</upper_bound>
+				<resolution>0.1</resolution>
+			</threshold_functionality>
+			<offset_functionality id='30ba5dff06a347938dbbcbef5a9b425d'>
+				<temperature_offset id='a7b6d9b100ac460eaa9316b20a4ac407'/>
+				<updated_date>2022-03-02T17:48:18.308+01:00</updated_date>
+				<type>temperature_offset</type>
+				<offset>0</offset>
+			</offset_functionality>
+			<thermostat_functionality id='5dd948c45a004b02a43d032117fda550'>
+				<updated_date>2021-06-18T20:48:58.072+02:00</updated_date>
+				<type>cooling_activation_outdoor_temperature</type>
+				<setpoint>26</setpoint>
+				<lower_bound>1</lower_bound>
+				<upper_bound>40</upper_bound>
+				<resolution>0.1</resolution>
+				<regulations/>
+				<thermostat id='6be1fe5740ee44ada8faf4fe8c7b24b8'/>
+			</thermostat_functionality>
+			<thermostat_functionality id='9d718e17024446f296adecf2a1da9e18'>
+				<updated_date>2022-03-10T06:45:00.390+01:00</updated_date>
+				<type>thermostat</type>
+				<setpoint>19.5</setpoint>
+				<lower_bound>4</lower_bound>
+				<upper_bound>30</upper_bound>
+				<resolution>0.1</resolution>
+				<regulations><ame_regulation id='1c8b1a395ed848a2a67d65996bf0bb75'/></regulations>
+				<thermostat id='52b5a053e83446e6a11fde60a6c9ed11'/>
+			</thermostat_functionality>
+			<toggle_functionality id='e841103f04ae4e8184c9b3e6172c2266'>
+				<proximity_sensor_toggle id='fbebb29bb7814191bae5c343567f4d8c'/>
+				<updated_date>2022-03-02T17:48:18.302+01:00</updated_date>
+				<type>proximity_sensor_state</type>
+				<state>on</state>
+			</toggle_functionality>
+		</actuator_functionalities>
+	</appliance>
+	<module id='3b36454dda794c6faaed4053a89e80ce'>
+		<vendor_name>Plugwise</vendor_name>
+		<vendor_model>ThermoTouch</vendor_model>
+		<hardware_version>6539-1301-5002</hardware_version>
+		<firmware_version>2018-02-08T11:15:53+01:00</firmware_version>
+		<created_date>2019-07-22T11:03:36.712+02:00</created_date>
+		<modified_date>2021-10-28T04:56:47.858+02:00</modified_date>
+		<deleted_date></deleted_date>
+		<services>
+			<thermo_meter id='00426b5ea5584f91a1705c1baffde511' log_type='temperature'>
+				<functionalities><point_log id='9c2e08cbe1184ac9ae604d2c7a7c88cd'/></functionalities>
+			</thermo_meter>
+			<threshold id='06c97b7ed1504d498e09d1aa33240317' log_type='cooling_deactivation_threshold'>
+				<functionalities><threshold_functionality id='12c30fcd3ae0465c9a57661cbb6b5e22'/><point_log id='5337865ab7f743388dca27d127deecb0'/></functionalities>
+			</threshold>
+			<temperature_offset_meter id='1b662f928c4f4a739b521214d8539c47' log_type='decentral_heat_demand_offset'>
+				<functionalities><point_log id='19a51cc2909a42308846d07095089c48'/></functionalities>
+			</temperature_offset_meter>
+			<thermo_meter id='261d7f5dd4494c139cf30bcc20a87ebe' log_type='target_temperature'>
+				<functionalities><point_log id='dbb111e942c74bc3bdac40d228d58082'/></functionalities>
+			</thermo_meter>
+			<illuminance_meter id='4792764e63104d1691efa5bc966f5187' log_type='illuminance'>
+				<functionalities><point_log id='a5da72e538e94d0690a3491ea1f5c35a'/></functionalities>
+			</illuminance_meter>
+			<thermostat id='52b5a053e83446e6a11fde60a6c9ed11' log_type='thermostat'>
+				<functionalities><thermostat_functionality id='9d718e17024446f296adecf2a1da9e18'/><point_log id='bfd9477530694a46bdc6749548fd218c'/></functionalities>
+			</thermostat>
+			<thermostat id='6be1fe5740ee44ada8faf4fe8c7b24b8' log_type='cooling_activation_outdoor_temperature'>
+				<functionalities><thermostat_functionality id='5dd948c45a004b02a43d032117fda550'/><point_log id='e2e178a233174a1fa9268c5d90a43bfe'/></functionalities>
+			</thermostat>
+			<temperature_rate id='725cff112a2b4d839ce6b8229c461c66' log_type='preheating_target_temperature_rate'>
+				<functionalities><point_log id='fa88a8770fe846f3a11e1bdffc09b7b5'/></functionalities>
+			</temperature_rate>
+			<temperature_offset_meter id='725e6fbd7440407a99c3bf13cc22d870' log_type='onoff_boiler_temperature_deadband'>
+				<functionalities><point_log id='90c3a54e3a1c465eb81302fef57f4410'/></functionalities>
+			</temperature_offset_meter>
+			<frequency_meter id='894b17e281dd4429bb5982de7048d929' log_type='cpu_frequency'>
+				<functionalities><point_log id='cecd3059ab6d4ece9b419b7bf820b7f4'/></functionalities>
+			</frequency_meter>
+			<boiler_state id='90771c033acc44f481f194309e2ed032' log_type='intended_central_heating_state'>
+				<functionalities><point_log id='bed93c9f59cf445e8e796daba3f61df1'/></functionalities>
+			</boiler_state>
+			<coefficient id='9c5191459bfa42e2bc92a951886ca6c0' log_type='derivative_coefficient'>
+				<functionalities><point_log id='5c206e6a6fff4962b3e06d965c9caf4d'/></functionalities>
+			</coefficient>
+			<temperature_offset id='a7b6d9b100ac460eaa9316b20a4ac407' log_type='temperature_offset'>
+				<functionalities><point_log id='01a06384c7d449bba2725e8edf714584'/><offset_functionality id='30ba5dff06a347938dbbcbef5a9b425d'/></functionalities>
+			</temperature_offset>
+			<temperature_offset_meter id='b107e4d0690c40e38f9519de498f80d0' log_type='open_therm_boiler_activation_threshold'>
+				<functionalities><point_log id='05cfa5d4403b42ddb2f0258dc76d6754'/></functionalities>
+			</temperature_offset_meter>
+			<button id='d349d6b8767c491991390ea199337223' log_type='button_left' position='left'>
+				<functionalities><point_log id='6b8756139eb34bab9692edb22d0bcd50'/></functionalities>
+			</button>
+			<boiler_state id='d67523ab0c934c4e9a0ec9262f7677b5' log_type='intended_domestic_hot_water_comfort_mode'>
+				<functionalities><point_log id='6c53a08fca4f44518247ca583f3f7741'/></functionalities>
+			</boiler_state>
+			<button id='d8d99db2d9214863a3c7e28bcd115b12' log_type='button_right' position='right'>
+				<functionalities><point_log id='87a32c244021436b88d59ae44af16378'/></functionalities>
+			</button>
+			<proximity_sensor id='ef39b2e2aacb40f08568a6fc638c242a' log_type='proximity_detection'>
+				<functionalities><point_log id='23544f8616644a87a971bb584cd2c926'/></functionalities>
+			</proximity_sensor>
+			<button id='f84d8f82ff114da995c4af377cecede7' log_type='button_top' position='top'>
+				<functionalities><point_log id='a406a1ebacf84ba2acde0a7bc37542e7'/></functionalities>
+			</button>
+			<proximity_sensor_toggle id='fbebb29bb7814191bae5c343567f4d8c' log_type='proximity_sensor_state'>
+				<functionalities><point_log id='a1041c7b4a0544ce84870460f4f7624a'/><toggle_functionality id='e841103f04ae4e8184c9b3e6172c2266'/></functionalities>
+			</proximity_sensor_toggle>
+		</services>
+		<protocols>
+			<thermo_touch id='af43990b4ca744cf8e9f9b5996190f6f'><thermo_extension id='668c0412fb2b420a80de9642b9f8a2f1'/></thermo_touch>
+		</protocols>
+	</module>
+	<template id='999adea416e84b9c96d9d198ed2005f8' tag="relay_state_based_on_time">
+		<name>Relay schedule template</name>
+		<description>Template for scheduling relays on a time basis.</description>
+		<single_actor>true</single_actor>
+		<created_date>2017-10-25T14:55:02.487+02:00</created_date>
+		<modified_date>2022-03-02T17:47:56.621+01:00</modified_date>
+		<deleted_date></deleted_date>
+		<objects>
+			<object name="direct_object" type="DirectObject"/>
+		</objects>
+		<parameters>
+			<parameter name="time" source="clock.weekTime" type="WeekTime"/>
+		</parameters>
+		<results>
+			<result name="state" type="OnOff" action="direct_object.iterateFunctionalities('RelayFunctionality')().state = state"/>
+		</results>
+	</template>
+	<gateway id='f65e90f31ac3496a9419f4b933e64c15'>
+		<created_date>2017-10-25T14:55:02.060+02:00</created_date>
+		<modified_date>2022-03-10T13:55:17.142+01:00</modified_date>
+		<deleted_date/>
+		<name></name>
+		<description></description>
+		<enabled>true</enabled>
+		<firmware_locked>false</firmware_locked>
+		<prevent_default_update>false</prevent_default_update>
+		<last_reset_date>2017-08-29T08:24:38.164+02:00</last_reset_date>
+		<last_boot_date>2021-10-31T14:48:27.951+01:00</last_boot_date>
+		<vendor_name>Plugwise</vendor_name>
+		<vendor_model>smile_thermo</vendor_model>
+		<hardware_version>AME Smile 2.0 board</hardware_version>
+		<firmware_version>4.2.1</firmware_version>
+		<mac_address>C4930002FE76</mac_address>
+		<short_id>abcdefgh</short_id>
+		<send_data>true</send_data>
+		<anonymous>true</anonymous>
+		<lan_ip></lan_ip>
+		<wifi_ip>127.0.0.2</wifi_ip>
+		<hostname>smile000000</hostname>
+		<time>2022-03-10T19:01:14+01:00</time>
+		<timezone>Europe/Amsterdam</timezone>
+		<ssh_relay>disabled</ssh_relay>
+		<project id='68e91423192a4093b6aaf3af0babe94f'>
+			<name>Techneco</name>
+			<description>Gateways voor Techneco</description>
+			<is_default>false</is_default>
+			<visible_in_production>false</visible_in_production>
+			<deleted_date></deleted_date>
+			<modified_date>2018-07-12T11:13:23.436+02:00</modified_date>
+			<created_date>2017-10-02T13:20:08+02:00</created_date>
+		</project>
+		<gateway_environment id='3034b99b7ec7493099e54d6d2849a86d'>
+			<savings_result_value/>
+			<longitude>4.49</longitude>
+			<thermostat_model/>
+			<city>Sassenheim</city>
+			<country>NL</country>
+			<electricity_consumption_tariff_structure/>
+			<electricity_production_peak_tariff/>
+			<central_heating_model/>
+			<household_children>2</household_children>
+			<thermostat_brand/>
+			<electricity_production_off_peak_tariff/>
+			<central_heating_installation_date/>
+			<postal_code>2171</postal_code>
+			<electricity_consumption_off_peak_tariff/>
+			<latitude>52.21</latitude>
+			<gas_consumption_tariff/>
+			<modified_date>2022-03-09T21:47:09.009+01:00</modified_date>
+			<electricity_production_tariff_structure/>
+			<tariff_region>NL</tariff_region>
+			<housing_construction_period>after_1990</housing_construction_period>
+			<electricity_production_single_tariff/>
+			<electricity_consumption_peak_tariff/>
+			<electricity_consumption_single_tariff/>
+			<central_heating_brand/>
+			<housing_type>detached</housing_type>
+			<currency>EUR</currency>
+			<savings_result_unit/>
+			<household_adults>3</household_adults>
+			<central_heating_year_of_manufacture/>
+			<deleted_date></deleted_date>
+			<modified_date>2022-03-09T21:47:09.009+01:00</modified_date>
+			<created_date>2022-03-08T22:00:34+01:00</created_date>
+		</gateway_environment>
+		<features>
+			<elga_support id='2a37ce7426b144688f2d09614ba20c36'>
+				<activation_date></activation_date>
+				<expiration_date>2038-01-19T04:14:07+01:00</expiration_date>
+				<validity_period/>
+				<valid_to></valid_to>
+				<valid_from></valid_from>
+				<grace_period/>
+				<deleted_date></deleted_date>
+				<modified_date>2018-07-12T11:13:23.659+02:00</modified_date>
+				<created_date>2017-10-31T15:37:07+01:00</created_date>
+			</elga_support>
+			<remote_control id='70b914220d974189ad03327c3ef023d6'>
+				<activation_date></activation_date>
+				<expiration_date>2038-01-19T04:14:07+01:00</expiration_date>
+				<validity_period/>
+				<valid_to></valid_to>
+				<valid_from></valid_from>
+				<grace_period/>
+				<deleted_date></deleted_date>
+				<modified_date>2018-07-12T11:13:23.496+02:00</modified_date>
+				<created_date>2017-10-31T15:37:07+01:00</created_date>
+			</remote_control>
+			<elga_support id='f23b22573edf4e928e0bf2f236c43aa6'>
+				<activation_date></activation_date>
+				<expiration_date>2038-01-19T04:14:07+01:00</expiration_date>
+				<validity_period/>
+				<valid_to></valid_to>
+				<valid_from></valid_from>
+				<grace_period/>
+				<deleted_date></deleted_date>
+				<modified_date>2018-07-12T11:13:23.723+02:00</modified_date>
+				<created_date>2017-10-31T15:38:09+01:00</created_date>
+			</elga_support>
+			<remote_control id='fcedcf651875495d8e7c89d75cc2c345'>
+				<activation_date></activation_date>
+				<expiration_date>2038-01-19T04:14:07+01:00</expiration_date>
+				<validity_period/>
+				<valid_to></valid_to>
+				<valid_from></valid_from>
+				<grace_period/>
+				<deleted_date></deleted_date>
+				<modified_date>2018-07-12T11:13:23.554+02:00</modified_date>
+				<created_date>2017-10-31T15:38:09+01:00</created_date>
+			</remote_control>
+		</features>
+	</gateway>
+	<appliance id='573c152e7d4f4720878222bd75638f5b'>
+		<name>Central heating boiler</name>
+		<description></description>
+		<type>heater_central</type>
+		<created_date>2019-07-22T11:08:27.693+02:00</created_date>
+		<modified_date>2022-03-10T19:03:14.319+01:00</modified_date>
+		<deleted_date></deleted_date>
+		<groups/>
+		<logs>
+			<point_log id='00c5146fe1a749e3925627d59700652a'>
+				<type>flame_state</type>
+				<unit></unit>
+				<updated_date>2022-03-10T18:58:40.743+01:00</updated_date>
+				<last_consecutive_log_date>2022-03-10T18:58:40.743+01:00</last_consecutive_log_date>
+				<interval/>
+				<boiler_state id='9c0a03f4a7f94290997bef767e5a81c2'/>
+				<period start_date="2022-03-10T18:58:40.743+01:00" end_date="2022-03-10T18:58:40.743+01:00">
+					<measurement log_date="2022-03-10T18:58:40.743+01:00">off</measurement>
+				</period>
+			</point_log>
+			<point_log id='02b66447758049fab71cfc396d0b4423'>
+				<type>hibernation_lead_time</type>
+				<unit>hr</unit>
+				<updated_date>2022-03-10T18:50:56.200+01:00</updated_date>
+				<last_consecutive_log_date>2020-07-09T14:27:57.508+02:00</last_consecutive_log_date>
+				<interval/>
+				<timer id='397304cc8cbe47798f41930b1d62b009'/>
+				<period start_date="2022-03-10T18:50:56.200+01:00" end_date="2022-03-10T18:50:56.200+01:00">
+					<measurement log_date="2022-03-10T18:50:56.200+01:00">10</measurement>
+				</period>
+			</point_log>
+			<point_log id='0444ed9ec551496fadbeb728ab619daa'>
+				<type>boiler_minimum_outdoor_temperature</type>
+				<unit>C</unit>
+				<updated_date>2022-03-10T18:52:08.027+01:00</updated_date>
+				<last_consecutive_log_date>2021-06-18T20:48:46.399+02:00</last_consecutive_log_date>
+				<interval/>
+				<thermostat id='bfe6665d0f05467b977b077b7b787cf1'/>
+				<period start_date="2022-03-10T18:52:08.027+01:00" end_date="2022-03-10T18:52:08.027+01:00">
+					<measurement log_date="2022-03-10T18:52:08.027+01:00">11.00</measurement>
+				</period>
+			</point_log>
+			<point_log id='083ba290a88245f3bd56957d6695dd55'>
+				<type>maximum_outdoor_unit_power_increase_temperature</type>
+				<unit>C</unit>
+				<updated_date>2022-03-10T18:51:35.435+01:00</updated_date>
+				<last_consecutive_log_date>2020-07-10T05:29:01.726+02:00</last_consecutive_log_date>
+				<interval/>
+				<thermostat id='564f724946434905b7d2b6c142e4ba67'/>
+				<period start_date="2022-03-10T18:51:35.435+01:00" end_date="2022-03-10T18:51:35.435+01:00">
+					<measurement log_date="2022-03-10T18:51:35.435+01:00">43.00</measurement>
+				</period>
+			</point_log>
+			<point_log id='08b3982eb0e445e79001228b879db934'>
+				<type>first_fan_enabled</type>
+				<unit></unit>
+				<updated_date>2022-03-10T19:02:55.817+01:00</updated_date>
+				<last_consecutive_log_date>2020-07-09T14:28:46.073+02:00</last_consecutive_log_date>
+				<interval/>
+				<dip_switch id='c90363c157d84f3cb34ec9fa0ad4a1b1'/>
+				<period start_date="2022-03-10T19:02:55.817+01:00" end_date="2022-03-10T19:02:55.817+01:00">
+					<measurement log_date="2022-03-10T19:02:55.817+01:00">off</measurement>
+				</period>
+			</point_log>
+			<point_log id='09e461faff3a4abc9259f7c6e26ffcf0'>
+				<type>domestic_hot_water_state</type>
+				<unit></unit>
+				<updated_date>2022-03-10T18:58:40.724+01:00</updated_date>
+				<last_consecutive_log_date>2022-03-10T18:58:40.724+01:00</last_consecutive_log_date>
+				<interval/>
+				<boiler_state id='aad2f61001b345ca85e9dda8e0beba70'/>
+				<period start_date="2022-03-10T18:58:40.724+01:00" end_date="2022-03-10T18:58:40.724+01:00">
+					<measurement log_date="2022-03-10T18:58:40.724+01:00">off</measurement>
+				</period>
+			</point_log>
+			<point_log id='0a12b2e6991e4f42bf2912673547b156'>
+				<type>underfloor_heating</type>
+				<unit></unit>
+				<updated_date>2022-03-10T19:03:27.643+01:00</updated_date>
+				<last_consecutive_log_date>2020-07-09T14:28:26.128+02:00</last_consecutive_log_date>
+				<interval/>
+				<dip_switch id='d127367c661c4c3582b544a08b0c68ad'/>
+				<period start_date="2022-03-10T19:03:27.643+01:00" end_date="2022-03-10T19:03:27.643+01:00">
+					<measurement log_date="2022-03-10T19:03:27.643+01:00">off</measurement>
+				</period>
+			</point_log>
+			<point_log id='0b1f4d8bbbbd451bb5214a7f592124e5'>
+				<type>intended_boiler_temperature</type>
+				<unit>C</unit>
+				<updated_date>2022-03-10T07:14:11.022+01:00</updated_date>
+				<last_consecutive_log_date>2022-03-10T07:14:11.022+01:00</last_consecutive_log_date>
+				<interval/>
+				<thermo_meter id='1d0d91857e4042ec9180e2bc78898d13'/>
+				<period start_date="2022-03-10T07:14:11.022+01:00" end_date="2022-03-10T07:14:11.022+01:00">
+					<measurement log_date="2022-03-10T07:14:11.022+01:00">0.00</measurement>
+				</period>
+			</point_log>
+			<point_log id='10cea8565cd343768a6867c47c0300c6'>
+				<type>maximum_outdoor_unit_temperature</type>
+				<unit>C</unit>
+				<updated_date>2022-03-10T18:51:25.148+01:00</updated_date>
+				<last_consecutive_log_date>2020-07-09T14:28:06.192+02:00</last_consecutive_log_date>
+				<interval/>
+				<thermostat id='333ef91f62d94f78ad7b9bedaecc71f2'/>
+				<period start_date="2022-03-10T18:51:25.148+01:00" end_date="2022-03-10T18:51:25.148+01:00">
+					<measurement log_date="2022-03-10T18:51:25.148+01:00">47.00</measurement>
+				</period>
+			</point_log>
+			<point_log id='1365f71019794971bbb06ebd881b7c84'>
+				<type>internal_pump_heating_lead_time</type>
+				<unit>s</unit>
+				<updated_date>2022-03-10T18:51:11.992+01:00</updated_date>
+				<last_consecutive_log_date>2020-07-09T14:27:25.659+02:00</last_consecutive_log_date>
+				<interval/>
+				<timer id='881f3c1377bc4efda8c78409a18ebe55'/>
+				<period start_date="2022-03-10T18:51:11.992+01:00" end_date="2022-03-10T18:51:11.992+01:00">
+					<measurement log_date="2022-03-10T18:51:11.992+01:00">60</measurement>
+				</period>
+			</point_log>
+			<point_log id='188ba49897614157a0b2723087058010'>
+				<type>hibernation_enabled</type>
+				<unit></unit>
+				<updated_date>2022-03-10T19:03:27.624+01:00</updated_date>
+				<last_consecutive_log_date>2020-07-09T14:28:22.042+02:00</last_consecutive_log_date>
+				<interval/>
+				<dip_switch id='53a892b70e7a4f01a6174415509e8590'/>
+				<period start_date="2022-03-10T19:03:27.624+01:00" end_date="2022-03-10T19:03:27.624+01:00">
+					<measurement log_date="2022-03-10T19:03:27.624+01:00">off</measurement>
+				</period>
+			</point_log>
+			<point_log id='1a94ecad909b40848efdce89197bae6d'>
+				<type>modulation_level</type>
+				<unit></unit>
+				<updated_date>2022-03-10T19:00:40.066+01:00</updated_date>
+				<last_consecutive_log_date>2022-03-10T04:18:58.547+01:00</last_consecutive_log_date>
+				<interval/>
+				<modulation_level id='8862e6a7a98842928028e3f14493de8b'/>
+				<period start_date="2022-03-10T19:00:40.066+01:00" end_date="2022-03-10T19:00:40.066+01:00">
+					<measurement log_date="2022-03-10T19:00:40.066+01:00">0.00</measurement>
+				</period>
+			</point_log>
+			<point_log id='1d03fff43bf640f998150fabc2aa7522'>
+				<type>elga_status_code</type>
+				<unit></unit>
+				<updated_date>2022-03-10T19:03:26.975+01:00</updated_date>
+				<last_consecutive_log_date>2022-03-10T07:58:46.609+01:00</last_consecutive_log_date>
+				<interval/>
+				<status_code id='91eb08ab048d4f8c947399a64a2e618b'/>
+				<period start_date="2022-03-10T19:03:26.975+01:00" end_date="2022-03-10T19:03:26.975+01:00">
+					<measurement log_date="2022-03-10T19:03:26.975+01:00">2</measurement>
+				</period>
+			</point_log>
+			<point_log id='1e2304cab4b14e80a91d30f733509659'>
+				<type>outdoor_temperature_used</type>
+				<unit></unit>
+				<updated_date>2022-03-10T19:02:55.805+01:00</updated_date>
+				<last_consecutive_log_date>2020-07-09T14:28:40.296+02:00</last_consecutive_log_date>
+				<interval/>
+				<dip_switch id='cbbc6155ab0945248c08fb6c08be2e64'/>
+				<period start_date="2022-03-10T19:02:55.805+01:00" end_date="2022-03-10T19:02:55.805+01:00">
+					<measurement log_date="2022-03-10T19:02:55.805+01:00">on</measurement>
+				</period>
+			</point_log>
+			<point_log id='24b48396d2c24a7089fd3a3f0476fe3d'>
+				<type>elga_outdoor_unit_fault_code</type>
+				<unit></unit>
+				<updated_date>2022-03-10T19:03:23.488+01:00</updated_date>
+				<last_consecutive_log_date>2020-07-10T05:29:03.330+02:00</last_consecutive_log_date>
+				<interval/>
+				<fault_code id='310985c85e5e42238c4ae63180e8ed2c'/>
+				<period start_date="2022-03-10T19:03:23.488+01:00" end_date="2022-03-10T19:03:23.488+01:00">
+					<measurement log_date="2022-03-10T19:03:23.488+01:00">0</measurement>
+				</period>
+			</point_log>
+			<point_log id='25e405154876410cbb760583417206bb'>
+				<type>thermostat_supports_cooling</type>
+				<unit></unit>
+				<updated_date>2022-03-10T19:03:27.599+01:00</updated_date>
+				<last_consecutive_log_date>2020-08-08T10:01:07.520+02:00</last_consecutive_log_date>
+				<interval/>
+				<dip_switch id='cdcb69e61cf7452dad650f828827fc3c'/>
+				<period start_date="2022-03-10T19:03:27.599+01:00" end_date="2022-03-10T19:03:27.599+01:00">
+					<measurement log_date="2022-03-10T19:03:27.599+01:00">on</measurement>
+				</period>
+			</point_log>
+			<point_log id='292c77f567194b14a0e7c3d63b340e66'>
+				<type>maximum_cooling_supply_temperature</type>
+				<unit>C</unit>
+				<updated_date>2022-03-10T18:51:53.457+01:00</updated_date>
+				<last_consecutive_log_date>2020-07-09T14:27:52.988+02:00</last_consecutive_log_date>
+				<interval/>
+				<thermostat id='82b1c7dcc6674568af1dbace5e64af8b'/>
+				<period start_date="2022-03-10T18:51:53.457+01:00" end_date="2022-03-10T18:51:53.457+01:00">
+					<measurement log_date="2022-03-10T18:51:53.457+01:00">21.00</measurement>
+				</period>
+			</point_log>
+			<point_log id='2e0289df2c7f4b66b8a4f562658a6903'>
+				<type>domestic_hot_water_comfort_mode</type>
+				<unit></unit>
+				<updated_date>2022-03-02T17:48:17.871+01:00</updated_date>
+				<last_consecutive_log_date>2021-06-18T19:48:06.123+02:00</last_consecutive_log_date>
+				<interval/>
+				<domestic_hot_water_toggle id='29fb663d576a46c79d629826edff95f0'/>
+				<period start_date="2022-03-02T17:48:17.871+01:00" end_date="2022-03-02T17:48:17.871+01:00">
+					<measurement log_date="2022-03-02T17:48:17.871+01:00">on</measurement>
+				</period>
+			</point_log>
+			<point_log id='375a05154d6647148cf393ac8b2c8b65'>
+				<type>refrigerent_in_temperature</type>
+				<unit>C</unit>
+				<updated_date>2022-03-10T19:03:13.936+01:00</updated_date>
+				<last_consecutive_log_date>2022-03-10T18:59:41.657+01:00</last_consecutive_log_date>
+				<interval/>
+				<thermo_meter id='d26080b9f53246c08ff76d20e162670a'/>
+				<period start_date="2022-03-10T19:03:13.936+01:00" end_date="2022-03-10T19:03:13.936+01:00">
+					<measurement log_date="2022-03-10T19:03:13.936+01:00">23.00</measurement>
+				</period>
+			</point_log>
+			<interval_log id='38e63c9a554249a9848053ad0ef8f148'>
+				<type>burner_operation_time</type>
+				<unit>s</unit>
+				<updated_date>2022-03-10T18:00:00+01:00</updated_date>
+				<last_consecutive_log_date>2022-03-10T17:00:00+01:00</last_consecutive_log_date>
+				<interval>PT1H</interval>
+				<interval_chrono_meter id='afda7f45daef401d9a0b651846933815'/>
+				<period start_date="2022-03-10T18:00:00+01:00" end_date="2022-03-10T18:00:00+01:00" interval="PT1H">
+					<measurement log_date="2022-03-10T18:00:00+01:00">66</measurement>
+				</period>
+			</interval_log>
+			<point_log id='3ad82db986354586b9a0b63ffe9685d6'>
+				<type>slave_boiler_state</type>
+				<unit></unit>
+				<updated_date>2022-03-10T19:03:05.441+01:00</updated_date>
+				<last_consecutive_log_date>2022-03-10T07:58:53.378+01:00</last_consecutive_log_date>
+				<interval/>
+				<boiler_state id='a5d3ae6bd1474d4ebf506f405bb94b06'/>
+				<period start_date="2022-03-10T19:03:05.441+01:00" end_date="2022-03-10T19:03:05.441+01:00">
+					<measurement log_date="2022-03-10T19:03:05.441+01:00">off</measurement>
+				</period>
+			</point_log>
+			<point_log id='3f1313a814ec4614be4e709e659a4f8d'>
+				<type>boiler_installed</type>
+				<unit></unit>
+				<updated_date>2022-03-10T19:02:55.820+01:00</updated_date>
+				<last_consecutive_log_date>2020-07-09T14:28:47.551+02:00</last_consecutive_log_date>
+				<interval/>
+				<dip_switch id='d3abfcd0012e4b47af6d69911031f7ab'/>
+				<period start_date="2022-03-10T19:02:55.820+01:00" end_date="2022-03-10T19:02:55.820+01:00">
+					<measurement log_date="2022-03-10T19:02:55.820+01:00">on</measurement>
+				</period>
+			</point_log>
+			<point_log id='40e35727c7b947f48099b5221633474c'>
+				<type>compressor_state</type>
+				<unit></unit>
+				<updated_date>2022-03-10T19:03:20.412+01:00</updated_date>
+				<last_consecutive_log_date>2022-03-10T04:19:06.754+01:00</last_consecutive_log_date>
+				<interval/>
+				<boiler_state id='1efb6c04052e4defbe429d6440c285c6'/>
+				<period start_date="2022-03-10T19:03:20.412+01:00" end_date="2022-03-10T19:03:20.412+01:00">
+					<measurement log_date="2022-03-10T19:03:20.412+01:00">off</measurement>
+				</period>
+			</point_log>
+			<point_log id='48f202225fb94f0b96540d97e65397c7'>
+				<type>temperature</type>
+				<unit>C</unit>
+				<updated_date></updated_date>
+				<last_consecutive_log_date></last_consecutive_log_date>
+				<interval>PT3H</interval>
+				<thermo_meter id='167efda4780e4fa8bbc8f588f4708fa2'/>
+			</point_log>
+			<point_log id='56c09638ead640a5a7b6864a6a1db81b'>
+				<type>weather_dependent_regulation</type>
+				<unit></unit>
+				<updated_date>2022-03-10T19:02:55.799+01:00</updated_date>
+				<last_consecutive_log_date>2020-07-09T14:28:37.344+02:00</last_consecutive_log_date>
+				<interval/>
+				<dip_switch id='60c6512c9b9249199ca4adb48ab30e4e'/>
+				<period start_date="2022-03-10T19:02:55.799+01:00" end_date="2022-03-10T19:02:55.799+01:00">
+					<measurement log_date="2022-03-10T19:02:55.799+01:00">off</measurement>
+				</period>
+			</point_log>
+			<point_log id='5cd62cb4ac5a4067859f074a9a0eeb66'>
+				<type>minimum_heating_supply_temperature</type>
+				<unit>C</unit>
+				<updated_date>2022-03-10T18:51:45.258+01:00</updated_date>
+				<last_consecutive_log_date>2020-07-09T14:27:54.422+02:00</last_consecutive_log_date>
+				<interval/>
+				<thermostat id='9d9f24a42c514c99887d85091ba46d74'/>
+				<period start_date="2022-03-10T18:51:45.258+01:00" end_date="2022-03-10T18:51:45.258+01:00">
+					<measurement log_date="2022-03-10T18:51:45.258+01:00">40.00</measurement>
+				</period>
+			</point_log>
+			<point_log id='5f0c73d239254abea42bdf1cf02bd7de'>
+				<type>intended_central_heating_state</type>
+				<unit></unit>
+				<updated_date>2022-03-10T07:14:23.490+01:00</updated_date>
+				<last_consecutive_log_date>2022-03-10T07:14:23.490+01:00</last_consecutive_log_date>
+				<interval/>
+				<boiler_state id='72ac57601ea7410381c889a1f58b191c'/>
+				<period start_date="2022-03-10T07:14:23.490+01:00" end_date="2022-03-10T07:14:23.490+01:00">
+					<measurement log_date="2022-03-10T07:14:23.490+01:00">off</measurement>
+				</period>
+			</point_log>
+			<point_log id='6c6734ca9c52437ebdd012dc1c9237b6'>
+				<type>cooling_lower_offset</type>
+				<unit>C</unit>
+				<updated_date>2022-03-10T18:51:54.652+01:00</updated_date>
+				<last_consecutive_log_date>2021-07-15T14:56:23.167+02:00</last_consecutive_log_date>
+				<interval/>
+				<temperature_offset id='c2c422292b904217a49eb2ebb64139fa'/>
+				<period start_date="2022-03-10T18:51:54.652+01:00" end_date="2022-03-10T18:51:54.652+01:00">
+					<measurement log_date="2022-03-10T18:51:54.652+01:00">1.00</measurement>
+				</period>
+			</point_log>
+			<point_log id='6e461af3d33245ffb49ffeaa2752a340'>
+				<type>serial_boiler_installation</type>
+				<unit></unit>
+				<updated_date>2022-03-10T19:02:55.814+01:00</updated_date>
+				<last_consecutive_log_date>2020-07-09T14:28:44.626+02:00</last_consecutive_log_date>
+				<interval/>
+				<dip_switch id='acc1480a9e1f4b02ad9d94f7cbd8c6d9'/>
+				<period start_date="2022-03-10T19:02:55.814+01:00" end_date="2022-03-10T19:02:55.814+01:00">
+					<measurement log_date="2022-03-10T19:02:55.814+01:00">on</measurement>
+				</period>
+			</point_log>
+			<point_log id='705e0e0f37574caabd69dd6a9db1620d'>
+				<type>minimum_cooling_supply_temperature</type>
+				<unit>C</unit>
+				<updated_date>2022-03-10T18:51:54.508+01:00</updated_date>
+				<last_consecutive_log_date>2020-07-09T14:27:51.551+02:00</last_consecutive_log_date>
+				<interval/>
+				<thermostat id='5304a8c3c39e42b990c9b057e880f8a4'/>
+				<period start_date="2022-03-10T18:51:54.508+01:00" end_date="2022-03-10T18:51:54.508+01:00">
+					<measurement log_date="2022-03-10T18:51:54.508+01:00">17.00</measurement>
+				</period>
+			</point_log>
+			<point_log id='72e0439587ac443c8880f35543c12834'>
+				<type>internal_pump_cooling_lead_time</type>
+				<unit>s</unit>
+				<updated_date>2022-03-10T18:50:38.763+01:00</updated_date>
+				<last_consecutive_log_date>2020-07-10T05:28:58.206+02:00</last_consecutive_log_date>
+				<interval/>
+				<timer id='7ccb6bc94f1948ee9f16ecfb5c80d719'/>
+				<period start_date="2022-03-10T18:50:38.763+01:00" end_date="2022-03-10T18:50:38.763+01:00">
+					<measurement log_date="2022-03-10T18:50:38.763+01:00">120</measurement>
+				</period>
+			</point_log>
+			<point_log id='78125fc1129b404782f7cf08c1a72401'>
+				<type>external_pump_cooling_lead_time</type>
+				<unit>s</unit>
+				<updated_date>2022-03-10T18:50:29.536+01:00</updated_date>
+				<last_consecutive_log_date>2020-07-10T05:28:58.417+02:00</last_consecutive_log_date>
+				<interval/>
+				<timer id='68a4b6945cbb49e0b1629ae6a44da34b'/>
+				<period start_date="2022-03-10T18:50:29.536+01:00" end_date="2022-03-10T18:50:29.536+01:00">
+					<measurement log_date="2022-03-10T18:50:29.536+01:00">120</measurement>
+				</period>
+			</point_log>
+			<point_log id='7a088fe1ff4d44d5a03be6f1ddb69b1a'>
+				<type>external_pump_heating_lead_time</type>
+				<unit>s</unit>
+				<updated_date>2022-03-10T18:51:00.507+01:00</updated_date>
+				<last_consecutive_log_date>2021-07-15T14:57:03.163+02:00</last_consecutive_log_date>
+				<interval/>
+				<timer id='cd3755b4f6454aa482f5603edc7c7019'/>
+				<period start_date="2022-03-10T18:51:00.507+01:00" end_date="2022-03-10T18:51:00.507+01:00">
+					<measurement log_date="2022-03-10T18:51:00.507+01:00">60</measurement>
+				</period>
+			</point_log>
+			<point_log id='7a90e2fb40a34176a94e408957c5c27c'>
+				<type>temperature_sensor_enabled</type>
+				<unit></unit>
+				<updated_date>2022-03-10T19:02:55.812+01:00</updated_date>
+				<last_consecutive_log_date>2020-07-09T14:28:43.155+02:00</last_consecutive_log_date>
+				<interval/>
+				<dip_switch id='74fab0d973c049e09f3514141f58c0ef'/>
+				<period start_date="2022-03-10T19:02:55.812+01:00" end_date="2022-03-10T19:02:55.812+01:00">
+					<measurement log_date="2022-03-10T19:02:55.812+01:00">off</measurement>
+				</period>
+			</point_log>
+			<point_log id='7d79610e27234506b0220b7e1a14eb3a'>
+				<type>open_therm_oem_fault_code</type>
+				<unit></unit>
+				<updated_date>2022-03-02T17:48:17.669+01:00</updated_date>
+				<last_consecutive_log_date>2021-06-18T20:15:20.896+02:00</last_consecutive_log_date>
+				<interval/>
+				<fault_code id='6e268f4aa86e4cc0a29c084d00c8319b'/>
+				<period start_date="2022-03-02T17:48:17.669+01:00" end_date="2022-03-02T17:48:17.669+01:00">
+					<measurement log_date="2022-03-02T17:48:17.669+01:00">0</measurement>
+				</period>
+			</point_log>
+			<point_log id='7e6f7d5dfdd84b5ca8287d0f30944e8b'>
+				<type>thermostat_enabled</type>
+				<unit></unit>
+				<updated_date>2022-03-10T19:03:27.593+01:00</updated_date>
+				<last_consecutive_log_date>2020-07-09T14:28:16.761+02:00</last_consecutive_log_date>
+				<interval/>
+				<dip_switch id='5f729e9aa96c4e33ad866f2efe41e694'/>
+				<period start_date="2022-03-10T19:03:27.593+01:00" end_date="2022-03-10T19:03:27.593+01:00">
+					<measurement log_date="2022-03-10T19:03:27.593+01:00">off</measurement>
+				</period>
+			</point_log>
+			<point_log id='80737def763544d797ce2ecebbaaf606'>
+				<type>input_contacts_installed</type>
+				<unit></unit>
+				<updated_date>2022-03-10T19:02:55.802+01:00</updated_date>
+				<last_consecutive_log_date>2020-07-09T14:28:38.738+02:00</last_consecutive_log_date>
+				<interval/>
+				<dip_switch id='4d79c04aa75340519aca29545955bf76'/>
+				<period start_date="2022-03-10T19:02:55.802+01:00" end_date="2022-03-10T19:02:55.802+01:00">
+					<measurement log_date="2022-03-10T19:02:55.802+01:00">on</measurement>
+				</period>
+			</point_log>
+			<point_log id='8bbc4ca809b84a41b6c6115a8ccacecf'>
+				<type>night_reduction_setpoint</type>
+				<unit>C</unit>
+				<updated_date>2022-03-10T18:52:04.533+01:00</updated_date>
+				<last_consecutive_log_date>2020-07-10T05:28:59.268+02:00</last_consecutive_log_date>
+				<interval/>
+				<thermostat id='7c4e5837e0474ad3888e97cf21a51670'/>
+				<period start_date="2022-03-10T18:52:04.533+01:00" end_date="2022-03-10T18:52:04.533+01:00">
+					<measurement log_date="2022-03-10T18:52:04.533+01:00">19.00</measurement>
+				</period>
+			</point_log>
+			<point_log id='9556ad80c44b48459e297eeca0720cc3'>
+				<type>boiler_temperature</type>
+				<unit>C</unit>
+				<updated_date>2022-03-10T19:02:40.695+01:00</updated_date>
+				<last_consecutive_log_date>2022-03-10T19:02:40.695+01:00</last_consecutive_log_date>
+				<interval>PT1H</interval>
+				<thermo_meter id='8eafb561fafb42ef8305eae670851e4a'/>
+				<period start_date="2022-03-10T19:02:40.695+01:00" end_date="2022-03-10T19:02:40.695+01:00">
+					<measurement log_date="2022-03-10T19:02:40.695+01:00">22.79</measurement>
+				</period>
+			</point_log>
+			<point_log id='a45bc7ff672748328d3f83e6a4808ea3'>
+				<type>open_therm_slave_oem_fault_code</type>
+				<unit></unit>
+				<updated_date>2022-03-10T19:03:21.028+01:00</updated_date>
+				<last_consecutive_log_date>2021-06-18T20:05:30.832+02:00</last_consecutive_log_date>
+				<interval/>
+				<fault_code id='3af7b55915d841808e61d89a7663b7a2'/>
+				<period start_date="2022-03-10T19:03:21.028+01:00" end_date="2022-03-10T19:03:21.028+01:00">
+					<measurement log_date="2022-03-10T19:03:21.028+01:00">0</measurement>
+				</period>
+			</point_log>
+			<point_log id='a6e3ad5afe8e4c6c9feafbd95f221a3a'>
+				<type>second_fan_enabled</type>
+				<unit></unit>
+				<updated_date>2022-03-10T19:02:55.808+01:00</updated_date>
+				<last_consecutive_log_date>2020-07-09T14:28:41.739+02:00</last_consecutive_log_date>
+				<interval/>
+				<dip_switch id='769ba34f091e4fe4a0718ed34defea99'/>
+				<period start_date="2022-03-10T19:02:55.808+01:00" end_date="2022-03-10T19:02:55.808+01:00">
+					<measurement log_date="2022-03-10T19:02:55.808+01:00">off</measurement>
+				</period>
+			</point_log>
+			<point_log id='acedb4c2dd3d49039768c23832f7b599'>
+				<type>refrigerent_out_temperature</type>
+				<unit>C</unit>
+				<updated_date>2022-03-10T19:03:33.179+01:00</updated_date>
+				<last_consecutive_log_date>2020-07-09T14:27:08.393+02:00</last_consecutive_log_date>
+				<interval/>
+				<thermo_meter id='ce44bfc81c5b4f2d82331c48b548aae7'/>
+				<period start_date="2022-03-10T19:03:33.179+01:00" end_date="2022-03-10T19:03:33.179+01:00">
+					<measurement log_date="2022-03-10T19:03:33.179+01:00">0.00</measurement>
+				</period>
+			</point_log>
+			<point_log id='af12fd7e384c4081b3700f7fc424ac79'>
+				<type>domestic_hot_water_setpoint</type>
+				<unit>C</unit>
+				<updated_date>2022-03-02T17:48:18.016+01:00</updated_date>
+				<last_consecutive_log_date>2020-07-10T05:28:53.712+02:00</last_consecutive_log_date>
+				<interval/>
+				<thermo_meter id='dec96976f5f14d97a6cc290f9110e5ee'/>
+				<period start_date="2022-03-02T17:48:18.016+01:00" end_date="2022-03-02T17:48:18.016+01:00">
+					<measurement log_date="2022-03-02T17:48:18.016+01:00">60.00</measurement>
+				</period>
+			</point_log>
+			<point_log id='b4629113c7b44a43a3ba634fc054279c'>
+				<type>boiler_enabled</type>
+				<unit></unit>
+				<updated_date>2022-03-10T19:03:27.614+01:00</updated_date>
+				<last_consecutive_log_date>2020-07-09T14:28:20.699+02:00</last_consecutive_log_date>
+				<interval/>
+				<dip_switch id='a8d50bc1b02c4453acbf78c484da2ed0'/>
+				<period start_date="2022-03-10T19:03:27.614+01:00" end_date="2022-03-10T19:03:27.614+01:00">
+					<measurement log_date="2022-03-10T19:03:27.614+01:00">off</measurement>
+				</period>
+			</point_log>
+			<point_log id='bbfaf21ad4e14ca3be4ba9b508047d6b'>
+				<type>cooling_state</type>
+				<unit></unit>
+				<updated_date>2022-03-02T17:48:17.865+01:00</updated_date>
+				<last_consecutive_log_date>2021-08-13T16:16:06.313+02:00</last_consecutive_log_date>
+				<interval/>
+				<boiler_state id='f613e055261943f4987856badb3fb0ae'/>
+				<period start_date="2022-03-02T17:48:17.865+01:00" end_date="2022-03-02T17:48:17.865+01:00">
+					<measurement log_date="2022-03-02T17:48:17.865+01:00">off</measurement>
+				</period>
+			</point_log>
+			<point_log id='bf9870695c254ead9edc22f9abe52260'>
+				<type>minimum_boiler_off_time</type>
+				<unit>s</unit>
+				<updated_date>2022-03-10T18:51:42.554+01:00</updated_date>
+				<last_consecutive_log_date>2020-07-09T14:28:00.562+02:00</last_consecutive_log_date>
+				<interval/>
+				<timer id='a783fff6c496488cbee3d8b43fd5be7e'/>
+				<period start_date="2022-03-10T18:51:42.554+01:00" end_date="2022-03-10T18:51:42.554+01:00">
+					<measurement log_date="2022-03-10T18:51:42.554+01:00">20</measurement>
+				</period>
+			</point_log>
+			<point_log id='c0a8e16b4efd465a88ed471330a99046'>
+				<type>maximum_outdoor_unit_steady_temperature</type>
+				<unit>C</unit>
+				<updated_date>2022-03-10T18:51:32.735+01:00</updated_date>
+				<last_consecutive_log_date>2020-07-09T14:28:04.609+02:00</last_consecutive_log_date>
+				<interval/>
+				<thermostat id='07c7b619be4242d6919733e6098a5b5e'/>
+				<period start_date="2022-03-10T18:51:32.735+01:00" end_date="2022-03-10T18:51:32.735+01:00">
+					<measurement log_date="2022-03-10T18:51:32.735+01:00">45.00</measurement>
+				</period>
+			</point_log>
+			<point_log id='c49b3ce126314dca848d51429a0ef2ea'>
+				<type>indoor_temperature_transition_time</type>
+				<unit>min</unit>
+				<updated_date>2022-03-10T18:52:06.142+01:00</updated_date>
+				<last_consecutive_log_date>2020-07-09T14:27:45.834+02:00</last_consecutive_log_date>
+				<interval/>
+				<timer id='1b79f533784742c796c973856b30909d'/>
+				<period start_date="2022-03-10T18:52:06.142+01:00" end_date="2022-03-10T18:52:06.142+01:00">
+					<measurement log_date="2022-03-10T18:52:06.142+01:00">5</measurement>
+				</period>
+			</point_log>
+			<point_log id='c65f2f2e30df4e1cb48bff1afc6bfaf5'>
+				<type>simultaneous_boiler_operation</type>
+				<unit></unit>
+				<updated_date>2022-03-10T19:03:27.637+01:00</updated_date>
+				<last_consecutive_log_date>2020-07-09T14:28:24.774+02:00</last_consecutive_log_date>
+				<interval/>
+				<dip_switch id='8eeb17de38da4b37992c7ef910592306'/>
+				<period start_date="2022-03-10T19:03:27.637+01:00" end_date="2022-03-10T19:03:27.637+01:00">
+					<measurement log_date="2022-03-10T19:03:27.637+01:00">on</measurement>
+				</period>
+			</point_log>
+			<point_log id='d368799910734cc89ed1e3d5d60363fc'>
+				<type>maximum_boiler_temperature</type>
+				<unit>C</unit>
+				<updated_date>2022-03-02T17:48:17.773+01:00</updated_date>
+				<last_consecutive_log_date>2020-07-10T05:28:53.525+02:00</last_consecutive_log_date>
+				<interval/>
+				<thermostat id='f7512e547d1c40f18d8911bd8bd1cce7'/>
+				<period start_date="2022-03-02T17:48:17.773+01:00" end_date="2022-03-02T17:48:17.773+01:00">
+					<measurement log_date="2022-03-02T17:48:17.773+01:00">60.00</measurement>
+				</period>
+			</point_log>
+			<point_log id='d517c9c0c3254926bd881c61b41f2185'>
+				<type>weather_dependent_maximum_supply_temperature</type>
+				<unit>C</unit>
+				<updated_date>2022-03-10T18:51:21.045+01:00</updated_date>
+				<last_consecutive_log_date>2021-07-15T15:55:13.072+02:00</last_consecutive_log_date>
+				<interval/>
+				<thermostat id='3636e8c24b764f9dae52ba36695ed476'/>
+				<period start_date="2022-03-10T18:51:21.045+01:00" end_date="2022-03-10T18:51:21.045+01:00">
+					<measurement log_date="2022-03-10T18:51:21.045+01:00">60.00</measurement>
+				</period>
+			</point_log>
+			<point_log id='d6e5970949cc4c48a1e20d830e3f9856'>
+				<type>central_heating_state</type>
+				<unit></unit>
+				<updated_date>2022-03-10T18:58:45.858+01:00</updated_date>
+				<last_consecutive_log_date>2022-03-10T18:58:45.858+01:00</last_consecutive_log_date>
+				<interval/>
+				<boiler_state id='93242446d05a443fa31dc19c56fef767'/>
+				<period start_date="2022-03-10T18:58:45.858+01:00" end_date="2022-03-10T18:58:45.858+01:00">
+					<measurement log_date="2022-03-10T18:58:45.858+01:00">off</measurement>
+				</period>
+			</point_log>
+			<point_log id='d703b335844c4d789b707534cb5dbd3e'>
+				<type>pump_lag_time</type>
+				<unit>s</unit>
+				<updated_date>2022-03-10T18:52:07.779+01:00</updated_date>
+				<last_consecutive_log_date>2021-07-15T15:56:51.601+02:00</last_consecutive_log_date>
+				<interval/>
+				<timer id='4ac8d9303b644429b5c5bae03a79470a'/>
+				<period start_date="2022-03-10T18:52:07.779+01:00" end_date="2022-03-10T18:52:07.779+01:00">
+					<measurement log_date="2022-03-10T18:52:07.779+01:00">30</measurement>
+				</period>
+			</point_log>
+			<point_log id='daac6bf095ce472082653bd4a57c58f9'>
+				<type>heatpump_minimum_outdoor_temperature</type>
+				<unit>C</unit>
+				<updated_date>2022-03-10T18:52:04.726+01:00</updated_date>
+				<last_consecutive_log_date>2021-06-02T15:40:22.531+02:00</last_consecutive_log_date>
+				<interval/>
+				<thermostat id='211f6996e8394d12a1f2cdb23b420a2c'/>
+				<period start_date="2022-03-10T18:52:04.726+01:00" end_date="2022-03-10T18:52:04.726+01:00">
+					<measurement log_date="2022-03-10T18:52:04.726+01:00">2.00</measurement>
+				</period>
+			</point_log>
+			<point_log id='db8123f44611441095c67a6c2ff84ec7'>
+				<type>open_therm_application_specific_fault_code</type>
+				<unit></unit>
+				<updated_date>2022-03-02T17:48:17.665+01:00</updated_date>
+				<last_consecutive_log_date>2019-07-22T11:08:35.538+02:00</last_consecutive_log_date>
+				<interval/>
+				<fault_code id='a649c0c0731b4efe8f971a2174d95901'/>
+				<period start_date="2022-03-02T17:48:17.665+01:00" end_date="2022-03-02T17:48:17.665+01:00">
+					<measurement log_date="2022-03-02T17:48:17.665+01:00">0</measurement>
+				</period>
+			</point_log>
+			<point_log id='dd64bb930f484e2e8047c5020ef9c185'>
+				<type>night_reduction</type>
+				<unit></unit>
+				<updated_date>2022-03-10T19:03:27.630+01:00</updated_date>
+				<last_consecutive_log_date>2020-07-09T14:28:23.418+02:00</last_consecutive_log_date>
+				<interval/>
+				<dip_switch id='ebf84b976e4e4cb39c5b553e7a9e5fc1'/>
+				<period start_date="2022-03-10T19:03:27.630+01:00" end_date="2022-03-10T19:03:27.630+01:00">
+					<measurement log_date="2022-03-10T19:03:27.630+01:00">off</measurement>
+				</period>
+			</point_log>
+			<point_log id='e5f051ef9b1542f2bf1b340fb6ba26d2'>
+				<type>cooling_upper_offset</type>
+				<unit>C</unit>
+				<updated_date>2022-03-10T18:51:55.065+01:00</updated_date>
+				<last_consecutive_log_date>2020-07-10T05:28:59.437+02:00</last_consecutive_log_date>
+				<interval/>
+				<temperature_offset id='7c77a680bb0645aeb325f196e4a3df57'/>
+				<period start_date="2022-03-10T18:51:55.065+01:00" end_date="2022-03-10T18:51:55.065+01:00">
+					<measurement log_date="2022-03-10T18:51:55.065+01:00">3.00</measurement>
+				</period>
+			</point_log>
+			<point_log id='e799a764479a4c4586179dd0760fe54e'>
+				<type>central_heater_water_pressure</type>
+				<unit>bar</unit>
+				<updated_date>2022-03-10T18:52:23.773+01:00</updated_date>
+				<last_consecutive_log_date>2022-03-10T07:52:15.530+01:00</last_consecutive_log_date>
+				<interval/>
+				<pressure_gauge id='01d551e4bb2b475a9463912a3fd887da'/>
+				<period start_date="2022-03-10T18:52:23.773+01:00" end_date="2022-03-10T18:52:23.773+01:00">
+					<measurement log_date="2022-03-10T18:52:23.773+01:00">0.50</measurement>
+				</period>
+			</point_log>
+			<point_log id='e7b09f30833c458c9291c7cf761f0068'>
+				<type>minimum_boiler_run_time</type>
+				<unit>s</unit>
+				<updated_date>2022-03-10T18:50:49.023+01:00</updated_date>
+				<last_consecutive_log_date>2020-07-10T05:29:01.284+02:00</last_consecutive_log_date>
+				<interval/>
+				<timer id='ecbec078612949e6aa050f2ad9b55958'/>
+				<period start_date="2022-03-10T18:50:49.023+01:00" end_date="2022-03-10T18:50:49.023+01:00">
+					<measurement log_date="2022-03-10T18:50:49.023+01:00">20</measurement>
+				</period>
+			</point_log>
+			<point_log id='e809f761a4c14287a852a8c727bbdc40'>
+				<type>boiler_activation_threshold</type>
+				<unit>Cmin</unit>
+				<updated_date>2022-03-10T18:51:14.452+01:00</updated_date>
+				<last_consecutive_log_date>2020-07-09T14:28:09.472+02:00</last_consecutive_log_date>
+				<interval/>
+				<threshold id='38eadee2fac04aaab6f8fac793560c82'/>
+				<period start_date="2022-03-10T18:51:14.452+01:00" end_date="2022-03-10T18:51:14.452+01:00">
+					<measurement log_date="2022-03-10T18:51:14.452+01:00">30</measurement>
+				</period>
+			</point_log>
+			<point_log id='e86e337316754960bca3bd5c3efe87c4'>
+				<type>heating_curve</type>
+				<unit></unit>
+				<updated_date>2022-03-10T19:03:27.610+01:00</updated_date>
+				<last_consecutive_log_date>2020-07-09T14:28:19.383+02:00</last_consecutive_log_date>
+				<interval/>
+				<dip_switch id='bc0af70f6ee24c6b9a48542b4e1cb7f0'/>
+				<period start_date="2022-03-10T19:03:27.610+01:00" end_date="2022-03-10T19:03:27.610+01:00">
+					<measurement log_date="2022-03-10T19:03:27.610+01:00">off</measurement>
+				</period>
+			</point_log>
+			<point_log id='f3eaebe5868840099b2f6eea9763dec3'>
+				<type>maximum_heating_supply_temperature</type>
+				<unit>C</unit>
+				<updated_date>2022-03-10T18:50:56.638+01:00</updated_date>
+				<last_consecutive_log_date>2020-07-10T05:29:00.729+02:00</last_consecutive_log_date>
+				<interval/>
+				<thermostat id='4b8a974d347f4cf1872a5bc07f613068'/>
+				<period start_date="2022-03-10T18:50:56.638+01:00" end_date="2022-03-10T18:50:56.638+01:00">
+					<measurement log_date="2022-03-10T18:50:56.638+01:00">70.00</measurement>
+				</period>
+			</point_log>
+			<point_log id='f9aff78878654f84a8344c0851d7cb33'>
+				<type>return_water_temperature</type>
+				<unit>C</unit>
+				<updated_date>2022-03-10T19:02:40.475+01:00</updated_date>
+				<last_consecutive_log_date>2022-03-10T19:02:40.475+01:00</last_consecutive_log_date>
+				<interval>PT1H</interval>
+				<thermo_meter id='a2847eec8a634ccdb70d3c1a79c60df7'/>
+				<period start_date="2022-03-10T19:02:40.475+01:00" end_date="2022-03-10T19:02:40.475+01:00">
+					<measurement log_date="2022-03-10T19:02:40.475+01:00">23.39</measurement>
+				</period>
+			</point_log>
+			<point_log id='fa0e3334f8d941cbbb040c5bf52fb2df'>
+				<type>outdoor_temperature</type>
+				<unit>C</unit>
+				<updated_date>2022-03-10T19:03:14.258+01:00</updated_date>
+				<last_consecutive_log_date>2022-03-10T19:03:14.258+01:00</last_consecutive_log_date>
+				<interval>PT3H</interval>
+				<thermo_meter id='8609fbdcab4b46e387953184f9878c28'/>
+				<period start_date="2022-03-10T19:03:14.258+01:00" end_date="2022-03-10T19:03:14.258+01:00">
+					<measurement log_date="2022-03-10T19:03:14.258+01:00">14.00</measurement>
+				</period>
+			</point_log>
+			<point_log id='9257714483e4423a8a3423072eda3d40'>
+				<type>cooling_enabled</type>
+				<unit></unit>
+				<updated_date>2022-11-02T03:57:23.207+01:00</updated_date>
+				<last_consecutive_log_date>2022-11-02T03:57:23.207+01:00</last_consecutive_log_date>
+				<interval/>
+				<cooling_toggle id='b556a934246f4d99979288841e7ee58a'/>
+				<period start_date="2022-11-02T03:57:23.207+01:00" end_date="2022-11-02T03:57:23.207+01:00">
+					<measurement log_date="2022-11-02T03:57:23.207+01:00">off</measurement>
+				</period>
+			</point_log>
+		</logs>
+		<actuator_functionalities>
+			<timer_functionality id='00a41642a7764d1d80fe37b0cd493730'>
+				<timer id='a783fff6c496488cbee3d8b43fd5be7e'/>
+				<updated_date>2022-03-10T18:51:42.554+01:00</updated_date>
+				<type>minimum_boiler_off_time</type>
+				<duration>20</duration>
+				<lower_bound>0</lower_bound>
+				<upper_bound>60</upper_bound>
+				<resolution>5</resolution>
+			</timer_functionality>
+			<timer_functionality id='0646e6e1204147668157d2a7c59ef3ee'>
+				<timer id='881f3c1377bc4efda8c78409a18ebe55'/>
+				<updated_date>2022-03-10T18:51:11.992+01:00</updated_date>
+				<type>internal_pump_heating_lead_time</type>
+				<duration>60</duration>
+				<lower_bound>10</lower_bound>
+				<upper_bound>240</upper_bound>
+				<resolution>10</resolution>
+			</timer_functionality>
+			<thermostat_functionality id='07699ce0bdd6491db490f0e15642ca43'>
+				<updated_date>2022-03-10T18:52:04.533+01:00</updated_date>
+				<type>night_reduction_setpoint</type>
+				<setpoint>19</setpoint>
+				<lower_bound>1</lower_bound>
+				<upper_bound>30</upper_bound>
+				<resolution>1</resolution>
+				<regulations/>
+				<thermostat id='7c4e5837e0474ad3888e97cf21a51670'/>
+			</thermostat_functionality>
+			<offset_functionality id='08ca8e47df01477ebfc92442fc327ba8'>
+				<temperature_offset id='c2c422292b904217a49eb2ebb64139fa'/>
+				<updated_date>2022-03-10T18:51:54.652+01:00</updated_date>
+				<type>cooling_lower_offset</type>
+				<offset>1</offset>
+			</offset_functionality>
+			<timer_functionality id='4538146f706d42098e9e233b0ef4d1bd'>
+				<timer id='cd3755b4f6454aa482f5603edc7c7019'/>
+				<updated_date>2022-03-10T18:51:00.507+01:00</updated_date>
+				<type>external_pump_heating_lead_time</type>
+				<duration>60</duration>
+				<lower_bound>10</lower_bound>
+				<upper_bound>240</upper_bound>
+				<resolution>10</resolution>
+			</timer_functionality>
+			<timer_functionality id='4823c26f51bc4b07928acbb5ef056ca1'>
+				<timer id='397304cc8cbe47798f41930b1d62b009'/>
+				<updated_date>2022-03-10T18:50:56.200+01:00</updated_date>
+				<type>hibernation_lead_time</type>
+				<duration>10</duration>
+				<lower_bound>1</lower_bound>
+				<upper_bound>24</upper_bound>
+				<resolution>1</resolution>
+			</timer_functionality>
+			<timer_functionality id='4d846b97eca946d78e6f3c0ae70f9db4'>
+				<timer id='ecbec078612949e6aa050f2ad9b55958'/>
+				<updated_date>2022-03-10T18:50:49.023+01:00</updated_date>
+				<type>minimum_boiler_run_time</type>
+				<duration>20</duration>
+				<lower_bound>0</lower_bound>
+				<upper_bound>60</upper_bound>
+				<resolution>5</resolution>
+			</timer_functionality>
+			<timer_functionality id='4e627a99dcf94bc086b31aa3a6de44b2'>
+				<timer id='1b79f533784742c796c973856b30909d'/>
+				<updated_date>2022-03-10T18:52:06.142+01:00</updated_date>
+				<type>indoor_temperature_transition_time</type>
+				<duration>5</duration>
+				<lower_bound>0</lower_bound>
+				<upper_bound>30</upper_bound>
+				<resolution>1</resolution>
+			</timer_functionality>
+			<threshold_functionality id='57fb489e615a46888a051712ca8954f2'>
+				<threshold id='38eadee2fac04aaab6f8fac793560c82'/>
+				<updated_date>2022-03-10T18:51:14.452+01:00</updated_date>
+				<type>boiler_activation_threshold</type>
+				<threshold>30</threshold>
+				<lower_bound>10</lower_bound>
+				<upper_bound>120</upper_bound>
+				<resolution>10</resolution>
+			</threshold_functionality>
+			<thermostat_functionality id='5b6c3a3cf0de4adc92e4aac0d93e1962'>
+				<updated_date>2022-03-10T18:51:45.258+01:00</updated_date>
+				<type>minimum_heating_supply_temperature</type>
+				<setpoint>40</setpoint>
+				<lower_bound>20</lower_bound>
+				<upper_bound>90</upper_bound>
+				<resolution>5</resolution>
+				<regulations/>
+				<thermostat id='9d9f24a42c514c99887d85091ba46d74'/>
+			</thermostat_functionality>
+			<timer_functionality id='631c67b8e2f2411d83ffa5a687f3b79b'>
+				<timer id='4ac8d9303b644429b5c5bae03a79470a'/>
+				<updated_date>2022-03-10T18:52:07.779+01:00</updated_date>
+				<type>pump_lag_time</type>
+				<duration>30</duration>
+				<lower_bound>10</lower_bound>
+				<upper_bound>240</upper_bound>
+				<resolution>10</resolution>
+			</timer_functionality>
+			<thermostat_functionality id='6385d825e10545bfabc3cd3574920b68'>
+				<updated_date>2022-03-10T18:51:53.457+01:00</updated_date>
+				<type>maximum_cooling_supply_temperature</type>
+				<setpoint>21</setpoint>
+				<lower_bound>5</lower_bound>
+				<upper_bound>25</upper_bound>
+				<resolution>1</resolution>
+				<regulations/>
+				<thermostat id='82b1c7dcc6674568af1dbace5e64af8b'/>
+			</thermostat_functionality>
+			<offset_functionality id='69ed60c3bc3846449e61dba62e71da40'>
+				<temperature_offset id='7c77a680bb0645aeb325f196e4a3df57'/>
+				<updated_date>2022-03-10T18:51:55.065+01:00</updated_date>
+				<type>cooling_upper_offset</type>
+				<offset>3</offset>
+			</offset_functionality>
+			<toggle_functionality id='700bd52a8729461bb0fdf6d055c08710'>
+				<domestic_hot_water_toggle id='29fb663d576a46c79d629826edff95f0'/>
+				<updated_date>2022-03-02T17:48:17.871+01:00</updated_date>
+				<type>domestic_hot_water_comfort_mode</type>
+				<state>on</state>
+			</toggle_functionality>
+			<timer_functionality id='8dcd68a78d704da8b0a61083d376223f'>
+				<timer id='68a4b6945cbb49e0b1629ae6a44da34b'/>
+				<updated_date>2022-03-10T18:50:29.536+01:00</updated_date>
+				<type>external_pump_cooling_lead_time</type>
+				<duration>120</duration>
+				<lower_bound>120</lower_bound>
+				<upper_bound>240</upper_bound>
+				<resolution>10</resolution>
+			</timer_functionality>
+			<thermostat_functionality id='965f1d814e594fb191268c47ff527022'>
+				<updated_date>2022-03-10T18:52:08.027+01:00</updated_date>
+				<type>boiler_minimum_outdoor_temperature</type>
+				<setpoint>11</setpoint>
+				<lower_bound>-10</lower_bound>
+				<upper_bound>40</upper_bound>
+				<resolution>1</resolution>
+				<regulations/>
+				<thermostat id='bfe6665d0f05467b977b077b7b787cf1'/>
+			</thermostat_functionality>
+			<thermostat_functionality id='9cee766c36c843288b9bc17628e2a5a7'>
+				<updated_date>2022-03-10T18:51:32.735+01:00</updated_date>
+				<type>maximum_outdoor_unit_steady_temperature</type>
+				<setpoint>45</setpoint>
+				<lower_bound>25</lower_bound>
+				<upper_bound>45</upper_bound>
+				<resolution>1</resolution>
+				<regulations/>
+				<thermostat id='07c7b619be4242d6919733e6098a5b5e'/>
+			</thermostat_functionality>
+			<thermostat_functionality id='9cfae18be05b4509b32d52571107f0ff'>
+				<updated_date>2022-03-10T18:51:21.045+01:00</updated_date>
+				<type>weather_dependent_maximum_supply_temperature</type>
+				<setpoint>60</setpoint>
+				<lower_bound>30</lower_bound>
+				<upper_bound>90</upper_bound>
+				<resolution>10</resolution>
+				<regulations/>
+				<thermostat id='3636e8c24b764f9dae52ba36695ed476'/>
+			</thermostat_functionality>
+			<thermostat_functionality id='a1f29fd4edae4894a74c0b8c523f8ef3'>
+				<updated_date>2022-03-10T18:51:54.508+01:00</updated_date>
+				<type>minimum_cooling_supply_temperature</type>
+				<setpoint>17</setpoint>
+				<lower_bound>5</lower_bound>
+				<upper_bound>25</upper_bound>
+				<resolution>1</resolution>
+				<regulations/>
+				<thermostat id='5304a8c3c39e42b990c9b057e880f8a4'/>
+			</thermostat_functionality>
+			<thermostat_functionality id='a67b1c7b6d2f403aba383a56ad3d8e0a'>
+				<updated_date>2022-03-10T18:51:25.148+01:00</updated_date>
+				<type>maximum_outdoor_unit_temperature</type>
+				<setpoint>47</setpoint>
+				<lower_bound>25</lower_bound>
+				<upper_bound>47</upper_bound>
+				<resolution>1</resolution>
+				<regulations/>
+				<thermostat id='333ef91f62d94f78ad7b9bedaecc71f2'/>
+			</thermostat_functionality>
+			<thermostat_functionality id='b6579ded90e7489ca51a48768c721eb0'>
+				<updated_date>2022-03-10T18:50:56.638+01:00</updated_date>
+				<type>maximum_heating_supply_temperature</type>
+				<setpoint>70</setpoint>
+				<lower_bound>20</lower_bound>
+				<upper_bound>90</upper_bound>
+				<resolution>5</resolution>
+				<regulations/>
+				<thermostat id='4b8a974d347f4cf1872a5bc07f613068'/>
+			</thermostat_functionality>
+			<thermostat_functionality id='c0d682baec2b45979720a0c4253665b0'>
+				<updated_date>2022-03-02T17:48:17.773+01:00</updated_date>
+				<type>maximum_boiler_temperature</type>
+				<setpoint>60</setpoint>
+				<lower_bound>0</lower_bound>
+				<upper_bound>100</upper_bound>
+				<resolution>1</resolution>
+				<regulations/>
+				<thermostat id='f7512e547d1c40f18d8911bd8bd1cce7'/>
+			</thermostat_functionality>
+			<thermostat_functionality id='c9b707c378b04420a55bdffe00e4f8f6'>
+				<updated_date>2022-03-10T18:52:04.726+01:00</updated_date>
+				<type>heatpump_minimum_outdoor_temperature</type>
+				<setpoint>2</setpoint>
+				<lower_bound>-16</lower_bound>
+				<upper_bound>4</upper_bound>
+				<resolution>1</resolution>
+				<regulations/>
+				<thermostat id='211f6996e8394d12a1f2cdb23b420a2c'/>
+			</thermostat_functionality>
+			<timer_functionality id='d24d209910e34533a95e361c8c66352c'>
+				<timer id='7ccb6bc94f1948ee9f16ecfb5c80d719'/>
+				<updated_date>2022-03-10T18:50:38.763+01:00</updated_date>
+				<type>internal_pump_cooling_lead_time</type>
+				<duration>120</duration>
+				<lower_bound>120</lower_bound>
+				<upper_bound>240</upper_bound>
+				<resolution>10</resolution>
+			</timer_functionality>
+			<thermostat_functionality id='f8b9ad4b594846628e305fdf7ff26b3e'>
+				<updated_date>2022-03-10T18:51:35.435+01:00</updated_date>
+				<type>maximum_outdoor_unit_power_increase_temperature</type>
+				<setpoint>43</setpoint>
+				<lower_bound>25</lower_bound>
+				<upper_bound>43</upper_bound>
+				<resolution>1</resolution>
+				<regulations/>
+				<thermostat id='564f724946434905b7d2b6c142e4ba67'/>
+			</thermostat_functionality>
+		</actuator_functionalities>
+	</appliance>
+	<appliance id='fb49af122f6e4b0f91267e1cf7666d6f'>
+		<name>Gateway</name>
+		<description>Container for variables logged about the Gateway in general.</description>
+		<type>gateway</type>
+		<created_date>2018-07-12T11:13:24.488+02:00</created_date>
+		<modified_date>2022-03-10T18:59:50.737+01:00</modified_date>
+		<deleted_date></deleted_date>
+		<groups/>
+		<logs>
+			<point_log id='170726b59a1c45f395dbc3d2920f9217'>
+				<type>lan_ip_address</type>
+				<unit></unit>
+				<updated_date>2022-03-10T18:58:30.167+01:00</updated_date>
+				<last_consecutive_log_date>2021-10-28T04:56:27+02:00</last_consecutive_log_date>
+				<interval/>
+				<network_address id='b4124ec2cee84ae182a6612e610e1690'/>
+				<period start_date="2022-03-10T18:58:30.167+01:00" end_date="2022-03-10T18:58:30.167+01:00">
+					<measurement log_date="2022-03-10T18:58:30.167+01:00">0.0.0.0</measurement>
+				</period>
+			</point_log>
+			<point_log id='2dfe41f254c74ce9a9e9aaff6be9dbe7'>
+				<type>signal_strength</type>
+				<unit>dBm</unit>
+				<updated_date>2022-03-10T18:59:50.695+01:00</updated_date>
+				<last_consecutive_log_date>2022-03-10T18:59:50.695+01:00</last_consecutive_log_date>
+				<interval/>
+				<signal_strength id='c61cb1657e7046f78f77f3a6a8bd4e01'/>
+				<period start_date="2022-03-10T18:59:50.695+01:00" end_date="2022-03-10T18:59:50.695+01:00">
+					<measurement log_date="2022-03-10T18:59:50.695+01:00">-56.00</measurement>
+				</period>
+			</point_log>
+			<point_log id='43466b056f2f457493b720430ba254c5'>
+				<type>wlan_state</type>
+				<unit></unit>
+				<updated_date>2022-03-10T18:59:50.696+01:00</updated_date>
+				<last_consecutive_log_date>2022-03-10T02:56:55.858+01:00</last_consecutive_log_date>
+				<interval/>
+				<network_state id='6fbd440a76444188adfcce9366e5e800'/>
+				<period start_date="2022-03-10T18:59:50.696+01:00" end_date="2022-03-10T18:59:50.696+01:00">
+					<measurement log_date="2022-03-10T18:59:50.696+01:00">up</measurement>
+				</period>
+			</point_log>
+			<point_log id='856cc738696245d1a580706b6db5574e'>
+				<type>wlan_ip_address</type>
+				<unit></unit>
+				<updated_date>2022-03-10T18:59:50.696+01:00</updated_date>
+				<last_consecutive_log_date>2022-03-10T02:56:55+01:00</last_consecutive_log_date>
+				<interval/>
+				<network_address id='936a423321184cf88cfc6c700e872230'/>
+				<period start_date="2022-03-10T18:59:50.696+01:00" end_date="2022-03-10T18:59:50.696+01:00">
+					<measurement log_date="2022-03-10T18:59:50.696+01:00">127.0.0.2</measurement>
+				</period>
+			</point_log>
+			<point_log id='aa949dbf9f654ba09d3f8bff22f91cd3'>
+				<type>gateway_mode</type>
+				<unit></unit>
+				<updated_date></updated_date>
+				<last_consecutive_log_date></last_consecutive_log_date>
+				<interval/>
+				<gateway_mode_control id='bfa38e00cc3d405b80dadfc05bea8a9b'/>
+			</point_log>
+			<point_log id='b41f590d2c06410dbe8be8e9f7b74deb'>
+				<type>link_quality</type>
+				<unit></unit>
+				<updated_date>2022-03-10T18:59:50.695+01:00</updated_date>
+				<last_consecutive_log_date>2022-03-10T18:59:50.695+01:00</last_consecutive_log_date>
+				<interval/>
+				<link_quality id='af0f81cc5ca844c492ef164e2c114508'/>
+				<period start_date="2022-03-10T18:59:50.695+01:00" end_date="2022-03-10T18:59:50.695+01:00">
+					<measurement log_date="2022-03-10T18:59:50.695+01:00">54</measurement>
+				</period>
+			</point_log>
+			<point_log id='e523c94b2efc445ba8bb26ec27152d6a'>
+				<type>lan_state</type>
+				<unit></unit>
+				<updated_date>2022-03-10T18:58:30.167+01:00</updated_date>
+				<last_consecutive_log_date>2019-07-22T11:03:31.494+02:00</last_consecutive_log_date>
+				<interval/>
+				<network_state id='af06c116bc7e4e7bbcac5b4d235bd2c8'/>
+				<period start_date="2022-03-10T18:58:30.167+01:00" end_date="2022-03-10T18:58:30.167+01:00">
+					<measurement log_date="2022-03-10T18:58:30.167+01:00">down</measurement>
+				</period>
+			</point_log>
+		</logs>
+		<actuator_functionalities>
+			<gateway_mode_control_functionality id='43a20461689e4536bcf02758b6a2c340'>
+				<gateway_mode_control id='bfa38e00cc3d405b80dadfc05bea8a9b'/>
+				<updated_date></updated_date>
+				<type>gateway_mode</type>
+				<mode>full</mode>
+				<allowed_modes>
+					<mode>setup</mode>
+					<mode>light</mode>
+					<mode>away</mode>
+					<mode>vacation</mode>
+					<mode/>
+					<mode>full</mode>
+					<mode>secure</mode>
+				</allowed_modes>
+			</gateway_mode_control_functionality>
+		</actuator_functionalities>
+	</appliance>
+	<template id='69699f9e8e584a12b5a803e724547ad2' tag="zone_preset_based_on_time_and_presence_with_override">
+		<name>Zone preset schedule template</name>
+		<description>Template for scheduling presets on a presence or time basis with the option to override the preset&apos;s setpoint/state.</description>
+		<single_actor>true</single_actor>
+		<created_date>2017-10-25T14:55:02.566+02:00</created_date>
+		<modified_date>2022-03-02T17:47:56.643+01:00</modified_date>
+		<deleted_date></deleted_date>
+		<objects>
+			<object name="zone" type="Location"/>
+		</objects>
+		<parameters>
+			<parameter name="presence" source="zone.presence" type="Boolean"/>
+			<parameter name="time" source="clock.weekTime" type="WeekTime"/>
+		</parameters>
+		<results>
+			<result name="state" type="OnOff" action="zone.iterateFunctionalities('RelayFunctionality')().switch(clock.addSeconds(null, 1), state)"/>
+			<result name="preset" type="Preset" action="zone.preset = preset"/>
+			<result name="setpoint" type="Number" action="zone.iterateFunctionalities('ThermostatFunctionality', 'thermostat')().setSetpoint(clock.addSeconds(null, 1), setpoint, setpoint)"/>
+			<result name="domestic_hot_water_state" type="OnOff" action="zone.iterateFunctionalities('ToggleFunctionality', 'domestic_hot_water_state')().switch(clock.addSeconds(null, 1), domestic_hot_water_state)"/>
+		</results>
+	</template>
+	<location id='d3ce834534114348be628b61b26d9220'>
+		<name>Living room</name>
+		<description>The room containing the (central) home thermostat.</description>
+		<type>livingroom</type>
+		<created_date>2019-07-22T11:03:38.853+02:00</created_date>
+		<modified_date>2022-03-10T19:01:01.344+01:00</modified_date>
+		<deleted_date></deleted_date>
+		<preset>home</preset>
+		<clients/>
+		<appliances>
+			<appliance id='ebd90df1ab334565b5895f37590ccff4'/>
+		</appliances>
+		<logs>
+			<point_log id='17367e62a10641f09c62555259917230'>
+				<type>thermostat</type>
+				<unit>C</unit>
+				<updated_date>2022-03-10T06:45:00.389+01:00</updated_date>
+				<last_consecutive_log_date>2022-03-02T06:45:00.397+01:00</last_consecutive_log_date>
+				<interval/>
+				<period start_date="2022-03-10T06:45:00.389+01:00" end_date="2022-03-10T06:45:00.389+01:00">
+					<measurement log_date="2022-03-10T06:45:00.389+01:00">19.50</measurement>
+				</period>
+			</point_log>
+			<point_log id='de702fce210440f488cc8269e3d10723'>
+				<type>temperature</type>
+				<unit></unit>
+				<updated_date>2022-03-10T19:01:01.330+01:00</updated_date>
+				<last_consecutive_log_date>2022-03-02T17:29:58.913+01:00</last_consecutive_log_date>
+				<interval>PT3H</interval>
+				<period start_date="2022-03-10T19:01:01.330+01:00" end_date="2022-03-10T19:01:01.330+01:00">
+					<measurement log_date="2022-03-10T19:01:01.330+01:00">20.93</measurement>
+				</period>
+			</point_log>
+		</logs>
+		<actuator_functionalities>
+			<thermostat_functionality id='913c4634ffce4cd8b2b921b148aae838'>
+				<updated_date>2022-03-10T06:45:00.348+01:00</updated_date>
+				<type>thermostat</type>
+				<setpoint>19.5</setpoint>
+				<lower_bound>4</lower_bound>
+				<upper_bound>30</upper_bound>
+				<resolution>0.1</resolution>
+				<regulations><ame_regulation id='1c8b1a395ed848a2a67d65996bf0bb75'/></regulations>
+				<cooling_allowed>true</cooling_allowed>
+				<preheating_allowed>true</preheating_allowed>
+				<control_state>off</control_state>
+				<regulation_control>active</regulation_control>
+			</thermostat_functionality>
+		</actuator_functionalities>
+	</location>
+	<ame_regulation id='1c8b1a395ed848a2a67d65996bf0bb75'>
+		<created_date>2019-07-22T11:03:37.635+02:00</created_date>
+		<modified_date>2022-03-02T17:48:09.912+01:00</modified_date>
+		<deleted_date></deleted_date>
+		<thermostat_functionalities>
+			<thermostat_functionality id='913c4634ffce4cd8b2b921b148aae838'/>
+			<thermostat_functionality id='9d718e17024446f296adecf2a1da9e18'/>
+		</thermostat_functionalities>
+		<heating_mode>economy</heating_mode>
+		<preheating>on</preheating>
+		<installation_size>unknown</installation_size>
+		<heating_type>unknown</heating_type>
+		<preheating_time_escalation_limit>120</preheating_time_escalation_limit>
+		<calculate_decentral_heat_demand>off</calculate_decentral_heat_demand>
+		<decentral_heat_demand_maximum_temperature>24</decentral_heat_demand_maximum_temperature>
+		<open_therm_boiler_activation_threshold>10</open_therm_boiler_activation_threshold>
+		<onoff_boiler_temperature_deadband>0.5</onoff_boiler_temperature_deadband>
+		<decentral_heat_demand_deadband>0.5</decentral_heat_demand_deadband>
+		<gradual_adhoc_heating_rate>1.5</gradual_adhoc_heating_rate>
+		<open_therm_low_outdoors_temperature_boiler_temperature_maximum>85</open_therm_low_outdoors_temperature_boiler_temperature_maximum>
+		<open_therm_high_outdoors_temperature_boiler_temperature_maximum>55</open_therm_high_outdoors_temperature_boiler_temperature_maximum>
+		<derivative_coefficient>0</derivative_coefficient>
+		<minimum_boiler_temperature>25</minimum_boiler_temperature>
+		<integral_coefficient_reduction_factor_during_preheating>7</integral_coefficient_reduction_factor_during_preheating>
+	</ame_regulation>
+	<rule id='dbc823ce5fa54eee85a8a822507a1de4'>
+		<name>Thermostat presets</name>
+		<description>Provides presets for a Location.</description>
+		<template id="c9a9744aad4646f5a1b02ed9d72191a3" tag="zone_setpoint_and_state_based_on_preset"/>
+		<active>true</active>
+		<created_date>2019-07-22T11:03:39.299+02:00</created_date>
+		<modified_date>2020-12-02T22:26:36.050+01:00</modified_date>
+		<deleted_date></deleted_date>
+		<directives>
+			<when preset="away"><then heating_setpoint="15" cooling_setpoint="25"/></when>
+			<when preset="no_frost"><then heating_setpoint="10" cooling_setpoint="30"/></when>
+			<when preset="vacation"><then heating_setpoint="15" cooling_setpoint="27"/></when>
+			<when preset="home"><then heating_setpoint="19.5" cooling_setpoint="23"/></when>
+			<when preset="asleep"><then heating_setpoint="19" cooling_setpoint="23"/></when>
+		</directives>
+		<contexts>
+			<context>
+				<zone><location id="d3ce834534114348be628b61b26d9220"/></zone>
+			</context>
+		</contexts>
+	</rule>
+	<module id='ef8f01b00b0945d28b42b12ae44eeb1b'>
+		<vendor_name>Plugwise</vendor_name>
+		<vendor_model>ThermoExtension</vendor_model>
+		<hardware_version>6539-1301-2304</hardware_version>
+		<firmware_version>2018-02-08T11:15:57+01:00</firmware_version>
+		<created_date>2017-08-29T08:24:38.164+02:00</created_date>
+		<modified_date>2019-07-22T11:08:07.986+02:00</modified_date>
+		<deleted_date></deleted_date>
+		<services/>
+		<protocols>
+			<thermo_extension id='668c0412fb2b420a80de9642b9f8a2f1'><thermo_touch id='af43990b4ca744cf8e9f9b5996190f6f'/><open_therm_boiler id='b2481333821543b0994b280c60395ba5'/></thermo_extension>
+		</protocols>
+	</module>
+	<location id='d34dfe6ab90b410c98068e75de3eb631'>
+		<name>Home</name>
+		<description></description>
+		<type>building</type>
+		<created_date>2017-10-25T14:55:03.100+02:00</created_date>
+		<modified_date>2022-03-10T18:52:07.240+01:00</modified_date>
+		<deleted_date></deleted_date>
+		<preset>home</preset>
+		<clients/>
+		<appliances/>
+		<logs>
+			<point_log id='19080fb9d9a94bd88a319419d285a56d'>
+				<type>weather_description</type>
+				<unit></unit>
+				<updated_date>2022-03-10T18:52:05+01:00</updated_date>
+				<last_consecutive_log_date>2022-03-10T18:52:05+01:00</last_consecutive_log_date>
+				<interval/>
+				<weather_descriptor id='acdffd53f1984f96b571bb4d6b7c6095'/>
+				<period start_date="2022-03-10T18:52:05+01:00" end_date="2022-03-10T18:52:05+01:00">
+					<measurement log_date="2022-03-10T18:52:05+01:00">cloudy</measurement>
+				</period>
+			</point_log>
+			<point_log id='67f6e7e97f6b47368f61460226ead4cb'>
+				<type>humidity</type>
+				<unit>RH</unit>
+				<updated_date>2022-03-10T18:52:05+01:00</updated_date>
+				<last_consecutive_log_date>2022-03-10T18:52:05+01:00</last_consecutive_log_date>
+				<interval>PT3H</interval>
+				<hygro_meter id='ec0d5294e3bf4e5e96054901fe25835a'/>
+				<period start_date="2022-03-10T18:52:05+01:00" end_date="2022-03-10T18:52:05+01:00">
+					<measurement log_date="2022-03-10T18:52:05+01:00">42.00</measurement>
+				</period>
+			</point_log>
+			<point_log id='837b147f4ce547388f76f7404cf1b6cc'>
+				<type>outdoor_temperature</type>
+				<unit>C</unit>
+				<updated_date>2022-03-10T18:52:05+01:00</updated_date>
+				<last_consecutive_log_date>2022-03-10T18:52:05+01:00</last_consecutive_log_date>
+				<interval>PT3H</interval>
+				<thermo_meter id='5702932dadad4591b77f8f30971ea0bf'/>
+				<period start_date="2022-03-10T18:52:05+01:00" end_date="2022-03-10T18:52:05+01:00">
+					<measurement log_date="2022-03-10T18:52:05+01:00">13.00</measurement>
+				</period>
+			</point_log>
+			<point_log id='a17661da905149eca734ba8b047fe177'>
+				<type>wind_vector</type>
+				<unit>m_s</unit>
+				<updated_date>2022-03-10T18:52:05+01:00</updated_date>
+				<last_consecutive_log_date>2022-03-10T18:52:05+01:00</last_consecutive_log_date>
+				<interval/>
+				<wind_vector id='b790ed1f2a0a4b629d13e0cd02f88821'/>
+				<period start_date="2022-03-10T18:52:05+01:00" end_date="2022-03-10T18:52:05+01:00">
+					<measurement log_date="2022-03-10T18:52:05+01:00">(3.60,120.00)</measurement>
+				</period>
+			</point_log>
+			<point_log id='e8d96f806c9746e9a47a3bc809e2438c'>
+				<type>solar_irradiance</type>
+				<unit>W_m2</unit>
+				<updated_date>2022-03-10T18:52:05+01:00</updated_date>
+				<last_consecutive_log_date>2022-03-10T18:52:05+01:00</last_consecutive_log_date>
+				<interval/>
+				<irradiance_meter id='3860fb2704834c3ba2bf9eb1840c7ca7'/>
+				<period start_date="2022-03-10T18:52:05+01:00" end_date="2022-03-10T18:52:05+01:00">
+					<measurement log_date="2022-03-10T18:52:05+01:00">0.00</measurement>
+				</period>
+			</point_log>
+		</logs>
+		<actuator_functionalities/>
+	</location>
+	<rule id='40e484ccfd644f1fa8b82f669091144a'>
+		<name>Thermostat schedule</name>
+		<description>Provides a week schedule for a Location.</description>
+		<template id="69699f9e8e584a12b5a803e724547ad2" tag="zone_preset_based_on_time_and_presence_with_override"/>
+		<active>true</active>
+		<created_date>2019-07-22T11:03:39.072+02:00</created_date>
+		<modified_date>2021-06-04T12:39:09.405+02:00</modified_date>
+		<deleted_date></deleted_date>
+		<directives>
+			<when time="[sa 23:00,mo 06:45)"><then preset="asleep"/></when>
+			<when time="[mo 06:45,tu 06:45)"><then preset="home"/></when>
+			<when time="[tu 06:45,we 06:45)"><then preset="home"/></when>
+			<when time="[we 06:45,th 06:45)"><then preset="home"/></when>
+			<when time="[th 06:45,fr 06:45)"><then preset="home"/></when>
+			<when time="[fr 06:45,su 08:30)"><then setpoint="21.5"/></when>
+			<when time="[su 22:45,mo 23:00)"><then preset="asleep"/></when>
+			<when time="[mo 23:00,th 23:00)"><then preset="asleep"/></when>
+			<when time="[th 23:00,fr 23:00)"><then preset="asleep"/></when>
+			<when time="[fr 23:00,we 23:00)"><then preset="asleep"/></when>
+			<when time="[we 23:00,tu 23:00)"><then preset="asleep"/></when>
+			<when time="[su 08:30,su 22:45)"><then preset="home"/></when>
+			<when time="[tu 23:00,sa 08:30)"><then preset="asleep"/></when>
+			<when time="[sa 08:30,sa 23:00)"><then preset="home"/></when>
+		</directives>
+		<contexts>
+			<context>
+				<zone><location id="d3ce834534114348be628b61b26d9220"/></zone>
+			</context>
+		</contexts>
+	</rule>
+	<template id='adb00662ec9c406fa75839cbd8d090da' tag="relay_state_based_on_time_and_preset">
+		<name>Relay schedule template</name>
+		<description>Template for scheduling relays on a time and preset basis.</description>
+		<single_actor>false</single_actor>
+		<created_date>2017-10-25T14:55:02.453+02:00</created_date>
+		<modified_date>2022-03-02T17:47:56.614+01:00</modified_date>
+		<deleted_date></deleted_date>
+		<objects>
+			<object name="direct_object" type="DirectObject"/>
+			<object name="zone" type="Location"/>
+		</objects>
+		<parameters>
+			<parameter name="preset" source="zone.preset" type="Preset"/>
+			<parameter name="time" source="clock.weekTime" type="WeekTime"/>
+		</parameters>
+		<results>
+			<result name="state" type="OnOff" action="direct_object.iterateFunctionalities('RelayFunctionality')().state = state"/>
+		</results>
+	</template>
+	<template id='3ad9f4216ff14ed794b3198871b6a9dc' tag="relay_state_based_on_time_preset_temperature_and_humidity">
+		<name>Relay schedule template</name>
+		<description>Template for scheduling relays on a time, solar time, preset, temperature and humidity basis.</description>
+		<single_actor>false</single_actor>
+		<created_date>2021-10-28T04:56:49.928+02:00</created_date>
+		<modified_date>2022-03-02T17:47:56.618+01:00</modified_date>
+		<deleted_date></deleted_date>
+		<objects>
+			<object name="direct_object" type="DirectObject"/>
+			<object name="zone" type="Location"/>
+		</objects>
+		<parameters>
+			<parameter name="time" source="clock.weekTime" type="WeekTime"/>
+			<parameter name="humidity" source="zone.humidity" type="Number"/>
+			<parameter name="preset" source="zone.preset" type="Preset"/>
+			<parameter name="temperature" source="zone.temperature" type="Number"/>
+		</parameters>
+		<results>
+			<result name="state" type="OnOff" action="direct_object.iterateFunctionalities('RelayFunctionality')().state = state"/>
+		</results>
+	</template>
+	<template id='53ef215f5cb44e8fb2895c6945d86586' tag="default_client_presence_based_on_pointlog">
+		<name>Client, Pointlog presence template</name>
+		<description>Template for setting default client presence based on point_logs</description>
+		<single_actor>false</single_actor>
+		<created_date>2017-10-25T14:55:02.608+02:00</created_date>
+		<modified_date>2022-03-02T17:47:56.649+01:00</modified_date>
+		<deleted_date></deleted_date>
+		<objects>
+			<object name="client" type="Client"/>
+			<object name="point_log" type="PointLogFunctionality"/>
+		</objects>
+		<parameters>
+			<parameter name="point_log_recently_used" source="point_log.wasRecentlyOn(null, 1800)" type="Boolean"/>
+		</parameters>
+		<results>
+			<result name="presence" type="Boolean" action="client.setPresence(presence, 'rule')"/>
+		</results>
+	</template>
+	<module id='c5539bb850ea40cab886354b10bec43b'>
+		<vendor_name></vendor_name>
+		<vendor_model></vendor_model>
+		<hardware_version></hardware_version>
+		<firmware_version></firmware_version>
+		<created_date>2017-10-25T14:55:02.841+02:00</created_date>
+		<modified_date>2020-07-10T05:28:40.857+02:00</modified_date>
+		<deleted_date></deleted_date>
+		<services>
+			<irradiance_meter id='3860fb2704834c3ba2bf9eb1840c7ca7' log_type='solar_irradiance'>
+				<functionalities><point_log id='e8d96f806c9746e9a47a3bc809e2438c'/></functionalities>
+			</irradiance_meter>
+			<thermo_meter id='5702932dadad4591b77f8f30971ea0bf' log_type='outdoor_temperature'>
+				<functionalities><point_log id='837b147f4ce547388f76f7404cf1b6cc'/></functionalities>
+			</thermo_meter>
+			<weather_descriptor id='acdffd53f1984f96b571bb4d6b7c6095' log_type='weather_description'>
+				<functionalities><point_log id='19080fb9d9a94bd88a319419d285a56d'/></functionalities>
+			</weather_descriptor>
+			<wind_vector id='b790ed1f2a0a4b629d13e0cd02f88821' log_type='wind_vector'>
+				<functionalities><point_log id='a17661da905149eca734ba8b047fe177'/></functionalities>
+			</wind_vector>
+			<hygro_meter id='ec0d5294e3bf4e5e96054901fe25835a' log_type='humidity'>
+				<functionalities><point_log id='67f6e7e97f6b47368f61460226ead4cb'/></functionalities>
+			</hygro_meter>
+		</services>
+		<protocols>
+			<weather_feed id='5b75838ca51c48f1853f71b23f9c4191'/>
+		</protocols>
+	</module>
+</domain_objects>

--- a/userdata/anna_elga_2_cooling/core.domain_objects.xml
+++ b/userdata/anna_elga_2_cooling/core.domain_objects.xml
@@ -1875,6 +1875,7 @@
 				<regulations><ame_regulation id='1c8b1a395ed848a2a67d65996bf0bb75'/></regulations>
 				<cooling_allowed>true</cooling_allowed>
 				<preheating_allowed>true</preheating_allowed>
+				<control_state>off</control_state>
 				<regulation_control>active</regulation_control>
 			</thermostat_functionality>
 		</actuator_functionalities>

--- a/userdata/anna_elga_2_cooling/core.domain_objects.xml
+++ b/userdata/anna_elga_2_cooling/core.domain_objects.xml
@@ -1875,7 +1875,6 @@
 				<regulations><ame_regulation id='1c8b1a395ed848a2a67d65996bf0bb75'/></regulations>
 				<cooling_allowed>true</cooling_allowed>
 				<preheating_allowed>true</preheating_allowed>
-				<control_state>off</control_state>
 				<regulation_control>active</regulation_control>
 			</thermostat_functionality>
 		</actuator_functionalities>

--- a/userdata/anna_elga_2_schedule_off/core.domain_objects.xml
+++ b/userdata/anna_elga_2_schedule_off/core.domain_objects.xml
@@ -1875,6 +1875,7 @@
 				<regulations><ame_regulation id='1c8b1a395ed848a2a67d65996bf0bb75'/></regulations>
 				<cooling_allowed>true</cooling_allowed>
 				<preheating_allowed>true</preheating_allowed>
+				<control_state>off</control_state>
 				<regulation_control>active</regulation_control>
 			</thermostat_functionality>
 		</actuator_functionalities>

--- a/userdata/anna_elga_2_schedule_off/core.domain_objects.xml
+++ b/userdata/anna_elga_2_schedule_off/core.domain_objects.xml
@@ -1875,7 +1875,6 @@
 				<regulations><ame_regulation id='1c8b1a395ed848a2a67d65996bf0bb75'/></regulations>
 				<cooling_allowed>true</cooling_allowed>
 				<preheating_allowed>true</preheating_allowed>
-				<control_state>off</control_state>
 				<regulation_control>active</regulation_control>
 			</thermostat_functionality>
 		</actuator_functionalities>


### PR DESCRIPTION
Plus some other fixes:
- add missing item-count.
- Line-up test-data-json headers ("entities"/"device_zones" -> devices") with the fixture-headers.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

Based on the comprehensive summary, here are the release notes:

- **Documentation**
	- Updated CHANGELOG.md with ongoing improvements for Anna_Elga_2 userdata
	- Refreshed test data configurations across multiple fixtures

- **Data Updates**
	- Modified item counts across various device configurations
	- Updated firmware versions for some devices
	- Adjusted sensor and device state values in test data

- **Test Updates**
	- Updated test assertions to reflect new data configurations
	- Modified expected entity item counts in test methods

These changes primarily focus on improving data consistency and test coverage for the Plugwise system, with an emphasis on the Anna and Elga device configurations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->