### PR TITLE
Cleanup packaging config

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,5 @@
 [build-system]
-requires = ["setuptools~=78.1", "wheel~=0.45.0"]
+requires = ["setuptools~=78.1"]
 build-backend = "setuptools.build_meta"
 
 [project]
@@ -38,7 +38,6 @@ dependencies    = [
 "Bug Reports" = "https://github.com/plugwise/python-plugwise/issues"
 
 [tool.setuptools]
-platforms = ["any"]
 include-package-data = true
 
 [tool.setuptools.package-data]

--- a/requirements_commit.txt
+++ b/requirements_commit.txt
@@ -1,4 +1,4 @@
-# Import from setup.py
+# Import from project.dependencies
 -e .
 # Minimal requirements for committing
 # Versioning omitted (leave this up to HA-core)

--- a/requirements_test.txt
+++ b/requirements_test.txt
@@ -1,4 +1,4 @@
-# Import from setup.py
+# Import from project.dependencies
 -e .
 # Versioning omitted (leave this up to HA-core)
 pytest-asyncio

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,9 +1,4 @@
-# Setuptools v62.3 doesn't support editable installs with just 'pyproject.toml' (PEP 660).
 # Added Codespell since pre-commit doesn't process args correctly (and python3.11 and toml prevent using pyproject.toml) check #277 (/#278) for details
-# Keep this file until it does!
-
-[metadata]
-url = https://github.com/plugwise/python-plugwise
 
 [codespell]
 # Most of the ignores from HA-Core upstream

--- a/setup.py
+++ b/setup.py
@@ -1,5 +1,0 @@
-"""Plugwise module setup."""
-
-from setuptools import setup
-
-setup()


### PR DESCRIPTION
- Remove `wheel` from build dependencies. Setuptools started vendoring / using it's own version a while ago, so this isn't needed anymore.
- Remove `platforms = ["any"]`. It's basically unused / redundant at this point. The metadata also includes a better classifier with `Operating System :: OS Independent`.
- Remove `setup.cfg` + `setup.py`. Editable installs with only `pyproject.toml` configs have been supported for some time now.
- Remove `metadata.url`. The url is already present as `project.urls."Source code"`.