### PR TITLE
Rename smile to api

### DIFF
--- a/tests/test_anna.py
+++ b/tests/test_anna.py
@@ -18,18 +18,18 @@ class TestPlugwiseAnna(TestPlugwise):  # pylint: disable=attribute-defined-outsi
         self.smile_setup = "anna_v4"
 
         testdata = await self.load_testdata(SMILE_TYPE, self.smile_setup)
-        server, smile, client = await self.connect_wrapper()
-        assert smile.smile.hostname == "smile000000"
+        server, api, client = await self.connect_wrapper()
+        assert api.smile.hostname == "smile000000"
 
         self.validate_test_basics(
             _LOGGER,
-            smile,
+            api,
             smile_version="4.0.15",
         )
 
-        await self.device_test(smile, "2020-04-05 00:00:01", testdata)
-        assert smile.gateway_id == "0466eae8520144c78afb29628384edeb"
-        assert smile._last_active["eb5309212bf5407bb143e5bfa3b18aee"] == "Standaard"
+        await self.device_test(api, "2020-04-05 00:00:01", testdata)
+        assert api.gateway_id == "0466eae8520144c78afb29628384edeb"
+        assert api._last_active["eb5309212bf5407bb143e5bfa3b18aee"] == "Standaard"
         assert self.entity_items == 60
         assert not self.notifications
 
@@ -38,19 +38,15 @@ class TestPlugwiseAnna(TestPlugwise):  # pylint: disable=attribute-defined-outsi
         assert not self._cooling_enabled
 
         result = await self.tinker_thermostat(
-            smile,
+            api,
             "eb5309212bf5407bb143e5bfa3b18aee",
             schedule_on=False,
             good_schedules=["Standaard", "Thuiswerken"],
         )
         assert result
-        result = await self.tinker_temp_offset(
-            smile, "01b85360fdd243d0aaad4d6ac2a5ba7e"
-        )
+        result = await self.tinker_temp_offset(api, "01b85360fdd243d0aaad4d6ac2a5ba7e")
         assert result
-        result = await self.tinker_temp_offset(
-            smile, "0466eae8520144c78afb29628384edeb"
-        )
+        result = await self.tinker_temp_offset(api, "0466eae8520144c78afb29628384edeb")
         assert not result
 
         # Now change some data and change directory reading xml from
@@ -61,20 +57,18 @@ class TestPlugwiseAnna(TestPlugwise):  # pylint: disable=attribute-defined-outsi
 
         self.smile_setup = "updated/anna_v4"
         await self.device_test(
-            smile, "2020-04-05 00:00:01", testdata_updated, initialize=False
+            api, "2020-04-05 00:00:01", testdata_updated, initialize=False
         )
 
-        await smile.close_connection()
+        await api.close_connection()
         await self.disconnect(server, client)
 
-        server, smile, client = await self.connect_wrapper(raise_timeout=True)
+        server, api, client = await self.connect_wrapper(raise_timeout=True)
         # Reset self.smile_setup
         self.smile_setup = "anna_v4"
