### PR TITLE
Avoid None-init for smile_version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## Ongoing
+
+- Avoid None-init for smile_version [#699](https://github.com/plugwise/python-plugwise/pull/699)
+
 ## v1.7.0
 
 - Continuous improvements [#678](https://github.com/plugwise/python-plugwise/pull/678)

--- a/plugwise/__init__.py
+++ b/plugwise/__init__.py
@@ -80,7 +80,7 @@ class Smile(SmileComm):
         self.smile_model_id: str | None = None
         self.smile_name: str = NONE
         self.smile_type: str = NONE
-        self.smile_version: Version | None = None
+        self.smile_version: Version = Version("0.0.0")
         self.smile_zigbee_mac_address: str | None = None
 
     @property

--- a/plugwise/__init__.py
+++ b/plugwise/__init__.py
@@ -115,7 +115,7 @@ class Smile(SmileComm):
         """
         return not self.smile_legacy
 
-    async def connect(self) -> Version | None:
+    async def connect(self) -> Version:
         """Connect to the Plugwise Gateway and determine its name, type, version, and other data."""
         result = await self._request(DOMAIN_OBJECTS)
         # Work-around for Stretch fw 2.7.18

--- a/plugwise/helper.py
+++ b/plugwise/helper.py
@@ -86,7 +86,7 @@ class SmileHelper(SmileCommon):
         self.smile_mac_address: str | None
         self.smile_model: str
         self.smile_model_id: str | None
-        self.smile_version: version.Version | None
+        self.smile_version: version.Version
         SmileCommon.__init__(self)
 
     def _all_appliances(self) -> None:

--- a/plugwise/helper.py
+++ b/plugwise/helper.py
@@ -786,7 +786,7 @@ class SmileHelper(SmileCommon):
 
         # Handle missing control_state in regulation_mode off for firmware >= 3.2.0 (issue #776)
         # In newer firmware versions, default to "off" when control_state is not present
-        if self.smile_version is not None:
+        if self.smile_version != version.Version("0.0.0"):
             if self.smile_version >= version.parse("3.2.0"):
                 return "off"
 

--- a/plugwise/legacy/helper.py
+++ b/plugwise/legacy/helper.py
@@ -72,7 +72,7 @@ class SmileLegacyHelper(SmileCommon):
         self.gw_entities: dict[str, GwEntityData] = {}
         self.smile_mac_address: str | None
         self.smile_model: str
-        self.smile_version: Version | None
+        self.smile_version: Version
         self.smile_zigbee_mac_address: str | None
         SmileCommon.__init__(self)
 

--- a/plugwise/legacy/smile.py
+++ b/plugwise/legacy/smile.py
@@ -50,7 +50,7 @@ class SmileLegacyAPI(SmileLegacyData):
         smile_model: str,
         smile_name: str,
         smile_type: str,
-        smile_version: Version | None,
+        smile_version: Version,
         smile_zigbee_mac_address: str | None,
     ) -> None:
         """Set the constructor for this class."""

--- a/plugwise/smile.py
+++ b/plugwise/smile.py
@@ -59,7 +59,7 @@ class SmileAPI(SmileData):
         smile_model_id: str | None,
         smile_name: str,
         smile_type: str,
-        smile_version: Version | None,
+        smile_version: Version,
     ) -> None:
         """Set the constructor for this class."""
         self._cooling_present = _cooling_present


### PR DESCRIPTION
Suggestion by Coderabbitai from the last P: init `self.smile_name` other than `None`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

- **New Features**
	- No new user-facing features added

- **Bug Fixes**
	- Improved version handling across multiple Plugwise library components
	- Ensured consistent version initialization and type safety

- **Refactor**
	- Updated type declarations for `smile_version` to always require a valid Version object
	- Removed nullable version parameters in multiple classes
	- Standardized version initialization with a default "0.0.0" value

- **Chores**
	- Enhanced type safety and code consistency in the Plugwise library
	- Added a new "Ongoing" section to the changelog highlighting improvements in version handling
<!-- end of auto-generated comment: release notes by coderabbit.ai -->