### PR TITLE
Solve pytest-depreciation-warning

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -556,3 +556,10 @@ forced-separate = [
 ]
 combine-as-imports = true
 split-on-trailing-comma = false
+
+[tool.pytest.ini_options]
+testpaths = [
+    "tests",
+]
+asyncio_default_fixture_loop_scope = "session"
+asyncio_mode = "strict"


### PR DESCRIPTION
Solution for: `PytestDeprecationWarning: The configuration option "asyncio_default_fixture_loop_scope" is unset.`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
	- Updated pytest configuration to specify test directory location
	- Enhanced asyncio testing settings with strict mode and session-scoped event loop

<!-- end of auto-generated comment: release notes by coderabbit.ai -->