-        await self.device_test(
-            smile, "2020-04-05 00:00:01", testdata, skip_testing=True
-        )
+        await self.device_test(api, "2020-04-05 00:00:01", testdata, skip_testing=True)
         result = await self.tinker_thermostat(
-            smile,
+            api,
             "eb5309212bf5407bb143e5bfa3b18aee",
             schedule_on=False,
             good_schedules=["Standaard", "Thuiswerken"],
@@ -83,13 +77,13 @@ class TestPlugwiseAnna(TestPlugwise):  # pylint: disable=attribute-defined-outsi
         assert result
 
         result = await self.tinker_temp_offset(
-            smile,
+            api,
             "01b85360fdd243d0aaad4d6ac2a5ba7e",
             unhappy=True,
         )
         assert result
 
-        await smile.close_connection()
+        await api.close_connection()
         await self.disconnect(server, client)
 
     @pytest.mark.asyncio
@@ -98,28 +92,28 @@ class TestPlugwiseAnna(TestPlugwise):  # pylint: disable=attribute-defined-outsi
         self.smile_setup = "anna_v4_dhw"
 
         testdata = await self.load_testdata(SMILE_TYPE, self.smile_setup)
-        server, smile, client = await self.connect_wrapper()
-        assert smile.smile.hostname == "smile000000"
+        server, api, client = await self.connect_wrapper()
+        assert api.smile.hostname == "smile000000"
 
         self.validate_test_basics(
             _LOGGER,
-            smile,
+            api,
             smile_version="4.0.15",
         )
 
-        await self.device_test(smile, "2020-04-05 00:00:01", testdata)
-        assert smile._last_active["eb5309212bf5407bb143e5bfa3b18aee"] == "Standaard"
+        await self.device_test(api, "2020-04-05 00:00:01", testdata)
+        assert api._last_active["eb5309212bf5407bb143e5bfa3b18aee"] == "Standaard"
         assert self.entity_items == 60
         assert not self.notifications
 
         result = await self.tinker_thermostat(
-            smile,
+            api,
             "eb5309212bf5407bb143e5bfa3b18aee",
             schedule_on=False,
             good_schedules=["Standaard", "Thuiswerken"],
         )
         assert result
-        await smile.close_connection()
+        await api.close_connection()
         await self.disconnect(server, client)
 
     @pytest.mark.asyncio
@@ -128,26 +122,26 @@ class TestPlugwiseAnna(TestPlugwise):  # pylint: disable=attribute-defined-outsi
         self.smile_setup = "anna_v4_no_tag"
 
         testdata = await self.load_testdata(SMILE_TYPE, self.smile_setup)
-        server, smile, client = await self.connect_wrapper()
-        assert smile.smile.hostname == "smile000000"
+        server, api, client = await self.connect_wrapper()
+        assert api.smile.hostname == "smile000000"
 
         self.validate_test_basics(
             _LOGGER,
-            smile,
+            api,
             smile_version="4.0.15",
         )
 
-        await self.device_test(smile, "2020-04-05 00:00:01", testdata)
+        await self.device_test(api, "2020-04-05 00:00:01", testdata)
         assert self.entity_items == 60
 
         result = await self.tinker_thermostat(
-            smile,
+            api,
             "eb5309212bf5407bb143e5bfa3b18aee",
             schedule_on=False,
             good_schedules=["Standaard", "Thuiswerken"],
         )
         assert result
-        await smile.close_connection()
+        await api.close_connection()
         await self.disconnect(server, client)
 
     @pytest.mark.asyncio
@@ -156,25 +150,25 @@ class TestPlugwiseAnna(TestPlugwise):  # pylint: disable=attribute-defined-outsi
         self.smile_setup = "anna_without_boiler_fw441"
 
         testdata = await self.load_testdata(SMILE_TYPE, self.smile_setup)
-        server, smile, client = await self.connect_wrapper()
-        assert smile.smile.hostname == "smile000000"
+        server, api, client = await self.connect_wrapper()
+        assert api.smile.hostname == "smile000000"
 
         self.validate_test_basics(
             _LOGGER,
-            smile,
+            api,
             smile_version="4.4.1",
         )
 
-        await self.device_test(smile, "2022-05-16 00:00:01", testdata)
-        assert smile._last_active["c34c6864216446528e95d88985e714cc"] == "Normaal"
+        await self.device_test(api, "2022-05-16 00:00:01", testdata)
+        assert api._last_active["c34c6864216446528e95d88985e714cc"] == "Normaal"
         assert self.entity_items == 41
         assert not self.notifications
 
         result = await self.tinker_thermostat(
-            smile, "c34c6864216446528e95d88985e714cc", good_schedules=["Normaal"]
+            api, "c34c6864216446528e95d88985e714cc", good_schedules=["Normaal"]
         )
         assert result
-        await smile.close_connection()
+        await api.close_connection()
         await self.disconnect(server, client)
 
     @pytest.mark.asyncio
@@ -184,18 +178,18 @@ class TestPlugwiseAnna(TestPlugwise):  # pylint: disable=attribute-defined-outsi
         self.smile_setup = "anna_heatpump_heating"
 
         testdata = await self.load_testdata(SMILE_TYPE, self.smile_setup)
-        server, smile, client = await self.connect_wrapper()
-        assert smile.smile.hostname == "smile000000"
+        server, api, client = await self.connect_wrapper()
+        assert api.smile.hostname == "smile000000"
 
         self.validate_test_basics(
             _LOGGER,
-            smile,
+            api,
             smile_version="4.0.15",
         )
 
-        await self.device_test(smile, "2020-04-12 00:00:01", testdata)
-        assert smile.gateway_id == "015ae9ea3f964e668e490fa39da3870b"
-        assert smile._last_active["c784ee9fdab44e1395b8dee7d7a497d5"] == "standaard"
+        await self.device_test(api, "2020-04-12 00:00:01", testdata)
+        assert api.gateway_id == "015ae9ea3f964e668e490fa39da3870b"
+        assert api._last_active["c784ee9fdab44e1395b8dee7d7a497d5"] == "standaard"
         assert self.entity_items == 69
         assert not self.notifications
         assert self.cooling_present
@@ -204,7 +198,7 @@ class TestPlugwiseAnna(TestPlugwise):  # pylint: disable=attribute-defined-outsi
 
         with pytest.raises(pw_exceptions.PlugwiseError) as exc:
             await self.tinker_thermostat(
-                smile,
+                api,
                 "c784ee9fdab44e1395b8dee7d7a497d5",
                 good_schedules=[
                     "standaard",
@@ -224,10 +218,10 @@ class TestPlugwiseAnna(TestPlugwise):  # pylint: disable=attribute-defined-outsi
 
         self.smile_setup = "updated/anna_heatpump_heating"
         await self.device_test(
-            smile, "2020-04-13 00:00:01", testdata_updated, initialize=False
+            api, "2020-04-13 00:00:01", testdata_updated, initialize=False
         )
         assert self.entity_items == 66
-        await smile.close_connection()
+        await api.close_connection()
         await self.disconnect(server, client)
 
     @pytest.mark.asyncio
@@ -241,17 +235,17 @@ class TestPlugwiseAnna(TestPlugwise):  # pylint: disable=attribute-defined-outsi
         self.smile_setup = "anna_heatpump_cooling"
 
         testdata = await self.load_testdata(SMILE_TYPE, self.smile_setup)
-        server, smile, client = await self.connect_wrapper()
-        assert smile.smile.hostname == "smile000000"
+        server, api, client = await self.connect_wrapper()
+        assert api.smile.hostname == "smile000000"
 
         self.validate_test_basics(
             _LOGGER,
-            smile,
+            api,
             smile_version="4.0.15",
         )
 
-        await self.device_test(smile, "2020-04-19 00:00:01", testdata)
-        assert smile._last_active["c784ee9fdab44e1395b8dee7d7a497d5"] == "standaard"
+        await self.device_test(api, "2020-04-19 00:00:01", testdata)
+        assert api._last_active["c784ee9fdab44e1395b8dee7d7a497d5"] == "standaard"
         assert self.entity_items == 66
         assert self.cooling_present
         assert not self.notifications
@@ -261,7 +255,7 @@ class TestPlugwiseAnna(TestPlugwise):  # pylint: disable=attribute-defined-outsi
 
         with pytest.raises(pw_exceptions.PlugwiseError) as exc:
             await self.tinker_thermostat(
-                smile,
+                api,
                 "c784ee9fdab44e1395b8dee7d7a497d5",
                 good_schedules=[
                     "standaard",
@@ -272,7 +266,7 @@ class TestPlugwiseAnna(TestPlugwise):  # pylint: disable=attribute-defined-outsi
                 "ERROR raised good schedule to standaard: %s", exc.value
             )  # pragma: no cover
 
-        await smile.close_connection()
+        await api.close_connection()
         await self.disconnect(server, client)
 
     @pytest.mark.asyncio
@@ -288,22 +282,22 @@ class TestPlugwiseAnna(TestPlugwise):  # pylint: disable=attribute-defined-outsi
         self.smile_setup = "anna_heatpump_cooling_fake_firmware"
 
         testdata = await self.load_testdata(SMILE_TYPE, self.smile_setup)
-        server, smile, client = await self.connect_wrapper()
-        assert smile.smile.hostname == "smile000000"
+        server, api, client = await self.connect_wrapper()
+        assert api.smile.hostname == "smile000000"
 
         self.validate_test_basics(
             _LOGGER,
-            smile,
+            api,
             smile_version="4.10.10",
         )
 
-        await self.device_test(smile, "2020-04-19 00:00:01", testdata)
+        await self.device_test(api, "2020-04-19 00:00:01", testdata)
         assert self.entity_items == 66
         assert self.cooling_present
         assert self._cooling_enabled
         assert self._cooling_active
 
-        await smile.close_connection()
+        await api.close_connection()
         await self.disconnect(server, client)
 
     @pytest.mark.asyncio
@@ -313,23 +307,23 @@ class TestPlugwiseAnna(TestPlugwise):  # pylint: disable=attribute-defined-outsi
         self.smile_setup = "anna_elga_no_cooling"
 
         testdata = await self.load_testdata(SMILE_TYPE, self.smile_setup)
-        server, smile, client = await self.connect_wrapper()
-        assert smile.smile.hostname == "smile000000"
+        server, api, client = await self.connect_wrapper()
+        assert api.smile.hostname == "smile000000"
 
         self.validate_test_basics(
             _LOGGER,
-            smile,
+            api,
             smile_version="4.0.15",
         )
 
-        await self.device_test(smile, "2020-04-12 00:00:01", testdata)
-        assert smile.gateway_id == "015ae9ea3f964e668e490fa39da3870b"
-        assert smile._last_active["c784ee9fdab44e1395b8dee7d7a497d5"] == "standaard"
+        await self.device_test(api, "2020-04-12 00:00:01", testdata)
+        assert api.gateway_id == "015ae9ea3f964e668e490fa39da3870b"
+        assert api._last_active["c784ee9fdab44e1395b8dee7d7a497d5"] == "standaard"
         assert self.entity_items == 65
         assert not self.notifications
         assert not self.cooling_present
 
-        await smile.close_connection()
+        await api.close_connection()
         await self.disconnect(server, client)
 
     @pytest.mark.asyncio
@@ -338,27 +332,26 @@ class TestPlugwiseAnna(TestPlugwise):  # pylint: disable=attribute-defined-outsi
         self.smile_setup = "anna_elga_2"
 
         testdata = await self.load_testdata(SMILE_TYPE, self.smile_setup)
-        server, smile, client = await self.connect_wrapper()
-        assert smile.smile.hostname == "smile000000"
+        server, api, client = await self.connect_wrapper()
+        assert api.smile.hostname == "smile000000"
 
         self.validate_test_basics(
             _LOGGER,
-            smile,
+            api,
             smile_version="4.4.1",
         )
 
-        await self.device_test(smile, "2022-03-13 00:00:01", testdata)
+        await self.device_test(api, "2022-03-13 00:00:01", testdata)
         assert (
-            smile._last_active["d3ce834534114348be628b61b26d9220"]
-            == THERMOSTAT_SCHEDULE
+            api._last_active["d3ce834534114348be628b61b26d9220"] == THERMOSTAT_SCHEDULE
         )
         assert self.entity_items == 61
-        assert smile.gateway_id == "fb49af122f6e4b0f91267e1cf7666d6f"
+        assert api.gateway_id == "fb49af122f6e4b0f91267e1cf7666d6f"
         assert self.cooling_present
         assert not self._cooling_enabled
         assert not self.notifications
 
-        await smile.close_connection()
+        await api.close_connection()
         await self.disconnect(server, client)
 
     @pytest.mark.asyncio
@@ -367,19 +360,18 @@ class TestPlugwiseAnna(TestPlugwise):  # pylint: disable=attribute-defined-outsi
         self.smile_setup = "anna_elga_2_schedule_off"
 
         testdata = await self.load_testdata(SMILE_TYPE, self.smile_setup)
-        server, smile, client = await self.connect_wrapper()
-        assert smile.smile.hostname == "smile000000"
+        server, api, client = await self.connect_wrapper()
+        assert api.smile.hostname == "smile000000"
 
-        await self.device_test(smile, "2022-03-13 00:00:01", testdata)
+        await self.device_test(api, "2022-03-13 00:00:01", testdata)
         assert (
-            smile._last_active["d3ce834534114348be628b61b26d9220"]
-            == THERMOSTAT_SCHEDULE
+            api._last_active["d3ce834534114348be628b61b26d9220"] == THERMOSTAT_SCHEDULE
         )
         assert self.cooling_present
         assert not self._cooling_enabled
         assert self.entity_items == 65
 
-        await smile.close_connection()
+        await api.close_connection()
         await self.disconnect(server, client)
 
     @pytest.mark.asyncio
@@ -392,19 +384,18 @@ class TestPlugwiseAnna(TestPlugwise):  # pylint: disable=attribute-defined-outsi
         self.smile_setup = "anna_elga_2_cooling"
 
         testdata = await self.load_testdata(SMILE_TYPE, self.smile_setup)
-        server, smile, client = await self.connect_wrapper()
-        assert smile.smile.hostname == "smile000000"
+        server, api, client = await self.connect_wrapper()
+        assert api.smile.hostname == "smile000000"
 
         self.validate_test_basics(
             _LOGGER,
-            smile,
+            api,
             smile_version="4.2.1",
         )
 
-        await self.device_test(smile, "2022-03-10 00:00:01", testdata)
+        await self.device_test(api, "2022-03-10 00:00:01", testdata)
         assert (
-            smile._last_active["d3ce834534114348be628b61b26d9220"]
-            == THERMOSTAT_SCHEDULE
+            api._last_active["d3ce834534114348be628b61b26d9220"] == THERMOSTAT_SCHEDULE
         )
         assert self.entity_items == 65
         assert not self.notifications
@@ -414,7 +405,7 @@ class TestPlugwiseAnna(TestPlugwise):  # pylint: disable=attribute-defined-outsi
         assert self._cooling_active
 
         result = await self.tinker_thermostat(
-            smile,
+            api,
             "d3ce834534114348be628b61b26d9220",
             good_schedules=["Thermostat schedule"],
         )
@@ -427,20 +418,20 @@ class TestPlugwiseAnna(TestPlugwise):  # pylint: disable=attribute-defined-outsi
 
         self.smile_setup = "updated/anna_elga_2_switch_heating"
         await self.device_test(
-            smile, "2020-04-05 00:00:01", testdata_updated, initialize=False
+            api, "2020-04-05 00:00:01", testdata_updated, initialize=False
         )
         assert self.cooling_present
         assert not self._cooling_enabled
         assert not self._cooling_active
 
         result = await self.tinker_thermostat(
-            smile,
+            api,
             "d3ce834534114348be628b61b26d9220",
             good_schedules=["Thermostat schedule"],
         )
         assert result
 
-        await smile.close_connection()
+        await api.close_connection()
         await self.disconnect(server, client)
 
     @pytest.mark.asyncio
@@ -449,23 +440,23 @@ class TestPlugwiseAnna(TestPlugwise):  # pylint: disable=attribute-defined-outsi
         self.smile_setup = "anna_loria_heating_idle"
 
         testdata = await self.load_testdata(SMILE_TYPE, self.smile_setup)
-        server, smile, client = await self.connect_wrapper()
-        assert smile.smile.hostname == "smile000000"
+        server, api, client = await self.connect_wrapper()
+        assert api.smile.hostname == "smile000000"
 
         self.validate_test_basics(
             _LOGGER,
-            smile,
+            api,
             smile_version=None,
         )
 
-        await self.device_test(smile, "2022-05-16 00:00:01", testdata)
-        assert smile._last_active["15da035090b847e7a21f93e08c015ebc"] == "Winter"
+        await self.device_test(api, "2022-05-16 00:00:01", testdata)
+        assert api._last_active["15da035090b847e7a21f93e08c015ebc"] == "Winter"
         assert self.entity_items == 68
         assert self.cooling_present
         assert not self._cooling_enabled
 
         switch_change = await self.tinker_switch(
-            smile,
+            api,
             "bfb5ee0a88e14e5f97bfa725a760cc49",
             model="cooling_ena_switch",
         )
@@ -473,7 +464,7 @@ class TestPlugwiseAnna(TestPlugwise):  # pylint: disable=attribute-defined-outsi
 
         with pytest.raises(pw_exceptions.PlugwiseError) as exc:
             await self.tinker_thermostat(
-                smile,
+                api,
                 "15da035090b847e7a21f93e08c015ebc",
                 good_schedules=[
                     "Winter",
@@ -486,7 +477,7 @@ class TestPlugwiseAnna(TestPlugwise):  # pylint: disable=attribute-defined-outsi
 
         with pytest.raises(pw_exceptions.PlugwiseError) as exc:
             await self.tinker_thermostat_temp(
-                smile,
+                api,
                 "15da035090b847e7a21f93e08c015ebc",
                 block_cooling=True,
             )
@@ -494,21 +485,19 @@ class TestPlugwiseAnna(TestPlugwise):  # pylint: disable=attribute-defined-outsi
                 "ERROR raised setting block cooling: %s", exc.value
             )  # pragma: no cover
 
-        tinkered = await self.tinker_dhw_mode(smile)
+        tinkered = await self.tinker_dhw_mode(api)
         assert not tinkered
 
-        await smile.close_connection()
+        await api.close_connection()
         await self.disconnect(server, client)
 
-        server, smile, client = await self.connect_wrapper(raise_timeout=True)
-        await self.device_test(
-            smile, "2022-05-16 00:00:01", testdata, skip_testing=True
-        )
+        server, api, client = await self.connect_wrapper(raise_timeout=True)
+        await self.device_test(api, "2022-05-16 00:00:01", testdata, skip_testing=True)
 
-        tinkered = await self.tinker_dhw_mode(smile, unhappy=True)
+        tinkered = await self.tinker_dhw_mode(api, unhappy=True)
         assert tinkered
 
-        await smile.close_connection()
+        await api.close_connection()
         await self.disconnect(server, client)
 
     @pytest.mark.asyncio
@@ -517,22 +506,22 @@ class TestPlugwiseAnna(TestPlugwise):  # pylint: disable=attribute-defined-outsi
         self.smile_setup = "anna_loria_cooling_active"
 
         testdata = await self.load_testdata(SMILE_TYPE, self.smile_setup)
-        server, smile, client = await self.connect_wrapper()
-        assert smile.smile.hostname == "smile000000"
+        server, api, client = await self.connect_wrapper()
+        assert api.smile.hostname == "smile000000"
 
         self.validate_test_basics(
             _LOGGER,
-            smile,
+            api,
             smile_version=None,
         )
 
-        await self.device_test(smile, "2022-05-16 00:00:01", testdata)
-        assert smile._last_active["15da035090b847e7a21f93e08c015ebc"] == "Winter"
+        await self.device_test(api, "2022-05-16 00:00:01", testdata)
+        assert api._last_active["15da035090b847e7a21f93e08c015ebc"] == "Winter"
         assert self.entity_items == 68
         assert self.cooling_present
         assert self._cooling_enabled
 
-        await smile.close_connection()
+        await api.close_connection()
         await self.disconnect(server, client)
 
     @pytest.mark.asyncio
@@ -541,19 +530,19 @@ class TestPlugwiseAnna(TestPlugwise):  # pylint: disable=attribute-defined-outsi
         self.smile_setup = "anna_loria_driessens"
 
         testdata = await self.load_testdata(SMILE_TYPE, self.smile_setup)
-        server, smile, client = await self.connect_wrapper()
-        assert smile.smile.hostname == "smile000000"
+        server, api, client = await self.connect_wrapper()
+        assert api.smile.hostname == "smile000000"
 
         self.validate_test_basics(
             _LOGGER,
-            smile,
+            api,
             smile_version=None,
         )
 
-        await self.device_test(smile, "2022-05-16 00:00:01", testdata)
+        await self.device_test(api, "2022-05-16 00:00:01", testdata)
         assert self.entity_items == 68
         assert self.cooling_present
         assert not self._cooling_enabled
 
-        await smile.close_connection()
+        await api.close_connection()
         await self.disconnect(server, client)

--- a/tests/test_generic.py
+++ b/tests/test_generic.py
@@ -17,7 +17,7 @@ class TestPlugwiseGeneric(TestPlugwise):  # pylint: disable=attribute-defined-ou
         """Test erroneous adam with anna system."""
         self.smile_setup = "anna_connected_to_adam"
         try:
-            _server, _smile, _client = await self.connect_wrapper()
+            _server, _api, _client = await self.connect_wrapper()
             setup_result = False  # pragma: no cover
         except pw_exceptions.InvalidSetupError:
             setup_result = True
@@ -59,7 +59,7 @@ class TestPlugwiseGeneric(TestPlugwise):  # pylint: disable=attribute-defined-ou
             self.smile_setup = "p1v4"
             (
                 server,
-                smile,
+                api,
                 client,
             ) = await self.connect_wrapper()
             setup_result = False  # pragma: no cover

--- a/tests/test_legacy_anna.py
+++ b/tests/test_legacy_anna.py
@@ -18,34 +18,32 @@ class TestPlugwiseAnna(TestPlugwise):  # pylint: disable=attribute-defined-outsi
         self.smile_setup = "legacy_anna"
         testdata = await self.load_testdata(SMILE_TYPE, self.smile_setup)
 
-        server, smile, client = await self.connect_legacy_wrapper()
-        assert smile.smile.hostname == "smile000000"
+        server, api, client = await self.connect_legacy_wrapper()
+        assert api.smile.hostname == "smile000000"
 
         self.validate_test_basics(
             _LOGGER,
-            smile,
+            api,
             smile_version="1.8.22",
             smile_legacy=True,
         )
 
-        await self.device_test(smile, "2020-03-22 00:00:01", testdata)
-        assert smile.gateway_id == "0000aaaa0000aaaa0000aaaa0000aa00"
+        await self.device_test(api, "2020-03-22 00:00:01", testdata)
+        assert api.gateway_id == "0000aaaa0000aaaa0000aaaa0000aa00"
         assert self.entity_items == 41
-        assert not smile.reboot
+        assert not api.reboot
 
-        result = await self.tinker_legacy_thermostat(smile, schedule_on=False)
+        result = await self.tinker_legacy_thermostat(api, schedule_on=False)
         assert result
 
-        await smile.close_connection()
+        await api.close_connection()
         await self.disconnect(server, client)
 
-        server, smile, client = await self.connect_legacy_wrapper(raise_timeout=True)
-        await self.device_test(
-            smile, "2020-03-22 00:00:01", testdata, skip_testing=True
-        )
-        result = await self.tinker_legacy_thermostat(smile, unhappy=True)
+        server, api, client = await self.connect_legacy_wrapper(raise_timeout=True)
+        await self.device_test(api, "2020-03-22 00:00:01", testdata, skip_testing=True)
+        result = await self.tinker_legacy_thermostat(api, unhappy=True)
         assert result
-        await smile.close_connection()
+        await api.close_connection()
         await self.disconnect(server, client)
 
     @pytest.mark.asyncio
@@ -54,26 +52,26 @@ class TestPlugwiseAnna(TestPlugwise):  # pylint: disable=attribute-defined-outsi
         self.smile_setup = "legacy_anna_2"
 
         testdata = await self.load_testdata(SMILE_TYPE, self.smile_setup)
-        server, smile, client = await self.connect_legacy_wrapper()
-        assert smile.smile.hostname == "smile000000"
+        server, api, client = await self.connect_legacy_wrapper()
+        assert api.smile.hostname == "smile000000"
 
         self.validate_test_basics(
             _LOGGER,
-            smile,
+            api,
             smile_version="1.8.22",
             smile_legacy=True,
         )
 
-        await self.device_test(smile, "2020-05-03 00:00:01", testdata)
+        await self.device_test(api, "2020-05-03 00:00:01", testdata)
 
-        assert smile.gateway_id == "be81e3f8275b4129852c4d8d550ae2eb"
+        assert api.gateway_id == "be81e3f8275b4129852c4d8d550ae2eb"
         assert self.entity_items == 43
 
-        result = await self.tinker_legacy_thermostat(smile)
+        result = await self.tinker_legacy_thermostat(api)
         assert result
 
-        result = await self.tinker_legacy_thermostat_schedule(smile, "on")
+        result = await self.tinker_legacy_thermostat_schedule(api, "on")
         assert result
 
-        await smile.close_connection()
+        await api.close_connection()
         await self.disconnect(server, client)

--- a/tests/test_legacy_generic.py
+++ b/tests/test_legacy_generic.py
@@ -13,7 +13,7 @@ class TestPlugwiseGeneric(TestPlugwise):  # pylint: disable=attribute-defined-ou
         """Test erroneous legacy stretch system."""
         self.smile_setup = "faulty_stretch"
         try:
-            _server, _smile, _client = await self.connect_legacy_wrapper()
+            _server, _api, _client = await self.connect_legacy_wrapper()
             setup_result = False  # pragma: no cover
         except pw_exceptions.InvalidXMLError:
             setup_result = True

--- a/tests/test_legacy_p1.py
+++ b/tests/test_legacy_p1.py
@@ -16,22 +16,22 @@ class TestPlugwiseP1(TestPlugwise):  # pylint: disable=attribute-defined-outside
         self.smile_setup = "smile_p1_v2"
 
         testdata = await self.load_testdata(SMILE_TYPE, self.smile_setup)
-        server, smile, client = await self.connect_legacy_wrapper()
-        assert smile.smile.hostname == "smile000000"
+        server, api, client = await self.connect_legacy_wrapper()
+        assert api.smile.hostname == "smile000000"
 
         self.validate_test_basics(
             _LOGGER,
-            smile,
+            api,
             smile_type="power",
             smile_version="2.5.9",
             smile_legacy=True,
         )
 
-        await self.device_test(smile, "2022-05-16 00:00:01", testdata)
-        assert smile.gateway_id == "aaaa0000aaaa0000aaaa0000aaaa00aa"
+        await self.device_test(api, "2022-05-16 00:00:01", testdata)
+        assert api.gateway_id == "aaaa0000aaaa0000aaaa0000aaaa00aa"
         assert self.entity_items == 26
 
-        await smile.close_connection()
+        await api.close_connection()
         await self.disconnect(server, client)
 
     @pytest.mark.asyncio
@@ -40,18 +40,18 @@ class TestPlugwiseP1(TestPlugwise):  # pylint: disable=attribute-defined-outside
         self.smile_setup = "smile_p1_v2_2"
 
         testdata = await self.load_testdata(SMILE_TYPE, self.smile_setup)
-        server, smile, client = await self.connect_legacy_wrapper()
-        assert smile.smile.hostname == "smile000000"
+        server, api, client = await self.connect_legacy_wrapper()
+        assert api.smile.hostname == "smile000000"
 
         self.validate_test_basics(
             _LOGGER,
-            smile,
+            api,
             smile_type="power",
             smile_version="2.5.9",
             smile_legacy=True,
         )
 
-        await self.device_test(smile, "2022-05-16 00:00:01", testdata)
+        await self.device_test(api, "2022-05-16 00:00:01", testdata)
         assert self.entity_items == 26
 
         # Now change some data and change directory reading xml from
@@ -61,8 +61,8 @@ class TestPlugwiseP1(TestPlugwise):  # pylint: disable=attribute-defined-outside
         )
         self.smile_setup = "updated/smile_p1_v2_2"
         await self.device_test(
-            smile, "2022-05-16 00:00:01", testdata_updated, initialize=False
+            api, "2022-05-16 00:00:01", testdata_updated, initialize=False
         )
 
-        await smile.close_connection()
+        await api.close_connection()
         await self.disconnect(server, client)

--- a/tests/test_legacy_stretch.py
+++ b/tests/test_legacy_stretch.py
@@ -16,23 +16,23 @@ class TestPlugwiseStretch(TestPlugwise):  # pylint: disable=attribute-defined-ou
         self.smile_setup = "stretch_v31"
 
         testdata = await self.load_testdata(SMILE_TYPE, self.smile_setup)
-        server, smile, client = await self.connect_legacy_wrapper(stretch=True)
-        assert smile.smile.hostname == "stretch000000"
+        server, api, client = await self.connect_legacy_wrapper(stretch=True)
+        assert api.smile.hostname == "stretch000000"
 
         self.validate_test_basics(
             _LOGGER,
-            smile,
+            api,
             smile_type="stretch",
             smile_version="3.1.11",
             smile_legacy=True,
         )
 
-        await self.device_test(smile, "2022-05-16 00:00:01", testdata)
-        assert smile.gateway_id == "0000aaaa0000aaaa0000aaaa0000aa00"
+        await self.device_test(api, "2022-05-16 00:00:01", testdata)
+        assert api.gateway_id == "0000aaaa0000aaaa0000aaaa0000aa00"
         assert self.entity_items == 83
 
         switch_change = await self.tinker_switch(
-            smile,
+            api,
             "059e4d03c7a34d278add5c7a4a781d19",
         )
         assert not switch_change
@@ -44,10 +44,10 @@ class TestPlugwiseStretch(TestPlugwise):  # pylint: disable=attribute-defined-ou
         )
         self.smile_setup = "updated/stretch_v31"
         await self.device_test(
-            smile, "2022-05-16 00:00:01", testdata_updated, initialize=False
+            api, "2022-05-16 00:00:01", testdata_updated, initialize=False
         )
 
-        await smile.close_connection()
+        await api.close_connection()
         await self.disconnect(server, client)
 
     @pytest.mark.asyncio
@@ -56,36 +56,36 @@ class TestPlugwiseStretch(TestPlugwise):  # pylint: disable=attribute-defined-ou
         self.smile_setup = "stretch_v23"
 
         testdata = await self.load_testdata(SMILE_TYPE, self.smile_setup)
-        server, smile, client = await self.connect_legacy_wrapper(stretch=True)
-        assert smile.smile.hostname == "stretch000000"
+        server, api, client = await self.connect_legacy_wrapper(stretch=True)
+        assert api.smile.hostname == "stretch000000"
 
         self.validate_test_basics(
             _LOGGER,
-            smile,
+            api,
             smile_type="stretch",
             smile_version="2.3.12",
             smile_legacy=True,
         )
 
-        await self.device_test(smile, "2022-05-16 00:00:01", testdata)
+        await self.device_test(api, "2022-05-16 00:00:01", testdata)
         assert self.entity_items == 243
 
         switch_change = await self.tinker_switch(
-            smile, "2587a7fcdd7e482dab03fda256076b4b"
+            api, "2587a7fcdd7e482dab03fda256076b4b"
         )
         assert switch_change
         switch_change = await self.tinker_switch(
-            smile, "2587a7fcdd7e482dab03fda256076b4b", model="lock"
+            api, "2587a7fcdd7e482dab03fda256076b4b", model="lock"
         )
         assert switch_change
         switch_change = await self.tinker_switch(
-            smile,
+            api,
             "f7b145c8492f4dd7a4de760456fdef3e",
             ["407aa1c1099d463c9137a3a9eda787fd"],
         )
         assert switch_change
 
-        await smile.close_connection()
+        await api.close_connection()
         await self.disconnect(server, client)
 
     @pytest.mark.asyncio
@@ -95,25 +95,25 @@ class TestPlugwiseStretch(TestPlugwise):  # pylint: disable=attribute-defined-ou
         self.smile_setup = "stretch_v27_no_domain"
 
         testdata = await self.load_testdata(SMILE_TYPE, self.smile_setup)
-        server, smile, client = await self.connect_legacy_wrapper(stretch=True)
-        assert smile.smile.hostname == "stretch000000"
+        server, api, client = await self.connect_legacy_wrapper(stretch=True)
+        assert api.smile.hostname == "stretch000000"
 
         self.validate_test_basics(
             _LOGGER,
-            smile,
+            api,
             smile_type="stretch",
             smile_version="2.7.18",
             smile_legacy=True,
         )
 
-        await self.device_test(smile, "2022-05-16 00:00:01", testdata)
+        await self.device_test(api, "2022-05-16 00:00:01", testdata)
         assert self.entity_items == 190
         _LOGGER.info(" # Assert no master thermostat")
 
         switch_change = await self.tinker_switch(
-            smile, "8b8d14b242e24cd789743c828b9a2ea9"
+            api, "8b8d14b242e24cd789743c828b9a2ea9"
         )
         assert switch_change
 
-        await smile.close_connection()
+        await api.close_connection()
         await self.disconnect(server, client)

--- a/tests/test_p1.py
+++ b/tests/test_p1.py
@@ -16,18 +16,18 @@ class TestPlugwiseP1(TestPlugwise):  # pylint: disable=attribute-defined-outside
         self.smile_setup = "p1v4_442_single"
 
         testdata = await self.load_testdata(SMILE_TYPE, self.smile_setup)
-        server, smile, client = await self.connect_wrapper()
-        assert smile.smile.hostname == "smile000000"
+        server, api, client = await self.connect_wrapper()
+        assert api.smile.hostname == "smile000000"
 
         self.validate_test_basics(
             _LOGGER,
-            smile,
+            api,
             smile_type="power",
             smile_version="4.4.2",
         )
 
-        await self.device_test(smile, "2022-05-16 00:00:01", testdata)
-        assert smile.gateway_id == "a455b61e52394b2db5081ce025a430f3"
+        await self.device_test(api, "2022-05-16 00:00:01", testdata)
+        assert api.gateway_id == "a455b61e52394b2db5081ce025a430f3"
         assert self.entity_items == 33
         assert not self.notifications
 
@@ -38,13 +38,13 @@ class TestPlugwiseP1(TestPlugwise):  # pylint: disable=attribute-defined-outside
         )
         self.smile_setup = "updated/p1v4_442_single"
         await self.device_test(
-            smile, "2022-05-16 00:00:01", testdata_updated, initialize=False
+            api, "2022-05-16 00:00:01", testdata_updated, initialize=False
         )
 
         # Simulate receiving no xml-data after a requesting a reboot of the gateway
         self.smile_setup = "reboot/p1v4_442_single"
         try:
-            await self.device_test(smile, initialize=False)
+            await self.device_test(api, initialize=False)
         except pw_exceptions.PlugwiseError as err:
             _LOGGER.debug(
                 f"Receiving no data after a reboot is properly handled: {err}"
@@ -53,11 +53,11 @@ class TestPlugwiseP1(TestPlugwise):  # pylint: disable=attribute-defined-outside
         # Simulate receiving xml-data with <error>
         self.smile_setup = "error/p1v4_442_single"
         try:
-            await self.device_test(smile, initialize=False)
+            await self.device_test(api, initialize=False)
         except pw_exceptions.ResponseError:
             _LOGGER.debug("Receiving error-data from the Gateway")
 
-        await smile.close_connection()
+        await api.close_connection()
         await self.disconnect(server, client)
 
     @pytest.mark.asyncio
@@ -66,20 +66,20 @@ class TestPlugwiseP1(TestPlugwise):  # pylint: disable=attribute-defined-outside
         self.smile_setup = "p1v4_442_triple"
 
         testdata = await self.load_testdata(SMILE_TYPE, self.smile_setup)
-        server, smile, client = await self.connect_wrapper()
-        assert smile.smile.hostname == "smile000000"
+        server, api, client = await self.connect_wrapper()
+        assert api.smile.hostname == "smile000000"
 
         self.validate_test_basics(
             _LOGGER,
-            smile,
+            api,
             smile_type="power",
             smile_version="4.4.2",
         )
 
-        await self.device_test(smile, "2022-05-16 00:00:01", testdata)
-        assert smile.gateway_id == "03e65b16e4b247a29ae0d75a78cb492e"
+        await self.device_test(api, "2022-05-16 00:00:01", testdata)
+        assert api.gateway_id == "03e65b16e4b247a29ae0d75a78cb492e"
         assert self.entity_items == 42
         assert self.notifications
 
-        await smile.close_connection()
+        await api.close_connection()
         await self.disconnect(server, client)


### PR DESCRIPTION
to avoid smile.smile.xyz constructs
