### PR TITLE
Force python minor version

### DIFF
--- a/.github/workflows/verify.yml
+++ b/.github/workflows/verify.yml
@@ -23,10 +23,11 @@ jobs:
     name: Cache identify
     outputs:
       cache-key: ${{ steps.set-key.outputs.cache-key }}
+      python-version: ${{ steps.python.outputs.python-verseion}}  # Ensure all runners use THIS minor version
     steps:
       - name: Check out committed code
         uses: actions/checkout@v5
-      - name: Set up Python ${{ env.DEFAULT_PYTHON }}
+      - name: Set up Python and determine minor version for ${{ env.DEFAULT_PYTHON }}
         id: python
         uses: actions/setup-python@v5
         with:
@@ -52,7 +53,7 @@ jobs:
           fail-on-miss: false  # First time create cache (if not already exists)
           python-version: ${{ env.DEFAULT_PYTHON }}
           venv-dir: ${{ env.VENV }}
-          precommit-home: ${{ env.PRE_COMMIT_HOME }}
+          precommit-home: ${{ needs.cache.outputs.python-version }}
 
   ruff:
     runs-on: ubuntu-latest
@@ -70,7 +71,7 @@ jobs:
         uses: plugwise/gh-actions/restore-venv@v1
         with:
           cache-key: ${{ needs.cache.outputs.cache-key }}
-          python-version: ${{ env.DEFAULT_PYTHON }}
+          python-version: ${{ needs.cache.outputs.python-version}}
           venv-dir: ${{ env.VENV }}
           precommit-home: ${{ env.PRE_COMMIT_HOME }}
       - name: Ruff (with fix)
@@ -106,7 +107,7 @@ jobs:
         uses: plugwise/gh-actions/restore-venv@v1
         with:
           cache-key: ${{ needs.cache.outputs.cache-key }}
-          python-version: ${{ env.DEFAULT_PYTHON }}
+          python-version: ${{ needs.cache.outputs.python-version}}
           venv-dir: ${{ env.VENV }}
           precommit-home: ${{ env.PRE_COMMIT_HOME }}
       - name: Verify commit
@@ -136,12 +137,17 @@ jobs:
     steps:
       - name: Check out committed code
         uses: actions/checkout@v5
+      - name: Set up Python ${{ matrix.python-version }}
+        id: python
+        uses: actions/setup-python@v5
+        with:
+          python-version: ${{ matrix.python-version }}
       - name: Restore cached environment
         id: cache-reuse
         uses: plugwise/gh-actions/restore-venv@v1
         with:
           cache-key: ${{ needs.cache.outputs.cache-key }}
-          python-version: ${{ env.DEFAULT_PYTHON }}
+          python-version: ${{ steps.python.outputs.python-version }}  # Force to installed python minor$
           venv-dir: ${{ env.VENV }}
           precommit-home: ${{ env.PRE_COMMIT_HOME }}
       - name: Run all tests
@@ -173,7 +179,7 @@ jobs:
         uses: plugwise/gh-actions/restore-venv@v1
         with:
           cache-key: ${{ needs.cache.outputs.cache-key }}
-          python-version: ${{ env.DEFAULT_PYTHON }}
+          python-version: ${{ needs.cache.outputs.python-version}}
           venv-dir: ${{ env.VENV }}
           precommit-home: ${{ env.PRE_COMMIT_HOME }}
       - name: Run mypy
@@ -218,7 +224,7 @@ jobs:
         uses: plugwise/gh-actions/restore-venv@v1
         with:
           cache-key: ${{ needs.cache.outputs.cache-key }}
-          python-version: ${{ env.DEFAULT_PYTHON }}
+          python-version: ${{ needs.cache.outputs.python-version}}
           venv-dir: ${{ env.VENV }}
           precommit-home: ${{ env.PRE_COMMIT_HOME }}
       - name: Download all coverage artifacts
@@ -296,7 +302,7 @@ jobs:
         uses: plugwise/gh-actions/restore-venv@v1
         with:
           cache-key: ${{ needs.cache.outputs.cache-key }}
-          python-version: ${{ env.DEFAULT_PYTHON }}
+          python-version: ${{ needs.cache.outputs.python-version}}
           venv-dir: ${{ env.VENV }}
           precommit-home: ${{ env.PRE_COMMIT_HOME }}
       - name: Run complexity report (click to view details)

--- a/.github/workflows/verify.yml
+++ b/.github/workflows/verify.yml
@@ -23,7 +23,7 @@ jobs:
     name: Cache identify
     outputs:
       cache-key: ${{ steps.set-key.outputs.cache-key }}
-      python-version: ${{ steps.python.outputs.python-verseion}}  # Ensure all runners use THIS minor version
+      python-version: ${{ steps.python.outputs.python-version}}  # Ensure all runners use THIS minor version
     steps:
       - name: Check out committed code
         uses: actions/checkout@v5
@@ -51,9 +51,9 @@ jobs:
         with:
           cache-key: ${{ needs.cache.outputs.cache-key }}
           fail-on-miss: false  # First time create cache (if not already exists)
-          python-version: ${{ env.DEFAULT_PYTHON }}
+          python-version: ${{ needs.cache.outputs.python-version }}
           venv-dir: ${{ env.VENV }}
-          precommit-home: ${{ needs.cache.outputs.python-version }}
+          precommit-home: ${{ env.PRE_COMMIT_HOME }}
 
   ruff:
     runs-on: ubuntu-latest


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * CI now propagates the exact installed Python minor version across jobs and caches, unifying environments for more consistent runs.
  * Setup step labels updated for clearer workflow logs.

* **Tests**
  * Pytest matrix now sets up Python per-version and restores matching cached environments, improving reproducibility and cache efficiency.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->