### PR TITLE
Change DHW comfort switch to select

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## v1.12.0
+
+- Replace the DHW-comfort-mode switch by a DHW mode selector to match the HA water_heater platform via PR [#883](https://github.com/plugwise/python-plugwise/pull/883) 
+
 ## v1.11.4
 
 - Correct Anna P1 detection via PR [#879](https://github.com/plugwise/python-plugwise/pull/879)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## v1.12.0
 
-- Replace the DHW-comfort-mode switch by a DHW mode selector to match the HA water_heater platform via PR [#883](https://github.com/plugwise/python-plugwise/pull/883)
+- Replace the DHW-comfort-mode switch by a DHW mode selector to match the HA select or water_heater platforms, via PR [#883](https://github.com/plugwise/python-plugwise/pull/883)
 
 ## v1.11.4
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## v1.12.0
 
-- Replace the DHW-comfort-mode switch by a DHW mode selector to match the HA select or water_heater platforms, via PR [#883](https://github.com/plugwise/python-plugwise/pull/883)
+- Replace the DHW-comfort-mode switch by a DHW mode selector to match the new HA select or water_heater platform updates, via PR [#883](https://github.com/plugwise/python-plugwise/pull/883)
 
 ## v1.11.4
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## v1.12.0
 
-- Replace the DHW-comfort-mode switch by a DHW mode selector to match the HA water_heater platform via PR [#883](https://github.com/plugwise/python-plugwise/pull/883) 
+- Replace the DHW-comfort-mode switch by a DHW mode selector to match the HA water_heater platform via PR [#883](https://github.com/plugwise/python-plugwise/pull/883)
 
 ## v1.11.4
 

--- a/fixtures/adam_bad_thermostat/data.json
+++ b/fixtures/adam_bad_thermostat/data.json
@@ -27,7 +27,6 @@
     "model": "Generic heater",
     "model_id": "1.1",
     "name": "OpenTherm",
-    "select_dhw_mode": "off",
     "sensors": {
       "dhw_temperature": 49.9,
       "intended_boiler_temperature": 0.0,
@@ -36,7 +35,8 @@
       "return_temperature": 33.0,
       "water_temperature": 20.9
     },
-    "vendor": "WeHeat"
+    "vendor": "WeHeat",
+    "water_heater_mode": "off"
   },
   "3ee6b9486cb04c258a3130fff2b144a4": {
     "active_preset": "home",

--- a/fixtures/adam_bad_thermostat/data.json
+++ b/fixtures/adam_bad_thermostat/data.json
@@ -7,6 +7,10 @@
       "heating_state": false
     },
     "dev_class": "heater_central",
+    "dhw_modes": [
+      "comfort",
+      "off"
+    ],
     "location": "856285a783f24bf4b2573c8bc510eabf",
     "max_dhw_temperature": {
       "lower_bound": 0.0,
@@ -23,6 +27,7 @@
     "model": "Generic heater",
     "model_id": "1.1",
     "name": "OpenTherm",
+    "select_dhw_mode": "off",
     "sensors": {
       "dhw_temperature": 49.9,
       "intended_boiler_temperature": 0.0,
@@ -30,9 +35,6 @@
       "outdoor_air_temperature": 13.6,
       "return_temperature": 33.0,
       "water_temperature": 20.9
-    },
-    "switches": {
-      "dhw_cm_switch": false
     },
     "vendor": "WeHeat"
   },

--- a/fixtures/adam_bad_thermostat/data.json
+++ b/fixtures/adam_bad_thermostat/data.json
@@ -7,6 +7,7 @@
       "heating_state": false
     },
     "dev_class": "heater_central",
+    "dhw_mode": "off",
     "dhw_modes": [
       "comfort",
       "off"
@@ -35,8 +36,7 @@
       "return_temperature": 33.0,
       "water_temperature": 20.9
     },
-    "vendor": "WeHeat",
-    "water_heater_mode": "off"
+    "vendor": "WeHeat"
   },
   "3ee6b9486cb04c258a3130fff2b144a4": {
     "active_preset": "home",

--- a/fixtures/adam_heatpump_cooling/data.json
+++ b/fixtures/adam_heatpump_cooling/data.json
@@ -55,6 +55,7 @@
       "heating_state": false
     },
     "dev_class": "heater_central",
+    "dhw_mode": "comfort",
     "dhw_modes": [
       "comfort",
       "off"
@@ -84,8 +85,7 @@
       "water_pressure": 2.0,
       "water_temperature": 24.5
     },
-    "vendor": "Remeha B.V.",
-    "water_heater_mode": "comfort"
+    "vendor": "Remeha B.V."
   },
   "1053c8bbf8be43c6921742b146a625f1": {
     "available": true,

--- a/fixtures/adam_heatpump_cooling/data.json
+++ b/fixtures/adam_heatpump_cooling/data.json
@@ -75,7 +75,6 @@
     "model": "Generic heater/cooler",
     "model_id": "17.1",
     "name": "OpenTherm",
-    "select_dhw_mode": "comfort",
     "sensors": {
       "dhw_temperature": 63.5,
       "intended_boiler_temperature": 0.0,
@@ -85,7 +84,8 @@
       "water_pressure": 2.0,
       "water_temperature": 24.5
     },
-    "vendor": "Remeha B.V."
+    "vendor": "Remeha B.V.",
+    "water_heater_mode": "comfort"
   },
   "1053c8bbf8be43c6921742b146a625f1": {
     "available": true,

--- a/fixtures/adam_heatpump_cooling/data.json
+++ b/fixtures/adam_heatpump_cooling/data.json
@@ -55,6 +55,10 @@
       "heating_state": false
     },
     "dev_class": "heater_central",
+    "dhw_modes": [
+      "comfort",
+      "off"
+    ],
     "location": "eedadcb297564f1483faa509179aebed",
     "max_dhw_temperature": {
       "lower_bound": 40.0,
@@ -71,6 +75,7 @@
     "model": "Generic heater/cooler",
     "model_id": "17.1",
     "name": "OpenTherm",
+    "select_dhw_mode": "comfort",
     "sensors": {
       "dhw_temperature": 63.5,
       "intended_boiler_temperature": 0.0,
@@ -79,9 +84,6 @@
       "return_temperature": 24.9,
       "water_pressure": 2.0,
       "water_temperature": 24.5
-    },
-    "switches": {
-      "dhw_cm_switch": true
     },
     "vendor": "Remeha B.V."
   },

--- a/fixtures/adam_jip/data.json
+++ b/fixtures/adam_jip/data.json
@@ -394,6 +394,10 @@
       "heating_state": false
     },
     "dev_class": "heater_central",
+    "dhw_modes": [
+      "comfort",
+      "off"
+    ],
     "location": "9e4433a9d69f40b3aefd15e74395eaec",
     "max_dhw_temperature": {
       "lower_bound": 40.0,
@@ -410,15 +414,13 @@
     "model": "Generic heater",
     "model_id": "10.20",
     "name": "OpenTherm",
+    "select_dhw_mode": "off",
     "sensors": {
       "intended_boiler_temperature": 0.0,
       "modulation_level": 0.0,
       "return_temperature": 37.1,
       "water_pressure": 1.4,
       "water_temperature": 37.3
-    },
-    "switches": {
-      "dhw_cm_switch": false
     },
     "vendor": "Remeha B.V."
   },

--- a/fixtures/adam_jip/data.json
+++ b/fixtures/adam_jip/data.json
@@ -394,6 +394,7 @@
       "heating_state": false
     },
     "dev_class": "heater_central",
+    "dhw_mode": "off",
     "dhw_modes": [
       "comfort",
       "off"
@@ -421,8 +422,7 @@
       "water_pressure": 1.4,
       "water_temperature": 37.3
     },
-    "vendor": "Remeha B.V.",
-    "water_heater_mode": "off"
+    "vendor": "Remeha B.V."
   },
   "f61f1a2535f54f52ad006a3d18e459ca": {
     "available": true,

--- a/fixtures/adam_jip/data.json
+++ b/fixtures/adam_jip/data.json
@@ -414,7 +414,6 @@
     "model": "Generic heater",
     "model_id": "10.20",
     "name": "OpenTherm",
-    "select_dhw_mode": "off",
     "sensors": {
       "intended_boiler_temperature": 0.0,
       "modulation_level": 0.0,
@@ -422,7 +421,8 @@
       "water_pressure": 1.4,
       "water_temperature": 37.3
     },
-    "vendor": "Remeha B.V."
+    "vendor": "Remeha B.V.",
+    "water_heater_mode": "off"
   },
   "f61f1a2535f54f52ad006a3d18e459ca": {
     "available": true,

--- a/fixtures/adam_onoff_cooling_fake_firmware/data.json
+++ b/fixtures/adam_onoff_cooling_fake_firmware/data.json
@@ -27,7 +27,6 @@
     },
     "model": "Unknown",
     "name": "OnOff",
-    "select_dhw_mode": "comfort",
     "sensors": {
       "dhw_temperature": 63.5,
       "intended_boiler_temperature": 0.0,
@@ -36,7 +35,8 @@
       "return_temperature": 24.9,
       "water_pressure": 2.0,
       "water_temperature": 24.5
-    }
+    },
+    "water_heater_mode": "comfort"
   },
   "7d97fc3117784cfdafe347bcedcbbbcb": {
     "binary_sensors": {

--- a/fixtures/adam_onoff_cooling_fake_firmware/data.json
+++ b/fixtures/adam_onoff_cooling_fake_firmware/data.json
@@ -8,6 +8,10 @@
       "heating_state": false
     },
     "dev_class": "heater_central",
+    "dhw_modes": [
+      "comfort",
+      "off"
+    ],
     "location": "eedadcb297564f1483faa509179aebed",
     "max_dhw_temperature": {
       "lower_bound": 40.0,
@@ -23,6 +27,7 @@
     },
     "model": "Unknown",
     "name": "OnOff",
+    "select_dhw_mode": "comfort",
     "sensors": {
       "dhw_temperature": 63.5,
       "intended_boiler_temperature": 0.0,
@@ -31,9 +36,6 @@
       "return_temperature": 24.9,
       "water_pressure": 2.0,
       "water_temperature": 24.5
-    },
-    "switches": {
-      "dhw_cm_switch": true
     }
   },
   "7d97fc3117784cfdafe347bcedcbbbcb": {

--- a/fixtures/adam_onoff_cooling_fake_firmware/data.json
+++ b/fixtures/adam_onoff_cooling_fake_firmware/data.json
@@ -8,6 +8,7 @@
       "heating_state": false
     },
     "dev_class": "heater_central",
+    "dhw_mode": "comfort",
     "dhw_modes": [
       "comfort",
       "off"
@@ -35,8 +36,7 @@
       "return_temperature": 24.9,
       "water_pressure": 2.0,
       "water_temperature": 24.5
-    },
-    "water_heater_mode": "comfort"
+    }
   },
   "7d97fc3117784cfdafe347bcedcbbbcb": {
     "binary_sensors": {

--- a/fixtures/adam_plus_anna/data.json
+++ b/fixtures/adam_plus_anna/data.json
@@ -45,6 +45,10 @@
       "heating_state": false
     },
     "dev_class": "heater_central",
+    "dhw_modes": [
+      "comfort",
+      "off"
+    ],
     "location": "07d618f0bb80412687f065b8698ce3e7",
     "maximum_boiler_temperature": {
       "lower_bound": 0.0,
@@ -54,12 +58,10 @@
     },
     "model": "Generic heater",
     "name": "OpenTherm",
+    "select_dhw_mode": "off",
     "sensors": {
       "intended_boiler_temperature": 0.0,
       "water_temperature": 48.0
-    },
-    "switches": {
-      "dhw_cm_switch": false
     }
   },
   "aa6b0002df0a46e1b1eb94beb61eddfe": {

--- a/fixtures/adam_plus_anna_new/data.json
+++ b/fixtures/adam_plus_anna_new/data.json
@@ -7,6 +7,10 @@
       "heating_state": true
     },
     "dev_class": "heater_central",
+    "dhw_modes": [
+      "comfort",
+      "off"
+    ],
     "location": "bc93488efab249e5bc54fd7e175a6f91",
     "maximum_boiler_temperature": {
       "lower_bound": 25.0,
@@ -16,12 +20,10 @@
     },
     "model": "Generic heater",
     "name": "OpenTherm",
+    "select_dhw_mode": "off",
     "sensors": {
       "intended_boiler_temperature": 22.5,
       "water_temperature": 43.0
-    },
-    "switches": {
-      "dhw_cm_switch": false
     }
   },
   "10016900610d4c7481df78c89606ef22": {

--- a/fixtures/adam_plus_anna_new_regulation_off/data.json
+++ b/fixtures/adam_plus_anna_new_regulation_off/data.json
@@ -7,6 +7,10 @@
       "heating_state": false
     },
     "dev_class": "heater_central",
+    "dhw_modes": [
+      "comfort",
+      "off"
+    ],
     "location": "bc93488efab249e5bc54fd7e175a6f91",
     "maximum_boiler_temperature": {
       "lower_bound": 25.0,
@@ -16,12 +20,10 @@
     },
     "model": "Generic heater",
     "name": "OpenTherm",
+    "select_dhw_mode": "off",
     "sensors": {
       "intended_boiler_temperature": 0.0,
       "water_temperature": 30.0
-    },
-    "switches": {
-      "dhw_cm_switch": false
     }
   },
   "10016900610d4c7481df78c89606ef22": {

--- a/fixtures/anna_elga_2/data.json
+++ b/fixtures/anna_elga_2/data.json
@@ -11,9 +11,14 @@
       "secondary_boiler_state": true
     },
     "dev_class": "heater_central",
+    "dhw_modes": [
+      "comfort",
+      "off"
+    ],
     "location": "d34dfe6ab90b410c98068e75de3eb631",
     "model": "Generic heater/cooler",
     "name": "OpenTherm",
+    "select_dhw_mode": "off",
     "sensors": {
       "domestic_hot_water_setpoint": 60.0,
       "intended_boiler_temperature": 58.3,
@@ -22,9 +27,6 @@
       "return_temperature": 35.5,
       "water_pressure": 0.5,
       "water_temperature": 42.6
-    },
-    "switches": {
-      "dhw_cm_switch": false
     },
     "vendor": "Techneco"
   },

--- a/fixtures/anna_elga_2_cooling/data.json
+++ b/fixtures/anna_elga_2_cooling/data.json
@@ -11,6 +11,10 @@
       "secondary_boiler_state": false
     },
     "dev_class": "heater_central",
+    "dhw_modes": [
+      "comfort",
+      "off"
+    ],
     "location": "d34dfe6ab90b410c98068e75de3eb631",
     "maximum_boiler_temperature": {
       "lower_bound": 0.0,
@@ -20,6 +24,7 @@
     },
     "model": "Generic heater/cooler",
     "name": "OpenTherm",
+    "select_dhw_mode": "comfort",
     "sensors": {
       "domestic_hot_water_setpoint": 60.0,
       "intended_boiler_temperature": 0.0,
@@ -28,9 +33,6 @@
       "return_temperature": 23.4,
       "water_pressure": 0.5,
       "water_temperature": 22.8
-    },
-    "switches": {
-      "dhw_cm_switch": true
     },
     "vendor": "Techneco"
   },

--- a/fixtures/anna_elga_2_schedule_off/data.json
+++ b/fixtures/anna_elga_2_schedule_off/data.json
@@ -11,6 +11,10 @@
       "secondary_boiler_state": false
     },
     "dev_class": "heater_central",
+    "dhw_modes": [
+      "comfort",
+      "off"
+    ],
     "location": "d34dfe6ab90b410c98068e75de3eb631",
     "maximum_boiler_temperature": {
       "lower_bound": 0.0,
@@ -20,6 +24,7 @@
     },
     "model": "Generic heater/cooler",
     "name": "OpenTherm",
+    "select_dhw_mode": "comfort",
     "sensors": {
       "domestic_hot_water_setpoint": 60.0,
       "intended_boiler_temperature": 0.0,
@@ -28,9 +33,6 @@
       "return_temperature": 23.4,
       "water_pressure": 0.5,
       "water_temperature": 22.8
-    },
-    "switches": {
-      "dhw_cm_switch": true
     },
     "vendor": "Techneco"
   },

--- a/fixtures/anna_elga_no_cooling/data.json
+++ b/fixtures/anna_elga_no_cooling/data.json
@@ -27,6 +27,10 @@
       "secondary_boiler_state": false
     },
     "dev_class": "heater_central",
+    "dhw_modes": [
+      "comfort",
+      "off"
+    ],
     "location": "a57efe5f145f498c9be62a9b63626fbf",
     "max_dhw_temperature": {
       "lower_bound": 35.0,
@@ -42,6 +46,7 @@
     },
     "model": "Generic heater",
     "name": "OpenTherm",
+    "select_dhw_mode": "off",
     "sensors": {
       "dhw_temperature": 46.3,
       "intended_boiler_temperature": 35.0,
@@ -50,9 +55,6 @@
       "return_temperature": 25.1,
       "water_pressure": 1.57,
       "water_temperature": 29.1
-    },
-    "switches": {
-      "dhw_cm_switch": false
     },
     "vendor": "Techneco"
   },

--- a/fixtures/anna_elga_no_cooling/data.json
+++ b/fixtures/anna_elga_no_cooling/data.json
@@ -27,6 +27,7 @@
       "secondary_boiler_state": false
     },
     "dev_class": "heater_central",
+    "dhw_mode": "off",
     "dhw_modes": [
       "comfort",
       "off"
@@ -55,8 +56,7 @@
       "water_pressure": 1.57,
       "water_temperature": 29.1
     },
-    "vendor": "Techneco",
-    "water_heater_mode": "off"
+    "vendor": "Techneco"
   },
   "3cb70739631c4d17a86b8b12e8a5161b": {
     "active_preset": "home",

--- a/fixtures/anna_elga_no_cooling/data.json
+++ b/fixtures/anna_elga_no_cooling/data.json
@@ -46,7 +46,6 @@
     },
     "model": "Generic heater",
     "name": "OpenTherm",
-    "select_dhw_mode": "off",
     "sensors": {
       "dhw_temperature": 46.3,
       "intended_boiler_temperature": 35.0,
@@ -56,7 +55,8 @@
       "water_pressure": 1.57,
       "water_temperature": 29.1
     },
-    "vendor": "Techneco"
+    "vendor": "Techneco",
+    "water_heater_mode": "off"
   },
   "3cb70739631c4d17a86b8b12e8a5161b": {
     "active_preset": "home",

--- a/fixtures/anna_heatpump_cooling/data.json
+++ b/fixtures/anna_heatpump_cooling/data.json
@@ -29,6 +29,10 @@
       "secondary_boiler_state": false
     },
     "dev_class": "heater_central",
+    "dhw_modes": [
+      "comfort",
+      "off"
+    ],
     "location": "a57efe5f145f498c9be62a9b63626fbf",
     "maximum_boiler_temperature": {
       "lower_bound": 0.0,
@@ -38,6 +42,7 @@
     },
     "model": "Generic heater/cooler",
     "name": "OpenTherm",
+    "select_dhw_mode": "off",
     "sensors": {
       "dhw_temperature": 41.5,
       "domestic_hot_water_setpoint": 60.0,
@@ -47,9 +52,6 @@
       "return_temperature": 23.8,
       "water_pressure": 1.61,
       "water_temperature": 24.7
-    },
-    "switches": {
-      "dhw_cm_switch": false
     },
     "vendor": "Techneco"
   },

--- a/fixtures/anna_heatpump_cooling_fake_firmware/data.json
+++ b/fixtures/anna_heatpump_cooling_fake_firmware/data.json
@@ -29,6 +29,10 @@
       "secondary_boiler_state": false
     },
     "dev_class": "heater_central",
+    "dhw_modes": [
+      "comfort",
+      "off"
+    ],
     "location": "a57efe5f145f498c9be62a9b63626fbf",
     "maximum_boiler_temperature": {
       "lower_bound": 0.0,
@@ -38,6 +42,7 @@
     },
     "model": "Generic heater/cooler",
     "name": "OpenTherm",
+    "select_dhw_mode": "off",
     "sensors": {
       "dhw_temperature": 41.5,
       "domestic_hot_water_setpoint": 60.0,
@@ -47,9 +52,6 @@
       "return_temperature": 23.8,
       "water_pressure": 1.61,
       "water_temperature": 24.7
-    },
-    "switches": {
-      "dhw_cm_switch": false
     },
     "vendor": "Techneco"
   },

--- a/fixtures/anna_heatpump_heating/data.json
+++ b/fixtures/anna_heatpump_heating/data.json
@@ -29,6 +29,7 @@
       "secondary_boiler_state": false
     },
     "dev_class": "heater_central",
+    "dhw_mode": "off",
     "dhw_modes": [
       "comfort",
       "off"
@@ -57,8 +58,7 @@
       "water_pressure": 1.57,
       "water_temperature": 29.1
     },
-    "vendor": "Techneco",
-    "water_heater_mode": "off"
+    "vendor": "Techneco"
   },
   "3cb70739631c4d17a86b8b12e8a5161b": {
     "active_preset": "home",

--- a/fixtures/anna_heatpump_heating/data.json
+++ b/fixtures/anna_heatpump_heating/data.json
@@ -48,7 +48,6 @@
     },
     "model": "Generic heater/cooler",
     "name": "OpenTherm",
-    "select_dhw_mode": "off",
     "sensors": {
       "dhw_temperature": 46.3,
       "intended_boiler_temperature": 35.0,
@@ -58,7 +57,8 @@
       "water_pressure": 1.57,
       "water_temperature": 29.1
     },
-    "vendor": "Techneco"
+    "vendor": "Techneco",
+    "water_heater_mode": "off"
   },
   "3cb70739631c4d17a86b8b12e8a5161b": {
     "active_preset": "home",

--- a/fixtures/anna_heatpump_heating/data.json
+++ b/fixtures/anna_heatpump_heating/data.json
@@ -29,6 +29,10 @@
       "secondary_boiler_state": false
     },
     "dev_class": "heater_central",
+    "dhw_modes": [
+      "comfort",
+      "off"
+    ],
     "location": "a57efe5f145f498c9be62a9b63626fbf",
     "max_dhw_temperature": {
       "lower_bound": 35.0,
@@ -44,6 +48,7 @@
     },
     "model": "Generic heater/cooler",
     "name": "OpenTherm",
+    "select_dhw_mode": "off",
     "sensors": {
       "dhw_temperature": 46.3,
       "intended_boiler_temperature": 35.0,
@@ -52,9 +57,6 @@
       "return_temperature": 25.1,
       "water_pressure": 1.57,
       "water_temperature": 29.1
-    },
-    "switches": {
-      "dhw_cm_switch": false
     },
     "vendor": "Techneco"
   },

--- a/fixtures/anna_loria_cooling_active/data.json
+++ b/fixtures/anna_loria_cooling_active/data.json
@@ -71,6 +71,7 @@
       "heating_state": false
     },
     "dev_class": "heater_central",
+    "dhw_mode": "auto",
     "dhw_modes": [
       "off",
       "auto",
@@ -105,7 +106,6 @@
     "switches": {
       "cooling_ena_switch": true
     },
-    "vendor": "Atlantic",
-    "water_heater_mode": "auto"
+    "vendor": "Atlantic"
   }
 }

--- a/fixtures/anna_loria_cooling_active/data.json
+++ b/fixtures/anna_loria_cooling_active/data.json
@@ -94,7 +94,6 @@
     "model": "Generic heater/cooler",
     "model_id": "173",
     "name": "OpenTherm",
-    "select_dhw_mode": "auto",
     "sensors": {
       "dhw_temperature": 52.9,
       "intended_boiler_temperature": 0.0,
@@ -106,6 +105,7 @@
     "switches": {
       "cooling_ena_switch": true
     },
-    "vendor": "Atlantic"
+    "vendor": "Atlantic",
+    "water_heater_mode": "auto"
   }
 }

--- a/fixtures/anna_loria_cooling_active/data.json
+++ b/fixtures/anna_loria_cooling_active/data.json
@@ -104,8 +104,7 @@
       "water_temperature": 25.3
     },
     "switches": {
-      "cooling_ena_switch": true,
-      "dhw_cm_switch": true
+      "cooling_ena_switch": true
     },
     "vendor": "Atlantic"
   }

--- a/fixtures/anna_loria_driessens/data.json
+++ b/fixtures/anna_loria_driessens/data.json
@@ -96,7 +96,6 @@
     "model": "Generic heater/cooler",
     "model_id": "173",
     "name": "OpenTherm",
-    "select_dhw_mode": "auto",
     "sensors": {
       "dhw_temperature": 49.5,
       "intended_boiler_temperature": 0.0,
@@ -108,6 +107,7 @@
     "switches": {
       "cooling_ena_switch": false
     },
-    "vendor": "Atlantic"
+    "vendor": "Atlantic",
+    "water_heater_mode": "auto"
   }
 }

--- a/fixtures/anna_loria_driessens/data.json
+++ b/fixtures/anna_loria_driessens/data.json
@@ -73,6 +73,7 @@
       "heating_state": false
     },
     "dev_class": "heater_central",
+    "dhw_mode": "auto",
     "dhw_modes": [
       "comfort",
       "eco",
@@ -107,7 +108,6 @@
     "switches": {
       "cooling_ena_switch": false
     },
-    "vendor": "Atlantic",
-    "water_heater_mode": "auto"
+    "vendor": "Atlantic"
   }
 }

--- a/fixtures/anna_loria_driessens/data.json
+++ b/fixtures/anna_loria_driessens/data.json
@@ -106,8 +106,7 @@
       "water_temperature": 23.3
     },
     "switches": {
-      "cooling_ena_switch": false,
-      "dhw_cm_switch": true
+      "cooling_ena_switch": false
     },
     "vendor": "Atlantic"
   }

--- a/fixtures/anna_loria_heating_idle/data.json
+++ b/fixtures/anna_loria_heating_idle/data.json
@@ -104,8 +104,7 @@
       "water_temperature": 25.3
     },
     "switches": {
-      "cooling_ena_switch": false,
-      "dhw_cm_switch": true
+      "cooling_ena_switch": false
     },
     "vendor": "Atlantic"
   }

--- a/fixtures/anna_loria_heating_idle/data.json
+++ b/fixtures/anna_loria_heating_idle/data.json
@@ -71,6 +71,7 @@
       "heating_state": false
     },
     "dev_class": "heater_central",
+    "dhw_mode": "auto",
     "dhw_modes": [
       "off",
       "auto",
@@ -105,7 +106,6 @@
     "switches": {
       "cooling_ena_switch": false
     },
-    "vendor": "Atlantic",
-    "water_heater_mode": "auto"
+    "vendor": "Atlantic"
   }
 }

--- a/fixtures/anna_loria_heating_idle/data.json
+++ b/fixtures/anna_loria_heating_idle/data.json
@@ -94,7 +94,6 @@
     "model": "Generic heater/cooler",
     "model_id": "173",
     "name": "OpenTherm",
-    "select_dhw_mode": "auto",
     "sensors": {
       "dhw_temperature": 52.9,
       "intended_boiler_temperature": 0.0,
@@ -106,6 +105,7 @@
     "switches": {
       "cooling_ena_switch": false
     },
-    "vendor": "Atlantic"
+    "vendor": "Atlantic",
+    "water_heater_mode": "auto"
   }
 }

--- a/fixtures/anna_p1/data.json
+++ b/fixtures/anna_p1/data.json
@@ -48,18 +48,20 @@
       "heating_state": false
     },
     "dev_class": "heater_central",
+    "dhw_modes": [
+      "comfort",
+      "off"
+    ],
     "location": "da7be222ab3b420c927f3e49fade0304",
     "model": "Generic heater",
     "model_id": "HR24",
     "name": "OpenTherm",
+    "select_dhw_mode": "comfort",
     "sensors": {
       "intended_boiler_temperature": 0.0,
       "modulation_level": 0.0,
       "water_pressure": 6.0,
       "water_temperature": 35.0
-    },
-    "switches": {
-      "dhw_cm_switch": true
     },
     "vendor": "Intergas"
   },

--- a/fixtures/anna_v4/data.json
+++ b/fixtures/anna_v4/data.json
@@ -67,6 +67,7 @@
       "heating_state": true
     },
     "dev_class": "heater_central",
+    "dhw_mode": "off",
     "dhw_modes": [
       "comfort",
       "off"
@@ -94,7 +95,6 @@
       "water_pressure": 2.2,
       "water_temperature": 45.0
     },
-    "vendor": "Bosch Thermotechniek B.V.",
-    "water_heater_mode": "off"
+    "vendor": "Bosch Thermotechniek B.V."
   }
 }

--- a/fixtures/anna_v4/data.json
+++ b/fixtures/anna_v4/data.json
@@ -67,6 +67,10 @@
       "heating_state": true
     },
     "dev_class": "heater_central",
+    "dhw_modes": [
+      "comfort",
+      "off"
+    ],
     "location": "94c107dc6ac84ed98e9f68c0dd06bf71",
     "max_dhw_temperature": {
       "lower_bound": 30.0,
@@ -83,15 +87,13 @@
     "model": "Generic heater",
     "model_id": "2.32",
     "name": "OpenTherm",
+    "select_dhw_mode": "off",
     "sensors": {
       "intended_boiler_temperature": 39.9,
       "modulation_level": 0.0,
       "return_temperature": 32.0,
       "water_pressure": 2.2,
       "water_temperature": 45.0
-    },
-    "switches": {
-      "dhw_cm_switch": false
     },
     "vendor": "Bosch Thermotechniek B.V."
   }

--- a/fixtures/anna_v4/data.json
+++ b/fixtures/anna_v4/data.json
@@ -87,7 +87,6 @@
     "model": "Generic heater",
     "model_id": "2.32",
     "name": "OpenTherm",
-    "select_dhw_mode": "off",
     "sensors": {
       "intended_boiler_temperature": 39.9,
       "modulation_level": 0.0,
@@ -95,6 +94,7 @@
       "water_pressure": 2.2,
       "water_temperature": 45.0
     },
-    "vendor": "Bosch Thermotechniek B.V."
+    "vendor": "Bosch Thermotechniek B.V.",
+    "water_heater_mode": "off"
   }
 }

--- a/fixtures/anna_v4_dhw/data.json
+++ b/fixtures/anna_v4_dhw/data.json
@@ -67,6 +67,10 @@
       "heating_state": false
     },
     "dev_class": "heater_central",
+    "dhw_modes": [
+      "comfort",
+      "off"
+    ],
     "location": "94c107dc6ac84ed98e9f68c0dd06bf71",
     "max_dhw_temperature": {
       "lower_bound": 30.0,
@@ -83,15 +87,13 @@
     "model": "Generic heater",
     "model_id": "2.32",
     "name": "OpenTherm",
+    "select_dhw_mode": "off",
     "sensors": {
       "intended_boiler_temperature": 39.9,
       "modulation_level": 0.0,
       "return_temperature": 32.0,
       "water_pressure": 2.2,
       "water_temperature": 45.0
-    },
-    "switches": {
-      "dhw_cm_switch": false
     },
     "vendor": "Bosch Thermotechniek B.V."
   }

--- a/fixtures/anna_v4_dhw/data.json
+++ b/fixtures/anna_v4_dhw/data.json
@@ -87,7 +87,6 @@
     "model": "Generic heater",
     "model_id": "2.32",
     "name": "OpenTherm",
-    "select_dhw_mode": "off",
     "sensors": {
       "intended_boiler_temperature": 39.9,
       "modulation_level": 0.0,
@@ -95,6 +94,7 @@
       "water_pressure": 2.2,
       "water_temperature": 45.0
     },
-    "vendor": "Bosch Thermotechniek B.V."
+    "vendor": "Bosch Thermotechniek B.V.",
+    "water_heater_mode": "off"
   }
 }

--- a/fixtures/anna_v4_dhw/data.json
+++ b/fixtures/anna_v4_dhw/data.json
@@ -67,6 +67,7 @@
       "heating_state": false
     },
     "dev_class": "heater_central",
+    "dhw_mode": "off",
     "dhw_modes": [
       "comfort",
       "off"
@@ -94,7 +95,6 @@
       "water_pressure": 2.2,
       "water_temperature": 45.0
     },
-    "vendor": "Bosch Thermotechniek B.V.",
-    "water_heater_mode": "off"
+    "vendor": "Bosch Thermotechniek B.V."
   }
 }

--- a/fixtures/anna_v4_no_tag/data.json
+++ b/fixtures/anna_v4_no_tag/data.json
@@ -67,6 +67,7 @@
       "heating_state": true
     },
     "dev_class": "heater_central",
+    "dhw_mode": "off",
     "dhw_modes": [
       "comfort",
       "off"
@@ -94,7 +95,6 @@
       "water_pressure": 2.2,
       "water_temperature": 45.0
     },
-    "vendor": "Bosch Thermotechniek B.V.",
-    "water_heater_mode": "off"
+    "vendor": "Bosch Thermotechniek B.V."
   }
 }

--- a/fixtures/anna_v4_no_tag/data.json
+++ b/fixtures/anna_v4_no_tag/data.json
@@ -67,6 +67,10 @@
       "heating_state": true
     },
     "dev_class": "heater_central",
+    "dhw_modes": [
+      "comfort",
+      "off"
+    ],
     "location": "94c107dc6ac84ed98e9f68c0dd06bf71",
     "max_dhw_temperature": {
       "lower_bound": 30.0,
@@ -83,15 +87,13 @@
     "model": "Generic heater",
     "model_id": "2.32",
     "name": "OpenTherm",
+    "select_dhw_mode": "off",
     "sensors": {
       "intended_boiler_temperature": 39.9,
       "modulation_level": 0.0,
       "return_temperature": 32.0,
       "water_pressure": 2.2,
       "water_temperature": 45.0
-    },
-    "switches": {
-      "dhw_cm_switch": false
     },
     "vendor": "Bosch Thermotechniek B.V."
   }

--- a/fixtures/anna_v4_no_tag/data.json
+++ b/fixtures/anna_v4_no_tag/data.json
@@ -87,7 +87,6 @@
     "model": "Generic heater",
     "model_id": "2.32",
     "name": "OpenTherm",
-    "select_dhw_mode": "off",
     "sensors": {
       "intended_boiler_temperature": 39.9,
       "modulation_level": 0.0,
@@ -95,6 +94,7 @@
       "water_pressure": 2.2,
       "water_temperature": 45.0
     },
-    "vendor": "Bosch Thermotechniek B.V."
+    "vendor": "Bosch Thermotechniek B.V.",
+    "water_heater_mode": "off"
   }
 }

--- a/fixtures/m_adam_cooling/data.json
+++ b/fixtures/m_adam_cooling/data.json
@@ -8,6 +8,10 @@
       "heating_state": false
     },
     "dev_class": "heater_central",
+    "dhw_modes": [
+      "comfort",
+      "off"
+    ],
     "location": "bc93488efab249e5bc54fd7e175a6f91",
     "maximum_boiler_temperature": {
       "lower_bound": 25.0,
@@ -17,12 +21,10 @@
     },
     "model": "Generic heater",
     "name": "OpenTherm",
+    "select_dhw_mode": "off",
     "sensors": {
       "intended_boiler_temperature": 17.5,
       "water_temperature": 19.0
-    },
-    "switches": {
-      "dhw_cm_switch": false
     }
   },
   "14df5c4dc8cb4ba69f9d1ac0eaf7c5c6": {

--- a/fixtures/m_adam_heating/data.json
+++ b/fixtures/m_adam_heating/data.json
@@ -7,6 +7,10 @@
       "heating_state": true
     },
     "dev_class": "heater_central",
+    "dhw_modes": [
+      "comfort",
+      "off"
+    ],
     "location": "bc93488efab249e5bc54fd7e175a6f91",
     "max_dhw_temperature": {
       "lower_bound": 40.0,
@@ -22,12 +26,10 @@
     },
     "model": "Generic heater",
     "name": "OpenTherm",
+    "select_dhw_mode": "off",
     "sensors": {
       "intended_boiler_temperature": 38.1,
       "water_temperature": 37.0
-    },
-    "switches": {
-      "dhw_cm_switch": false
     }
   },
   "14df5c4dc8cb4ba69f9d1ac0eaf7c5c6": {

--- a/fixtures/m_adam_heating_off_schedule/data.json
+++ b/fixtures/m_adam_heating_off_schedule/data.json
@@ -7,6 +7,10 @@
       "heating_state": false
     },
     "dev_class": "heater_central",
+    "dhw_modes": [
+      "comfort",
+      "off"
+    ],
     "location": "bc93488efab249e5bc54fd7e175a6f91",
     "max_dhw_temperature": {
       "lower_bound": 40.0,
@@ -22,12 +26,10 @@
     },
     "model": "Generic heater",
     "name": "OpenTherm",
+    "select_dhw_mode": "off",
     "sensors": {
       "intended_boiler_temperature": 0.0,
       "water_temperature": 37.0
-    },
-    "switches": {
-      "dhw_cm_switch": false
     }
   },
   "14df5c4dc8cb4ba69f9d1ac0eaf7c5c6": {

--- a/fixtures/m_adam_jip/data.json
+++ b/fixtures/m_adam_jip/data.json
@@ -393,6 +393,10 @@
       "heating_state": false
     },
     "dev_class": "heater_central",
+    "dhw_modes": [
+      "comfort",
+      "off"
+    ],
     "location": "9e4433a9d69f40b3aefd15e74395eaec",
     "max_dhw_temperature": {
       "lower_bound": 40.0,
@@ -409,15 +413,13 @@
     "model": "Generic heater",
     "model_id": "10.20",
     "name": "OpenTherm",
+    "select_dhw_mode": "off",
     "sensors": {
       "intended_boiler_temperature": 0.0,
       "modulation_level": 0.0,
       "return_temperature": 37.1,
       "water_pressure": 1.4,
       "water_temperature": 37.3
-    },
-    "switches": {
-      "dhw_cm_switch": false
     },
     "vendor": "Remeha B.V."
   },

--- a/fixtures/m_adam_jip/data.json
+++ b/fixtures/m_adam_jip/data.json
@@ -393,6 +393,7 @@
       "heating_state": false
     },
     "dev_class": "heater_central",
+    "dhw_mode": "off",
     "dhw_modes": [
       "comfort",
       "off"
@@ -420,8 +421,7 @@
       "water_pressure": 1.4,
       "water_temperature": 37.3
     },
-    "vendor": "Remeha B.V.",
-    "water_heater_mode": "off"
+    "vendor": "Remeha B.V."
   },
   "f61f1a2535f54f52ad006a3d18e459ca": {
     "available": true,

--- a/fixtures/m_adam_jip/data.json
+++ b/fixtures/m_adam_jip/data.json
@@ -413,7 +413,6 @@
     "model": "Generic heater",
     "model_id": "10.20",
     "name": "OpenTherm",
-    "select_dhw_mode": "off",
     "sensors": {
       "intended_boiler_temperature": 0.0,
       "modulation_level": 0.0,
@@ -421,7 +420,8 @@
       "water_pressure": 1.4,
       "water_temperature": 37.3
     },
-    "vendor": "Remeha B.V."
+    "vendor": "Remeha B.V.",
+    "water_heater_mode": "off"
   },
   "f61f1a2535f54f52ad006a3d18e459ca": {
     "available": true,

--- a/fixtures/m_anna_heatpump_cooling/data.json
+++ b/fixtures/m_anna_heatpump_cooling/data.json
@@ -48,7 +48,6 @@
     },
     "model": "Generic heater/cooler",
     "name": "OpenTherm",
-    "select_dhw_mode": "off",
     "sensors": {
       "dhw_temperature": 41.5,
       "intended_boiler_temperature": 0.0,
@@ -58,7 +57,8 @@
       "water_pressure": 1.57,
       "water_temperature": 22.7
     },
-    "vendor": "Techneco"
+    "vendor": "Techneco",
+    "water_heater_mode": "off"
   },
   "3cb70739631c4d17a86b8b12e8a5161b": {
     "active_preset": "home",

--- a/fixtures/m_anna_heatpump_cooling/data.json
+++ b/fixtures/m_anna_heatpump_cooling/data.json
@@ -29,6 +29,10 @@
       "secondary_boiler_state": false
     },
     "dev_class": "heater_central",
+    "dhw_modes": [
+      "comfort",
+      "off"
+    ],
     "location": "a57efe5f145f498c9be62a9b63626fbf",
     "max_dhw_temperature": {
       "lower_bound": 35.0,
@@ -44,6 +48,7 @@
     },
     "model": "Generic heater/cooler",
     "name": "OpenTherm",
+    "select_dhw_mode": "off",
     "sensors": {
       "dhw_temperature": 41.5,
       "intended_boiler_temperature": 0.0,
@@ -52,9 +57,6 @@
       "return_temperature": 23.8,
       "water_pressure": 1.57,
       "water_temperature": 22.7
-    },
-    "switches": {
-      "dhw_cm_switch": false
     },
     "vendor": "Techneco"
   },

--- a/fixtures/m_anna_heatpump_cooling/data.json
+++ b/fixtures/m_anna_heatpump_cooling/data.json
@@ -29,6 +29,7 @@
       "secondary_boiler_state": false
     },
     "dev_class": "heater_central",
+    "dhw_mode": "off",
     "dhw_modes": [
       "comfort",
       "off"
@@ -57,8 +58,7 @@
       "water_pressure": 1.57,
       "water_temperature": 22.7
     },
-    "vendor": "Techneco",
-    "water_heater_mode": "off"
+    "vendor": "Techneco"
   },
   "3cb70739631c4d17a86b8b12e8a5161b": {
     "active_preset": "home",

--- a/fixtures/m_anna_heatpump_idle/data.json
+++ b/fixtures/m_anna_heatpump_idle/data.json
@@ -29,6 +29,7 @@
       "secondary_boiler_state": false
     },
     "dev_class": "heater_central",
+    "dhw_mode": "off",
     "dhw_modes": [
       "comfort",
       "off"
@@ -57,8 +58,7 @@
       "water_pressure": 1.57,
       "water_temperature": 19.1
     },
-    "vendor": "Techneco",
-    "water_heater_mode": "off"
+    "vendor": "Techneco"
   },
   "3cb70739631c4d17a86b8b12e8a5161b": {
     "active_preset": "home",

--- a/fixtures/m_anna_heatpump_idle/data.json
+++ b/fixtures/m_anna_heatpump_idle/data.json
@@ -48,7 +48,6 @@
     },
     "model": "Generic heater/cooler",
     "name": "OpenTherm",
-    "select_dhw_mode": "off",
     "sensors": {
       "dhw_temperature": 46.3,
       "intended_boiler_temperature": 18.0,
@@ -58,7 +57,8 @@
       "water_pressure": 1.57,
       "water_temperature": 19.1
     },
-    "vendor": "Techneco"
+    "vendor": "Techneco",
+    "water_heater_mode": "off"
   },
   "3cb70739631c4d17a86b8b12e8a5161b": {
     "active_preset": "home",

--- a/fixtures/m_anna_heatpump_idle/data.json
+++ b/fixtures/m_anna_heatpump_idle/data.json
@@ -29,6 +29,10 @@
       "secondary_boiler_state": false
     },
     "dev_class": "heater_central",
+    "dhw_modes": [
+      "comfort",
+      "off"
+    ],
     "location": "a57efe5f145f498c9be62a9b63626fbf",
     "max_dhw_temperature": {
       "lower_bound": 35.0,
@@ -44,6 +48,7 @@
     },
     "model": "Generic heater/cooler",
     "name": "OpenTherm",
+    "select_dhw_mode": "off",
     "sensors": {
       "dhw_temperature": 46.3,
       "intended_boiler_temperature": 18.0,
@@ -52,9 +57,6 @@
       "return_temperature": 22.0,
       "water_pressure": 1.57,
       "water_temperature": 19.1
-    },
-    "switches": {
-      "dhw_cm_switch": false
     },
     "vendor": "Techneco"
   },

--- a/plugwise/__init__.py
+++ b/plugwise/__init__.py
@@ -461,11 +461,11 @@ class Smile(SmileComm):
                 f"Failed to set regulation mode: {str(exc)}"
             ) from exc  # pragma no cover
 
-    async def set_dhw_mode(self, location: str, length: int, mode: str) -> None:
+    async def set_dhw_mode(self, key: str, location: str, length: int, mode: str) -> None:
         """Set the domestic hot water heating regulation mode."""
         try:  # pragma no cover
             await self._smile_api.set_dhw_mode(
-                location, length, mode
+                key, location, length, mode
             )  # pragma: no cover
         except ConnectionFailedError as exc:  # pragma no cover
             raise ConnectionFailedError(

--- a/plugwise/__init__.py
+++ b/plugwise/__init__.py
@@ -461,10 +461,10 @@ class Smile(SmileComm):
                 f"Failed to set regulation mode: {str(exc)}"
             ) from exc  # pragma no cover
 
-    async def set_dhw_mode(self, mode: str) -> None:
+    async def set_dhw_mode(self, location: str, length: int, mode: str) -> None:
         """Set the domestic hot water heating regulation mode."""
         try:  # pragma no cover
-            await self._smile_api.set_dhw_mode(mode)  # pragma: no cover
+            await self._smile_api.set_dhw_mode(location, length, mode)  # pragma: no cover
         except ConnectionFailedError as exc:  # pragma no cover
             raise ConnectionFailedError(
                 f"Failed to set dhw mode: {str(exc)}"

--- a/plugwise/__init__.py
+++ b/plugwise/__init__.py
@@ -210,10 +210,11 @@ class Smile(SmileComm):
             elec_point_meters = result.findall(
                 "./location/logs/point_log/electricity_point_meter"
             )
-            for meter in elec_point_meters:
-                if meter.get("id") and model == "smile_thermo":
-                    self.smile.anna_p1 = True
-                    break
+            if model == "smile_thermo":
+                for meter in elec_point_meters:
+                    if meter.get("id"):
+                        self.smile.anna_p1 = True
+                        break
         else:
             model = await self._smile_detect_legacy(result, dsmrmain, model)
 

--- a/plugwise/__init__.py
+++ b/plugwise/__init__.py
@@ -423,7 +423,7 @@ class Smile(SmileComm):
 
     async def set_switch_state(
         self, appl_id: str, members: list[str] | None, model: str, state: str
-    ) -> bool:
+    ) -> bool | None:
         """Set the given State of the relevant Switch.
 
         Return the result:

--- a/plugwise/__init__.py
+++ b/plugwise/__init__.py
@@ -464,7 +464,9 @@ class Smile(SmileComm):
     async def set_dhw_mode(self, location: str, length: int, mode: str) -> None:
         """Set the domestic hot water heating regulation mode."""
         try:  # pragma no cover
-            await self._smile_api.set_dhw_mode(location, length, mode)  # pragma: no cover
+            await self._smile_api.set_dhw_mode(
+                location, length, mode
+            )  # pragma: no cover
         except ConnectionFailedError as exc:  # pragma no cover
             raise ConnectionFailedError(
                 f"Failed to set dhw mode: {str(exc)}"

--- a/plugwise/__init__.py
+++ b/plugwise/__init__.py
@@ -461,7 +461,9 @@ class Smile(SmileComm):
                 f"Failed to set regulation mode: {str(exc)}"
             ) from exc  # pragma no cover
 
-    async def set_dhw_mode(self, key: str, location: str, length: int, mode: str) -> None:
+    async def set_dhw_mode(
+        self, key: str, location: str, length: int, mode: str
+    ) -> None:
         """Set the domestic hot water heating regulation mode."""
         try:  # pragma no cover
             await self._smile_api.set_dhw_mode(

--- a/plugwise/constants.py
+++ b/plugwise/constants.py
@@ -500,6 +500,7 @@ class SmileSwitches(TypedDict, total=False):
     """Smile Switches class."""
 
     cooling_ena_switch: bool
+    dhw_cm_switch: bool
     lock: bool
     relay: bool
 

--- a/plugwise/constants.py
+++ b/plugwise/constants.py
@@ -556,8 +556,9 @@ class GwEntityData(TypedDict, total=False):
     # Device availability
     available: bool | None
 
-    # Loria
+    # DHW mode related
     select_dhw_mode: str
+    water_heater_mode: str
     dhw_modes: list[str]
 
     # Gateway

--- a/plugwise/constants.py
+++ b/plugwise/constants.py
@@ -406,11 +406,6 @@ ToggleNameType = Literal[
     "cooling_ena_switch",
     "dhw_cm_switch",
 ]
-TOGGLES: Final[dict[str, ToggleNameType]] = {
-    "cooling_enabled": "cooling_ena_switch",
-    "domestic_hot_water_comfort_mode": "dhw_cm_switch",
-}
-
 ZONE_THERMOSTATS: Final[tuple[str, ...]] = (
     "thermostat",
     "thermostatic_radiator_valve",

--- a/plugwise/constants.py
+++ b/plugwise/constants.py
@@ -557,9 +557,9 @@ class GwEntityData(TypedDict, total=False):
     available: bool | None
 
     # DHW mode related
-    select_dhw_mode: str
-    water_heater_mode: str
+    dhw_mode: str
     dhw_modes: list[str]
+    select_dhw_mode: str
 
     # Gateway
     gateway_modes: list[str]

--- a/plugwise/constants.py
+++ b/plugwise/constants.py
@@ -181,6 +181,7 @@ HEATER_CENTRAL_MEASUREMENTS: Final[dict[str, DATA | UOM]] = {
     ),  # Available with the Loria and Elga (newer Anna firmware) heatpumps
     "cooling_state": UOM(NONE),
     "domestic_hot_water_mode": DATA("select_dhw_mode", NONE),
+    "domestic_hot_water_comfort_mode": DATA("select_dhw_mode", NONE),
     "domestic_hot_water_setpoint": UOM(TEMP_CELSIUS),
     "domestic_hot_water_state": DATA("dhw_state", NONE),
     "domestic_hot_water_temperature": DATA("dhw_temperature", TEMP_CELSIUS),

--- a/plugwise/constants.py
+++ b/plugwise/constants.py
@@ -387,7 +387,6 @@ SPECIAL_FORMAT: Final[tuple[str, ...]] = (ENERGY_KILO_WATT_HOUR, VOLUME_CUBIC_ME
 
 SwitchType = Literal[
     "cooling_ena_switch",
-    "dhw_cm_switch",
     "lock",
     "relay",
 ]
@@ -506,7 +505,6 @@ class SmileSwitches(TypedDict, total=False):
     """Smile Switches class."""
 
     cooling_ena_switch: bool
-    dhw_cm_switch: bool
     lock: bool
     relay: bool
 

--- a/plugwise/data.py
+++ b/plugwise/data.py
@@ -10,6 +10,7 @@ import re
 from plugwise.constants import (
     ADAM,
     ANNA,
+    LOGGER,
     MAX_SETPOINT,
     MIN_SETPOINT,
     NONE,
@@ -77,6 +78,9 @@ class SmileData(SmileHelper):
             self._update_for_cooling(entity)
 
             remove_empty_platform_dicts(entity)
+
+            if "max_dhw_temperature" in entity:
+                LOGGER.debug("HOI data: %s", entity)
 
     def _detect_low_batteries(self) -> list[str]:
         """Helper-function updating the low-battery binary_sensor status from a Battery-is-low message."""

--- a/plugwise/data.py
+++ b/plugwise/data.py
@@ -10,7 +10,6 @@ import re
 from plugwise.constants import (
     ADAM,
     ANNA,
-    LOGGER,
     MAX_SETPOINT,
     MIN_SETPOINT,
     NONE,
@@ -79,6 +78,7 @@ class SmileData(SmileHelper):
 
             remove_empty_platform_dicts(entity)
 
+            # Replace select_dhw_mode with water_heater_mode when applicable
             if "max_dhw_temperature" in entity:
                 mode = entity.get("select_dhw_mode")
                 if mode is not None:

--- a/plugwise/data.py
+++ b/plugwise/data.py
@@ -80,7 +80,10 @@ class SmileData(SmileHelper):
             remove_empty_platform_dicts(entity)
 
             if "max_dhw_temperature" in entity:
-                LOGGER.debug("HOI data: %s", entity)
+                mode = entity.get("select_dhw_mode")
+                if mode is not None:
+                    entity.pop("select_dhw_mode")
+                    entity["water_heater_mode"] = mode
 
     def _detect_low_batteries(self) -> list[str]:
         """Helper-function updating the low-battery binary_sensor status from a Battery-is-low message."""

--- a/plugwise/data.py
+++ b/plugwise/data.py
@@ -79,11 +79,12 @@ class SmileData(SmileHelper):
             remove_empty_platform_dicts(entity)
 
             # Replace select_dhw_mode with dhw_mode when applicable
-            if "max_dhw_temperature" in entity:
-                mode = entity.get("select_dhw_mode")
-                if mode is not None:
-                    entity.pop("select_dhw_mode")
-                    entity["dhw_mode"] = mode
+            if (
+                "max_dhw_temperature" in entity
+                and (mode := entity.get("select_dhw_mode")) is not None
+            ):
+                entity.pop("select_dhw_mode")
+                entity["dhw_mode"] = mode
 
     def _detect_low_batteries(self) -> list[str]:
         """Helper-function updating the low-battery binary_sensor status from a Battery-is-low message."""

--- a/plugwise/data.py
+++ b/plugwise/data.py
@@ -83,7 +83,7 @@ class SmileData(SmileHelper):
                 mode = entity.get("select_dhw_mode")
                 if mode is not None:
                     entity.pop("select_dhw_mode")
-                    entity["water_heater_mode"] = mode
+                    entity["dhw_mode"] = mode
 
     def _detect_low_batteries(self) -> list[str]:
         """Helper-function updating the low-battery binary_sensor status from a Battery-is-low message."""

--- a/plugwise/data.py
+++ b/plugwise/data.py
@@ -78,7 +78,7 @@ class SmileData(SmileHelper):
 
             remove_empty_platform_dicts(entity)
 
-            # Replace select_dhw_mode with water_heater_mode when applicable
+            # Replace select_dhw_mode with dhw_mode when applicable
             if "max_dhw_temperature" in entity:
                 mode = entity.get("select_dhw_mode")
                 if mode is not None:

--- a/plugwise/helper.py
+++ b/plugwise/helper.py
@@ -471,12 +471,7 @@ class SmileHelper(SmileCommon):
                     case "elga_status_code":
                         data["elga_status_code"] = int(appl_p_loc.text)
                     case "select_dhw_mode":
-                        if self._dhw_allowed_modes and "select_dhw_mode" not in data:
-                            data["select_dhw_mode"] = appl_p_loc.text
-                            if old_measurement == "domestic_hot_water_comfort_mode":
-                                data["select_dhw_mode"] = (
-                                    "comfort" if appl_p_loc.text == "on" else "off"
-                                )
+                        self._select_dhw_mode(appl_p_loc.text, data, old_measurement)
 
                 common_match_cases(measurement, attrs, appl_p_loc, data)
 
@@ -488,6 +483,15 @@ class SmileHelper(SmileCommon):
                 )
 
         self._count = count_data_items(self._count, data)
+
+    def _select_dhw_mode(self, text: str, data: GwEntityData, measurement: str) -> None:
+        """Set the selected dhw mode."""
+        if self._dhw_allowed_modes and "select_dhw_mode" not in data:
+            data["select_dhw_mode"] = text
+            if measurement == "domestic_hot_water_comfort_mode":
+                data["select_dhw_mode"] = (
+                    "comfort" if text == "on" else "off"
+                )
 
     def _get_toggle_state(
         self,

--- a/plugwise/helper.py
+++ b/plugwise/helper.py
@@ -463,6 +463,7 @@ class SmileHelper(SmileCommon):
                     continue
 
                 if new_name := getattr(attrs, ATTR_NAME, None):
+                    old_measurement = measurement
                     measurement = new_name
 
                 match measurement:
@@ -471,6 +472,8 @@ class SmileHelper(SmileCommon):
                     case "select_dhw_mode":
                         if self._dhw_allowed_modes:
                             data["select_dhw_mode"] = appl_p_loc.text
+                            if old_measurement == "domestic_hot_water_comfort_mode":
+                                  data["select_dhw_mode"] = "comfort" if appl_p_loc.text == "on" else "off"
 
                 common_match_cases(measurement, attrs, appl_p_loc, data)
 
@@ -499,7 +502,6 @@ class SmileHelper(SmileCommon):
                         self._count += 1
                     case "domestic_hot_water_comfort_mode":
                         self._dhw_allowed_modes = ["comfort", "off"]
-                        # data["select_dhw_mode"] = "comfort" if state.text == "on" else "off"
 
     def _get_plugwise_notifications(self) -> None:
         """Collect the Plugwise notifications."""

--- a/plugwise/helper.py
+++ b/plugwise/helper.py
@@ -503,7 +503,6 @@ class SmileHelper(SmileCommon):
                 match toggle:
                     case "cooling_enabled":
                         data["switches"][name] = state.text == "on"
-                        self._count += 1
                     case "domestic_hot_water_comfort_mode":
                         self._dhw_allowed_modes = ["comfort", "off"]
 

--- a/plugwise/helper.py
+++ b/plugwise/helper.py
@@ -419,7 +419,9 @@ class SmileHelper(SmileCommon):
             appliance := self._domain_objects.find(f'./appliance[@id="{entity_id}"]')
         ) is not None:
             # Collect the cooling enabled toggle state
-            self._get_toggle_state(appliance, "cooling_enabled", "cooling_ena_switch", data)
+            self._get_toggle_state(
+                appliance, "cooling_enabled", "cooling_ena_switch", data
+            )
 
             self._appliance_measurements(appliance, data, measurements)
             self._get_lock_state(appliance, data)
@@ -473,7 +475,9 @@ class SmileHelper(SmileCommon):
                         if self._dhw_allowed_modes:
                             data["select_dhw_mode"] = appl_p_loc.text
                             if old_measurement == "domestic_hot_water_comfort_mode":
-                                  data["select_dhw_mode"] = "comfort" if appl_p_loc.text == "on" else "off"
+                                data["select_dhw_mode"] = (
+                                    "comfort" if appl_p_loc.text == "on" else "off"
+                                )
 
                 common_match_cases(measurement, attrs, appl_p_loc, data)
 

--- a/plugwise/helper.py
+++ b/plugwise/helper.py
@@ -463,8 +463,8 @@ class SmileHelper(SmileCommon):
                 if skip_obsolete_measurements(appliance, measurement):
                     continue
 
+                old_measurement = measurement
                 if new_name := getattr(attrs, ATTR_NAME, None):
-                    old_measurement = measurement
                     measurement = new_name
 
                 match measurement:

--- a/plugwise/helper.py
+++ b/plugwise/helper.py
@@ -272,7 +272,7 @@ class SmileHelper(SmileCommon):
         # Collect the default dhw modes: comfort and off
         if not self._dhw_allowed_modes:
             self._get_toggle_state(
-                appliance, "domestic_hot_water_comfort_mode", "dhw_cm_switch", None
+                appliance, "domestic_hot_water_comfort_mode", "dhw_cm_switch", {}
             )
 
     def _appl_gateway_info(self, appl: Munch, appliance: etree.Element) -> Munch:
@@ -490,7 +490,11 @@ class SmileHelper(SmileCommon):
         self._count = count_data_items(self._count, data)
 
     def _get_toggle_state(
-        self, xml: etree.Element, toggle: str, name: ToggleNameType, data: GwEntityData | None
+        self,
+        xml: etree.Element,
+        toggle: str,
+        name: ToggleNameType,
+        data: GwEntityData,
     ) -> None:
         """Helper-function for _get_measurement_data().
 

--- a/plugwise/helper.py
+++ b/plugwise/helper.py
@@ -242,9 +242,8 @@ class SmileHelper(SmileCommon):
                     appl := self._appl_heater_central_info(appl, appliance, False)
                 ):  # False means non-legacy entity
                     return Munch()
-                self._dhw_allowed_modes = self._get_appl_actuator_modes(
-                    appliance, "domestic_hot_water_mode_control_functionality"
-                )
+                self._collect_dhw_modes(appliance)
+
                 return appl
             case _ as s if s.endswith("_plug"):
                 # Collect info from plug-types (Plug, Aqara Smart Plug)
@@ -264,6 +263,18 @@ class SmileHelper(SmileCommon):
                 return appl
             case _:  # pragma: no cover
                 return Munch()
+
+    def _collect_dhw_modes(self, appliance: etree.Element) -> None:
+        """Collect the DHW modes."""
+        # Collect the Loria dhw_modes
+        self._dhw_allowed_modes = self._get_appl_actuator_modes(
+            appliance, "domestic_hot_water_mode_control_functionality"
+        )
+        # Collect the default dhw modes: comfort and off
+        if not self._dhw_allowed_modes:
+            self._get_toggle_state(
+                appliance, "domestic_hot_water_comfort_mode", "dhw_cm_switch", None
+            )
 
     def _appl_gateway_info(self, appl: Munch, appliance: etree.Element) -> Munch:
         """Helper-function for _appliance_info_finder()."""
@@ -407,8 +418,8 @@ class SmileHelper(SmileCommon):
         if (
             appliance := self._domain_objects.find(f'./appliance[@id="{entity_id}"]')
         ) is not None:
-            for toggle, name in TOGGLES.items():
-                self._get_toggle_state(appliance, toggle, name, data)
+            # Collect the cooling enabled toggle state
+            self._get_toggle_state(appliance, "cooling_enabled", "cooling_ena_switch", data)
 
             self._appliance_measurements(appliance, data, measurements)
             self._get_lock_state(appliance, data)
@@ -483,12 +494,12 @@ class SmileHelper(SmileCommon):
             locator = f"./actuator_functionalities/toggle_functionality[type='{toggle}']/state"
             if (state := xml.find(locator)) is not None:
                 match toggle:
-                    case "cooling_ena_switch":
+                    case "cooling_enabled":
                         data["switches"][name] = state.text == "on"
                         self._count += 1
-                    case "dhw_cm_switch":
+                    case "domestic_hot_water_comfort_mode":
                         self._dhw_allowed_modes = ["comfort", "off"]
-                        self.select_dhw_mode = "comfort" if state.text == "on" else "off"
+                        # data["select_dhw_mode"] = "comfort" if state.text == "on" else "off"
 
     def _get_plugwise_notifications(self) -> None:
         """Collect the Plugwise notifications."""

--- a/plugwise/helper.py
+++ b/plugwise/helper.py
@@ -407,11 +407,11 @@ class SmileHelper(SmileCommon):
         if (
             appliance := self._domain_objects.find(f'./appliance[@id="{entity_id}"]')
         ) is not None:
-            self._appliance_measurements(appliance, data, measurements)
-            self._get_lock_state(appliance, data)
-
             for toggle, name in TOGGLES.items():
                 self._get_toggle_state(appliance, toggle, name, data)
+
+            self._appliance_measurements(appliance, data, measurements)
+            self._get_lock_state(appliance, data)
 
             if appliance.find("type").text in ACTUATOR_CLASSES:
                 self._get_actuator_functionalities(appliance, entity, data)

--- a/plugwise/helper.py
+++ b/plugwise/helper.py
@@ -491,7 +491,7 @@ class SmileHelper(SmileCommon):
         self._count = count_data_items(self._count, data)
 
     def _get_toggle_state(
-        self, xml: etree.Element, toggle: str, name: ToggleNameType, data: GwEntityData
+        self, xml: etree.Element, toggle: str, name: ToggleNameType, data: GwEntityData | None
     ) -> None:
         """Helper-function for _get_measurement_data().
 

--- a/plugwise/helper.py
+++ b/plugwise/helper.py
@@ -489,9 +489,7 @@ class SmileHelper(SmileCommon):
         if self._dhw_allowed_modes and "select_dhw_mode" not in data:
             data["select_dhw_mode"] = text
             if measurement == "domestic_hot_water_comfort_mode":
-                data["select_dhw_mode"] = (
-                    "comfort" if text == "on" else "off"
-                )
+                data["select_dhw_mode"] = "comfort" if text == "on" else "off"
 
     def _get_toggle_state(
         self,

--- a/plugwise/helper.py
+++ b/plugwise/helper.py
@@ -482,8 +482,13 @@ class SmileHelper(SmileCommon):
         if xml.find("type").text == "heater_central":
             locator = f"./actuator_functionalities/toggle_functionality[type='{toggle}']/state"
             if (state := xml.find(locator)) is not None:
-                data["switches"][name] = state.text == "on"
-                self._count += 1
+                match toggle:
+                    case "cooling_ena_switch":
+                        data["switches"][name] = state.text == "on"
+                        self._count += 1
+                    case "dhw_cm_switch":
+                        self._dhw_allowed_modes = ["comfort", "off"]
+                        self.select_dhw_mode = "comfort" if state.text == "on" else "off"
 
     def _get_plugwise_notifications(self) -> None:
         """Collect the Plugwise notifications."""

--- a/plugwise/helper.py
+++ b/plugwise/helper.py
@@ -472,7 +472,7 @@ class SmileHelper(SmileCommon):
                     case "elga_status_code":
                         data["elga_status_code"] = int(appl_p_loc.text)
                     case "select_dhw_mode":
-                        if self._dhw_allowed_modes:
+                        if self._dhw_allowed_modes and "select_dhw_mode" not in data:
                             data["select_dhw_mode"] = appl_p_loc.text
                             if old_measurement == "domestic_hot_water_comfort_mode":
                                 data["select_dhw_mode"] = (

--- a/plugwise/helper.py
+++ b/plugwise/helper.py
@@ -32,7 +32,6 @@ from plugwise.constants import (
     TEMP_CELSIUS,
     THERMO_MATCHING,
     THERMOSTAT_CLASSES,
-    TOGGLES,
     UOM,
     ZONE_MEASUREMENTS,
     ActuatorData,

--- a/plugwise/helper.py
+++ b/plugwise/helper.py
@@ -351,7 +351,7 @@ class SmileHelper(SmileCommon):
         measurements = DEVICE_MEASUREMENTS
         if self._is_thermostat and entity_id == self.heater_id:
             measurements = HEATER_CENTRAL_MEASUREMENTS
-            # Show the allowed dhw_modes (Loria only)
+            # Show the available dhw_modes
             if self._dhw_allowed_modes:
                 data["dhw_modes"] = self._dhw_allowed_modes
                 # Counting of this item is done in _appliance_measurements()

--- a/plugwise/helper.py
+++ b/plugwise/helper.py
@@ -265,11 +265,11 @@ class SmileHelper(SmileCommon):
 
     def _collect_dhw_modes(self, appliance: etree.Element) -> None:
         """Collect the DHW modes."""
-        # Collect the Loria dhw_modes
+        # Collect the Loria dhw modes
         self._dhw_allowed_modes = self._get_appl_actuator_modes(
             appliance, "domestic_hot_water_mode_control_functionality"
         )
-        # Collect the default dhw modes: comfort and off
+        # Determine the dhw modes from the domestic_hot_water_comfort_mode toggle
         if not self._dhw_allowed_modes:
             self._get_toggle_state(
                 appliance, "domestic_hot_water_comfort_mode", "dhw_cm_switch", {}

--- a/plugwise/legacy/smile.py
+++ b/plugwise/legacy/smile.py
@@ -223,7 +223,7 @@ class SmileLegacyAPI(SmileLegacyData):
 
     async def set_switch_state(
         self, appl_id: str, members: list[str] | None, model: str, state: str
-    ) -> bool:
+    ) -> bool | None:
         """Set the given state of the relevant switch.
 
         For individual switches, sets the state directly.
@@ -231,7 +231,7 @@ class SmileLegacyAPI(SmileLegacyData):
         For switch-locks, sets the lock state using a different data format.
         Return the requested state when successful, the current state otherwise.
         """
-        current_state = self.gw_entities[appl_id]["switches"]["relay"]
+        current_state = self.gw_entities[appl_id]["switches"].get("relay")
         requested_state = state == STATE_ON
         switch = Munch()
         switch.actuator = "actuator_functionalities"

--- a/plugwise/legacy/smile.py
+++ b/plugwise/legacy/smile.py
@@ -131,7 +131,7 @@ class SmileLegacyAPI(SmileLegacyData):
     async def reboot_gateway(self) -> None:
         """Set-function placeholder for legacy devices."""
 
-    async def set_dhw_mode(self, loc_id: str, length: int, mode: str) -> None:
+    async def set_dhw_mode(self, key: str, location: str, length: int, mode: str) -> None:
         """Set-function placeholder for legacy devices."""
 
     async def set_gateway_mode(self, mode: str) -> None:

--- a/plugwise/legacy/smile.py
+++ b/plugwise/legacy/smile.py
@@ -131,7 +131,9 @@ class SmileLegacyAPI(SmileLegacyData):
     async def reboot_gateway(self) -> None:
         """Set-function placeholder for legacy devices."""
 
-    async def set_dhw_mode(self, key: str, location: str, length: int, mode: str) -> None:
+    async def set_dhw_mode(
+        self, key: str, location: str, length: int, mode: str
+    ) -> None:
         """Set-function placeholder for legacy devices."""
 
     async def set_gateway_mode(self, mode: str) -> None:

--- a/plugwise/legacy/smile.py
+++ b/plugwise/legacy/smile.py
@@ -131,7 +131,7 @@ class SmileLegacyAPI(SmileLegacyData):
     async def reboot_gateway(self) -> None:
         """Set-function placeholder for legacy devices."""
 
-    async def set_dhw_mode(self, mode: str) -> None:
+    async def set_dhw_mode(self, loc_id: str, length: int, mode: str) -> None:
         """Set-function placeholder for legacy devices."""
 
     async def set_gateway_mode(self, mode: str) -> None:

--- a/plugwise/smile.py
+++ b/plugwise/smile.py
@@ -43,10 +43,6 @@ def model_to_switch_items(model: str, state: str, switch: Munch) -> tuple[str, M
     Helper function for set_switch_state().
     """
     match model:
-        case "dhw_cm_switch":
-            switch.device = "toggle"
-            switch.func_type = "toggle_functionality"
-            switch.act_type = "domestic_hot_water_comfort_mode"
         case "cooling_ena_switch":
             switch.device = "toggle"
             switch.func_type = "toggle_functionality"

--- a/plugwise/smile.py
+++ b/plugwise/smile.py
@@ -238,7 +238,6 @@ class SmileAPI(SmileData):
         """Set a dhw/gateway/regulation mode or the thermostat schedule option."""
         match key:
             case "select_dhw_mode":
-                state = STATE_ON if option == "comfort" else STATE_OFF
                 await self.set_switch_state(loc_id, None, key, state)
             case "select_gateway_mode":
                 await self.set_gateway_mode(option)

--- a/plugwise/smile.py
+++ b/plugwise/smile.py
@@ -43,6 +43,10 @@ def model_to_switch_items(model: str, state: str, switch: Munch) -> tuple[str, M
     Helper function for set_switch_state().
     """
     match model:
+        case "select_dhw_mode":
+            switch.device = "toggle"
+            switch.func_type = "toggle_functionality"
+            switch.act_type = "domestic_hot_water_comfort_mode"
         case "cooling_ena_switch":
             switch.device = "toggle"
             switch.func_type = "toggle_functionality"
@@ -234,7 +238,8 @@ class SmileAPI(SmileData):
         """Set a dhw/gateway/regulation mode or the thermostat schedule option."""
         match key:
             case "select_dhw_mode":
-                await self.set_dhw_mode(option)
+                state = STATE_ON if option == "comfort" else STATE_OFF
+                await self.set_switch_state(loc_id, None, key, state)
             case "select_gateway_mode":
                 await self.set_gateway_mode(option)
             case "select_regulation_mode":
@@ -245,18 +250,27 @@ class SmileAPI(SmileData):
             case "select_zone_profile":
                 await self.set_zone_profile(loc_id, option)
 
-    async def set_dhw_mode(self, mode: str) -> None:
-        """Set the domestic hot water heating regulation mode."""
+    async def set_dhw_mode(
+        self, key: str, loc_id: str, length: int, mode: str
+    ) -> None:
+        """Set the domestic hot water mode."""
         if mode not in self._dhw_allowed_modes:
             raise PlugwiseError("Plugwise: invalid dhw mode.")
 
-        data = (
-            "<domestic_hot_water_mode_control_functionality>"
-            f"<mode>{mode}</mode>"
-            "</domestic_hot_water_mode_control_functionality>"
-        )
-        uri = f"{APPLIANCES};type=heater_central/domestic_hot_water_mode_control"
-        await self.call_request(uri, method="put", data=data)
+        match length:
+            # Devices with the domestic_hot_water_comfort switch
+            case 2:
+                state = STATE_ON if mode == "comfort" else STATE_OFF
+                await self.set_switch_state(loc_id, None, key, state)
+            # Loria with extended dhw modes
+            case _:
+                data = (
+                    "<domestic_hot_water_mode_control_functionality>"
+                    f"<mode>{mode}</mode>"
+                    "</domestic_hot_water_mode_control_functionality>"
+                )
+                uri = f"{APPLIANCES};type=heater_central/domestic_hot_water_mode_control"
+                await self.call_request(uri, method="put", data=data)
 
     async def set_gateway_mode(self, mode: str) -> None:
         """Set the gateway mode."""

--- a/plugwise/smile.py
+++ b/plugwise/smile.py
@@ -460,6 +460,7 @@ class SmileAPI(SmileData):
 
         locator = f'appliance[@id="{appl_id}"]/{switch.actuator}/{switch.func_type}'
         found = self._domain_objects.findall(locator)
+        switch_id: str | None = None
         for item in found:
             # multiple types of e.g. toggle_functionality present
             if (sw_type := item.find("type")) is not None:

--- a/plugwise/smile.py
+++ b/plugwise/smile.py
@@ -256,7 +256,7 @@ class SmileAPI(SmileData):
         self, key: str, appl_id: str, length: int, mode: str
     ) -> None:
         """Set the domestic hot water mode.
-        
+
         Two options are known:
         - 2 modes, comfort and off, representing the dhw comfort mode on and off switch states,
         - and the 5 modes available on the Loria.

--- a/plugwise/smile.py
+++ b/plugwise/smile.py
@@ -54,6 +54,7 @@ def model_to_switch_items(model: str, state: str, switch: Munch) -> tuple[str, M
             switch.act_type = "cooling_enabled"
         case "lock":
             switch.func = "lock"
+            switch.method = "post"
             state = "true" if state == STATE_ON else "false"
 
     return state, switch
@@ -446,6 +447,7 @@ class SmileAPI(SmileData):
         switch.device = "relay"
         switch.func_type = "relay_functionality"
         switch.func = "state"
+        switch.method = "put"
         state, switch = model_to_switch_items(model, state, switch)
         data = (
             f"<{switch.func_type}>"
@@ -469,7 +471,7 @@ class SmileAPI(SmileData):
                 # lock is present. That means the relay can't be controlled by the user.
                 return current_state
 
-        await self.call_request(uri, method="put", data=data)
+        await self.call_request(uri, method=switch.method, data=data)
         return requested_state
 
     async def _set_groupswitch_member_state(

--- a/plugwise/smile.py
+++ b/plugwise/smile.py
@@ -46,11 +46,11 @@ def model_to_switch_items(model: str, state: str, switch: Munch) -> tuple[str, M
     match model:
         case "select_dhw_mode" | "dhw_mode":
             switch.device = "toggle"
-            switch.func_type = "toggle_functionality"
+            switch.func_type = "toggle"
             switch.act_type = "domestic_hot_water_comfort_mode"
         case "cooling_ena_switch":
             switch.device = "toggle"
-            switch.func_type = "toggle_functionality"
+            switch.func_type = "toggle"
             switch.act_type = "cooling_enabled"
         case "lock":
             switch.func = "lock"
@@ -452,27 +452,16 @@ class SmileAPI(SmileData):
             f"<{switch.func}>{state}</{switch.func}>"
             f"</{switch.func_type}>"
         )
+        extra = ""
+        if switch.device == "toggle":
+            extra = f";type={switch.act_type}"
 
         if members is not None:
             return await self._set_groupswitch_member_state(
                 appl_id, data, members, state, switch
             )
 
-        locator = f'appliance[@id="{appl_id}"]/{switch.actuator}/{switch.func_type}'
-        found = self._domain_objects.findall(locator)
-        switch_id: str | None = None
-        for item in found:
-            # multiple types of e.g. toggle_functionality present
-            if (sw_type := item.find("type")) is not None:
-                LOGGER.debug("HOI switch_type: %s", sw_type.text)
-                if sw_type.text == switch.act_type:
-                    switch_id = item.get("id")
-                    break
-            else:  # actuators with a single item like relay_functionality
-                switch_id = item.get("id")
-        LOGGER.debug("HOI switch_id: %s", switch_id)
-
-        uri = f"{APPLIANCES};id={appl_id}/{switch.device};id={switch_id}"
+        uri = f"{APPLIANCES};id={appl_id}/{switch.device}{extra}"
         if model == "relay":
             lock_blocked = self.gw_entities[appl_id]["switches"].get("lock")
             if lock_blocked or lock_blocked is None:

--- a/plugwise/smile.py
+++ b/plugwise/smile.py
@@ -44,7 +44,7 @@ def model_to_switch_items(model: str, state: str, switch: Munch) -> tuple[str, M
     Helper function for set_switch_state().
     """
     match model:
-        case "select_dhw_mode":
+        case "select_dhw_mode" | "dhw_mode":
             switch.device = "toggle"
             switch.func_type = "toggle_functionality"
             switch.act_type = "domestic_hot_water_comfort_mode"
@@ -238,7 +238,7 @@ class SmileAPI(SmileData):
     ) -> None:
         """Set a dhw/gateway/regulation mode or the thermostat schedule option."""
         match key:
-            case "select_dhw_mode":
+            case "select_dhw_mode" | "dhw_mode":
                 await self.set_switch_state(loc_id, None, key, state)
             case "select_gateway_mode":
                 await self.set_gateway_mode(option)
@@ -250,7 +250,9 @@ class SmileAPI(SmileData):
             case "select_zone_profile":
                 await self.set_zone_profile(loc_id, option)
 
-    async def set_dhw_mode(self, loc_id: str, length: int, mode: str) -> None:
+    async def set_dhw_mode(
+        self, key: str, loc_id: str, length: int, mode: str
+    ) -> None:
         """Set the domestic hot water mode."""
         if mode not in self._dhw_allowed_modes:
             raise PlugwiseError("Plugwise: invalid dhw mode.")
@@ -258,12 +260,8 @@ class SmileAPI(SmileData):
         match length:
             # Devices with the domestic_hot_water_comfort switch
             case 2:
-                # two options here:
-                # - with max_dhw_temperature dict: call set_select()
-                # - without: call set_switch_state()
                 state = STATE_ON if mode == "comfort" else STATE_OFF
-                await self.set_switch_state(loc_id, None, "select_dhw_mode", state)
-
+                await self.set_select(key, loc_id, None, state)
             # Loria with extended dhw modes
             case _:
                 data = (

--- a/plugwise/smile.py
+++ b/plugwise/smile.py
@@ -232,37 +232,41 @@ class SmileAPI(SmileData):
         await self.call_request(uri, method="put", data=data)
 
     async def set_select(
-        self, key: str, loc_id: str, option: str, state: str | None
+        self, key: str, appl_or_loc_id: str, option: str, state: str | None
     ) -> None:
         """Set a dhw/gateway/regulation mode or the thermostat schedule option."""
         match key:
             case "select_dhw_mode" | "dhw_mode":
                 state = STATE_ON if option == "comfort" else STATE_OFF
-                # Appliance id is passed as loc_id
-                await self.set_switch_state(loc_id, None, key, state)
+                # Appliance id is passed
+                await self.set_switch_state(appl_or_loc_id, None, key, state)
             case "select_gateway_mode":
                 await self.set_gateway_mode(option)
             case "select_regulation_mode":
                 await self.set_regulation_mode(option)
             case "select_schedule":
                 # The schedule name corresponds to the select option
-                # Location id is passed as loc_id
-                await self.set_schedule_state(loc_id, state, option)
+                # Location id is passed
+                await self.set_schedule_state(appl_or_loc_id, state, option)
             case "select_zone_profile":
-                await self.set_zone_profile(loc_id, option)
+                # Location id is passed
+                await self.set_zone_profile(appl_or_loc_id, option)
 
     async def set_dhw_mode(
         self, key: str, appl_id: str, length: int, mode: str
     ) -> None:
-        """Set the domestic hot water mode."""
+        """Set the domestic hot water mode.
+        
+        Two options are known:
+        - 2 modes, comfort and off, representing the dhw comfort mode on and off switch states,
+        - and the 5 modes available on the Loria.
+        """
         if mode not in self._dhw_allowed_modes:
             raise PlugwiseError("Plugwise: invalid dhw mode.")
 
         match length:
-            # Devices with the domestic_hot_water_comfort switch
             case 2:
                 await self.set_select(key, appl_id, mode, None)
-            # Loria with extended dhw modes
             case _:
                 data = (
                     "<domestic_hot_water_mode_control_functionality>"

--- a/plugwise/smile.py
+++ b/plugwise/smile.py
@@ -16,7 +16,6 @@ from plugwise.constants import (
     DOMAIN_OBJECTS,
     GATEWAY_REBOOT,
     LOCATIONS,
-    LOGGER,
     MAX_SETPOINT,
     MIN_SETPOINT,
     NONE,
@@ -236,9 +235,6 @@ class SmileAPI(SmileData):
         self, key: str, loc_id: str, option: str, state: str | None
     ) -> None:
         """Set a dhw/gateway/regulation mode or the thermostat schedule option."""
-        LOGGER.debug(
-            "HOI set_select called with: %s, %s, %s, %s", key, loc_id, option, state
-        )
         match key:
             case "select_dhw_mode" | "dhw_mode":
                 state = STATE_ON if option == "comfort" else STATE_OFF
@@ -262,9 +258,6 @@ class SmileAPI(SmileData):
         if mode not in self._dhw_allowed_modes:
             raise PlugwiseError("Plugwise: invalid dhw mode.")
 
-        LOGGER.debug(
-            "HOI set_dhw_mode called with: %s, %s, %s, %s", key, appl_id, length, mode
-        )
         match length:
             # Devices with the domestic_hot_water_comfort switch
             case 2:
@@ -427,13 +420,6 @@ class SmileAPI(SmileData):
         For switch-locks, sets the lock state using a different data format.
         Return the requested state when successful, the current state otherwise.
         """
-        LOGGER.debug(
-            "HOI set_switch_state called with: %s, %s, %s, %s",
-            appl_id,
-            members,
-            model,
-            state,
-        )
         model_type = cast(SwitchType, model)
         try:
             current_state = self.gw_entities[appl_id]["switches"][model_type]

--- a/plugwise/smile.py
+++ b/plugwise/smile.py
@@ -410,7 +410,7 @@ class SmileAPI(SmileData):
 
     async def set_switch_state(
         self, appl_id: str, members: list[str] | None, model: str, state: str
-    ) -> bool:
+    ) -> bool | None:
         """Set the given state of the relevant Switch.
 
         For individual switches, sets the state directly.

--- a/plugwise/smile.py
+++ b/plugwise/smile.py
@@ -238,7 +238,8 @@ class SmileAPI(SmileData):
         """Set a dhw/gateway/regulation mode or the thermostat schedule option."""
         match key:
             case "select_dhw_mode" | "dhw_mode":
-                await self.set_switch_state(loc_id, None, key, state)
+                if state is not None:
+                    await self.set_switch_state(loc_id, None, key, state)
             case "select_gateway_mode":
                 await self.set_gateway_mode(option)
             case "select_regulation_mode":
@@ -258,7 +259,7 @@ class SmileAPI(SmileData):
             # Devices with the domestic_hot_water_comfort switch
             case 2:
                 state = STATE_ON if mode == "comfort" else STATE_OFF
-                await self.set_select(key, loc_id, None, state)
+                await self.set_select(key, loc_id, "dummy", state)
             # Loria with extended dhw modes
             case _:
                 data = (

--- a/plugwise/smile.py
+++ b/plugwise/smile.py
@@ -419,7 +419,11 @@ class SmileAPI(SmileData):
         Return the requested state when successful, the current state otherwise.
         """
         model_type = cast(SwitchType, model)
-        current_state = self.gw_entities[appl_id]["switches"][model_type]
+        try:
+            current_state = self.gw_entities[appl_id]["switches"][model_type]
+        except KeyError:
+            current_state = None
+
         requested_state = state == STATE_ON
         switch = Munch()
         switch.actuator = "actuator_functionalities"

--- a/plugwise/smile.py
+++ b/plugwise/smile.py
@@ -244,14 +244,15 @@ class SmileAPI(SmileData):
         match key:
             case "select_dhw_mode" | "dhw_mode":
                 state = STATE_ON if option == "comfort" else STATE_OFF
-                # loc_id = appliance_id
+                # Appliance id is passed as loc_id
                 await self.set_switch_state(loc_id, None, key, state)
             case "select_gateway_mode":
                 await self.set_gateway_mode(option)
             case "select_regulation_mode":
                 await self.set_regulation_mode(option)
             case "select_schedule":
-                # schedule name corresponds to select option
+                # The schedule name corresponds to the select option
+                # Location id is passed as loc_id
                 await self.set_schedule_state(loc_id, state, option)
             case "select_zone_profile":
                 await self.set_zone_profile(loc_id, option)

--- a/plugwise/smile.py
+++ b/plugwise/smile.py
@@ -238,8 +238,9 @@ class SmileAPI(SmileData):
         """Set a dhw/gateway/regulation mode or the thermostat schedule option."""
         match key:
             case "select_dhw_mode" | "dhw_mode":
-                if state is not None:
-                    await self.set_switch_state(loc_id, None, key, state)
+                state = STATE_ON if option == "comfort" else STATE_OFF
+                # loc_id = appliance_id
+                await self.set_switch_state(loc_id, None, key, state)
             case "select_gateway_mode":
                 await self.set_gateway_mode(option)
             case "select_regulation_mode":
@@ -250,7 +251,7 @@ class SmileAPI(SmileData):
             case "select_zone_profile":
                 await self.set_zone_profile(loc_id, option)
 
-    async def set_dhw_mode(self, key: str, loc_id: str, length: int, mode: str) -> None:
+    async def set_dhw_mode(self, key: str, appl_id: str, length: int, mode: str) -> None:
         """Set the domestic hot water mode."""
         if mode not in self._dhw_allowed_modes:
             raise PlugwiseError("Plugwise: invalid dhw mode.")
@@ -258,8 +259,7 @@ class SmileAPI(SmileData):
         match length:
             # Devices with the domestic_hot_water_comfort switch
             case 2:
-                state = STATE_ON if mode == "comfort" else STATE_OFF
-                await self.set_select(key, loc_id, "dummy", state)
+                await self.set_select(key, appl_id, mode, None)
             # Loria with extended dhw modes
             case _:
                 data = (

--- a/plugwise/smile.py
+++ b/plugwise/smile.py
@@ -251,7 +251,9 @@ class SmileAPI(SmileData):
             case "select_zone_profile":
                 await self.set_zone_profile(loc_id, option)
 
-    async def set_dhw_mode(self, key: str, appl_id: str, length: int, mode: str) -> None:
+    async def set_dhw_mode(
+        self, key: str, appl_id: str, length: int, mode: str
+    ) -> None:
         """Set the domestic hot water mode."""
         if mode not in self._dhw_allowed_modes:
             raise PlugwiseError("Plugwise: invalid dhw mode.")

--- a/plugwise/smile.py
+++ b/plugwise/smile.py
@@ -484,9 +484,7 @@ class SmileAPI(SmileData):
         requested_state = state == STATE_ON
         switched = 0
         for member in members:
-            locator = f'appliance[@id="{member}"]/{switch.actuator}/{switch.func_type}'
-            switch_id = self._domain_objects.find(locator).get("id")
-            uri = f"{APPLIANCES};id={member}/{switch.device};id={switch_id}"
+            uri = f"{APPLIANCES};id={member}/{switch.device}"
             lock_blocked = self.gw_entities[member]["switches"].get("lock")
             # Assume Plugs under Plugwise control are not part of a group
             if lock_blocked is not None and not lock_blocked:

--- a/plugwise/smile.py
+++ b/plugwise/smile.py
@@ -16,7 +16,6 @@ from plugwise.constants import (
     DOMAIN_OBJECTS,
     GATEWAY_REBOOT,
     LOCATIONS,
-    LOGGER,
     MAX_SETPOINT,
     MIN_SETPOINT,
     NONE,
@@ -250,9 +249,7 @@ class SmileAPI(SmileData):
             case "select_zone_profile":
                 await self.set_zone_profile(loc_id, option)
 
-    async def set_dhw_mode(
-        self, key: str, loc_id: str, length: int, mode: str
-    ) -> None:
+    async def set_dhw_mode(self, key: str, loc_id: str, length: int, mode: str) -> None:
         """Set the domestic hot water mode."""
         if mode not in self._dhw_allowed_modes:
             raise PlugwiseError("Plugwise: invalid dhw mode.")

--- a/plugwise/smile.py
+++ b/plugwise/smile.py
@@ -45,12 +45,10 @@ def model_to_switch_items(model: str, state: str, switch: Munch) -> tuple[str, M
     """
     match model:
         case "select_dhw_mode" | "dhw_mode":
-            switch.device = "toggle"
-            switch.func_type = "toggle"
+            switch.device = switch.func_type = "toggle"
             switch.act_type = "domestic_hot_water_comfort_mode"
         case "cooling_ena_switch":
-            switch.device = "toggle"
-            switch.func_type = "toggle"
+            switch.device = switch.func_type = "toggle"
             switch.act_type = "cooling_enabled"
         case "lock":
             switch.func = "lock"

--- a/plugwise/smile.py
+++ b/plugwise/smile.py
@@ -16,6 +16,7 @@ from plugwise.constants import (
     DOMAIN_OBJECTS,
     GATEWAY_REBOOT,
     LOCATIONS,
+    LOGGER,
     MAX_SETPOINT,
     MIN_SETPOINT,
     NONE,
@@ -257,8 +258,12 @@ class SmileAPI(SmileData):
         match length:
             # Devices with the domestic_hot_water_comfort switch
             case 2:
+                # two options here:
+                # - with max_dhw_temperature dict: call set_select()
+                # - without: call set_switch_state()
                 state = STATE_ON if mode == "comfort" else STATE_OFF
                 await self.set_switch_state(loc_id, None, "select_dhw_mode", state)
+
             # Loria with extended dhw modes
             case _:
                 data = (

--- a/plugwise/smile.py
+++ b/plugwise/smile.py
@@ -250,9 +250,7 @@ class SmileAPI(SmileData):
             case "select_zone_profile":
                 await self.set_zone_profile(loc_id, option)
 
-    async def set_dhw_mode(
-        self, key: str, loc_id: str, length: int, mode: str
-    ) -> None:
+    async def set_dhw_mode(self, loc_id: str, length: int, mode: str) -> None:
         """Set the domestic hot water mode."""
         if mode not in self._dhw_allowed_modes:
             raise PlugwiseError("Plugwise: invalid dhw mode.")
@@ -261,7 +259,7 @@ class SmileAPI(SmileData):
             # Devices with the domestic_hot_water_comfort switch
             case 2:
                 state = STATE_ON if mode == "comfort" else STATE_OFF
-                await self.set_switch_state(loc_id, None, key, state)
+                await self.set_switch_state(loc_id, None, "select_dhw_mode", state)
             # Loria with extended dhw modes
             case _:
                 data = (

--- a/plugwise/smile.py
+++ b/plugwise/smile.py
@@ -16,6 +16,7 @@ from plugwise.constants import (
     DOMAIN_OBJECTS,
     GATEWAY_REBOOT,
     LOCATIONS,
+    LOGGER,
     MAX_SETPOINT,
     MIN_SETPOINT,
     NONE,
@@ -236,6 +237,9 @@ class SmileAPI(SmileData):
         self, key: str, loc_id: str, option: str, state: str | None
     ) -> None:
         """Set a dhw/gateway/regulation mode or the thermostat schedule option."""
+        LOGGER.debug(
+            "HOI set_select called with: %s, %s, %s, %s", key, loc_id, option, state
+        )
         match key:
             case "select_dhw_mode" | "dhw_mode":
                 state = STATE_ON if option == "comfort" else STATE_OFF
@@ -258,6 +262,9 @@ class SmileAPI(SmileData):
         if mode not in self._dhw_allowed_modes:
             raise PlugwiseError("Plugwise: invalid dhw mode.")
 
+        LOGGER.debug(
+            "HOI set_dhw_mode called with: %s, %s, %s, %s", key, appl_id, length, mode
+        )
         match length:
             # Devices with the domestic_hot_water_comfort switch
             case 2:
@@ -420,6 +427,13 @@ class SmileAPI(SmileData):
         For switch-locks, sets the lock state using a different data format.
         Return the requested state when successful, the current state otherwise.
         """
+        LOGGER.debug(
+            "HOI set_switch_state called with: %s, %s, %s, %s",
+            appl_id,
+            members,
+            model,
+            state,
+        )
         model_type = cast(SwitchType, model)
         try:
             current_state = self.gw_entities[appl_id]["switches"][model_type]
@@ -449,11 +463,13 @@ class SmileAPI(SmileData):
         for item in found:
             # multiple types of e.g. toggle_functionality present
             if (sw_type := item.find("type")) is not None:
+                LOGGER.debug("HOI switch_type: %s", sw_type.text)
                 if sw_type.text == switch.act_type:
                     switch_id = item.get("id")
                     break
             else:  # actuators with a single item like relay_functionality
                 switch_id = item.get("id")
+            LOGGER.debug("HOI switch_id: %s", switch_id)
 
         uri = f"{APPLIANCES};id={appl_id}/{switch.device};id={switch_id}"
         if model == "relay":

--- a/plugwise/smile.py
+++ b/plugwise/smile.py
@@ -267,7 +267,9 @@ class SmileAPI(SmileData):
                     f"<mode>{mode}</mode>"
                     "</domestic_hot_water_mode_control_functionality>"
                 )
-                uri = f"{APPLIANCES};type=heater_central/domestic_hot_water_mode_control"
+                uri = (
+                    f"{APPLIANCES};type=heater_central/domestic_hot_water_mode_control"
+                )
                 await self.call_request(uri, method="put", data=data)
 
     async def set_gateway_mode(self, mode: str) -> None:

--- a/plugwise/smile.py
+++ b/plugwise/smile.py
@@ -470,7 +470,7 @@ class SmileAPI(SmileData):
                     break
             else:  # actuators with a single item like relay_functionality
                 switch_id = item.get("id")
-            LOGGER.debug("HOI switch_id: %s", switch_id)
+        LOGGER.debug("HOI switch_id: %s", switch_id)
 
         uri = f"{APPLIANCES};id={appl_id}/{switch.device};id={switch_id}"
         if model == "relay":

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name            = "plugwise"
-version         = "1.11.4"
+version         = "1.12.0"
 license         = "MIT"
 description     = "Plugwise Smile (Adam/Anna/P1) and Stretch module for Python 3."
 readme          = "README.md"

--- a/scripts/tests_and_coverage.sh
+++ b/scripts/tests_and_coverage.sh
@@ -52,8 +52,7 @@ set +u
 
 if [ -z "${GITHUB_ACTIONS}" ] || [ "$1" == "test_and_coverage" ] ; then
     # Python tests (rerun with debug if failures)
-    # PYTHONPATH=$(pwd) pytest -qx tests/ --cov='.' --no-cov-on-fail --cov-report term-missing || 
-    PYTHONPATH=$(pwd) pytest -xrpP --log-level debug tests/
+    PYTHONPATH=$(pwd) pytest -qx tests/ --cov='.' --no-cov-on-fail --cov-report term-missing || PYTHONPATH=$(pwd) pytest -xrpP --log-level debug tests/
     handle_command_error "python code testing"
 fi
 

--- a/scripts/tests_and_coverage.sh
+++ b/scripts/tests_and_coverage.sh
@@ -52,7 +52,8 @@ set +u
 
 if [ -z "${GITHUB_ACTIONS}" ] || [ "$1" == "test_and_coverage" ] ; then
     # Python tests (rerun with debug if failures)
-    PYTHONPATH=$(pwd) pytest -qx tests/ --cov='.' --no-cov-on-fail --cov-report term-missing || PYTHONPATH=$(pwd) pytest -xrpP --log-level debug tests/
+    # PYTHONPATH=$(pwd) pytest -qx tests/ --cov='.' --no-cov-on-fail --cov-report term-missing || 
+    PYTHONPATH=$(pwd) pytest -xrpP --log-level debug tests/
     handle_command_error "python code testing"
 fi
 

--- a/tests/data/adam/adam_bad_thermostat.json
+++ b/tests/data/adam/adam_bad_thermostat.json
@@ -7,6 +7,10 @@
       "heating_state": false
     },
     "dev_class": "heater_central",
+    "dhw_modes": [
+      "comfort",
+      "off"
+    ],
     "location": "856285a783f24bf4b2573c8bc510eabf",
     "max_dhw_temperature": {
       "lower_bound": 0.0,
@@ -23,6 +27,7 @@
     "model": "Generic heater",
     "model_id": "1.1",
     "name": "OpenTherm",
+    "select_dhw_mode": "off",
     "sensors": {
       "dhw_temperature": 49.9,
       "intended_boiler_temperature": 0.0,
@@ -30,9 +35,6 @@
       "outdoor_air_temperature": 13.6,
       "return_temperature": 33.0,
       "water_temperature": 20.9
-    },
-    "switches": {
-      "dhw_cm_switch": false
     },
     "vendor": "WeHeat"
   },

--- a/tests/data/adam/adam_bad_thermostat.json
+++ b/tests/data/adam/adam_bad_thermostat.json
@@ -27,7 +27,7 @@
     "model": "Generic heater",
     "model_id": "1.1",
     "name": "OpenTherm",
-    "water_heater_mode": "off",
+    "dhw_mode": "off",
     "sensors": {
       "dhw_temperature": 49.9,
       "intended_boiler_temperature": 0.0,

--- a/tests/data/adam/adam_bad_thermostat.json
+++ b/tests/data/adam/adam_bad_thermostat.json
@@ -27,7 +27,7 @@
     "model": "Generic heater",
     "model_id": "1.1",
     "name": "OpenTherm",
-    "select_dhw_mode": "off",
+    "water_heater_mode": "off",
     "sensors": {
       "dhw_temperature": 49.9,
       "intended_boiler_temperature": 0.0,

--- a/tests/data/adam/adam_heatpump_cooling.json
+++ b/tests/data/adam/adam_heatpump_cooling.json
@@ -44,6 +44,10 @@
     },
     "dev_class": "heater_central",
     "location": "eedadcb297564f1483faa509179aebed",
+    "dhw_modes": [
+      "comfort",
+      "off"
+    ],
     "max_dhw_temperature": {
       "lower_bound": 40.0,
       "resolution": 0.01,
@@ -59,6 +63,7 @@
     "model": "Generic heater/cooler",
     "model_id": "17.1",
     "name": "OpenTherm",
+    "select_dhw_mode": "off",
     "sensors": {
       "dhw_temperature": 63.5,
       "intended_boiler_temperature": 0.0,
@@ -67,9 +72,6 @@
       "return_temperature": 24.9,
       "water_pressure": 2.0,
       "water_temperature": 24.5
-    },
-    "switches": {
-      "dhw_cm_switch": true
     },
     "vendor": "Remeha B.V."
   },

--- a/tests/data/adam/adam_heatpump_cooling.json
+++ b/tests/data/adam/adam_heatpump_cooling.json
@@ -63,7 +63,7 @@
     "model": "Generic heater/cooler",
     "model_id": "17.1",
     "name": "OpenTherm",
-    "water_heater_mode": "comfort",
+    "dhw_mode": "comfort",
     "sensors": {
       "dhw_temperature": 63.5,
       "intended_boiler_temperature": 0.0,

--- a/tests/data/adam/adam_heatpump_cooling.json
+++ b/tests/data/adam/adam_heatpump_cooling.json
@@ -63,7 +63,7 @@
     "model": "Generic heater/cooler",
     "model_id": "17.1",
     "name": "OpenTherm",
-    "select_dhw_mode": "off",
+    "select_dhw_mode": "comfort",
     "sensors": {
       "dhw_temperature": 63.5,
       "intended_boiler_temperature": 0.0,

--- a/tests/data/adam/adam_heatpump_cooling.json
+++ b/tests/data/adam/adam_heatpump_cooling.json
@@ -63,7 +63,7 @@
     "model": "Generic heater/cooler",
     "model_id": "17.1",
     "name": "OpenTherm",
-    "select_dhw_mode": "comfort",
+    "water_heater_mode": "comfort",
     "sensors": {
       "dhw_temperature": 63.5,
       "intended_boiler_temperature": 0.0,

--- a/tests/data/adam/adam_jip.json
+++ b/tests/data/adam/adam_jip.json
@@ -349,7 +349,7 @@
     "model": "Generic heater",
     "model_id": "10.20",
     "name": "OpenTherm",
-    "select_dhw_mode": "off",
+    "water_heater_mode": "off",
     "sensors": {
       "intended_boiler_temperature": 0.0,
       "modulation_level": 0.0,

--- a/tests/data/adam/adam_jip.json
+++ b/tests/data/adam/adam_jip.json
@@ -330,6 +330,10 @@
     },
     "dev_class": "heater_central",
     "location": "9e4433a9d69f40b3aefd15e74395eaec",
+    "dhw_modes": [
+      "comfort",
+      "off"
+    ],
     "max_dhw_temperature": {
       "lower_bound": 40.0,
       "resolution": 0.01,
@@ -345,15 +349,13 @@
     "model": "Generic heater",
     "model_id": "10.20",
     "name": "OpenTherm",
+    "select_dhw_mode": "off",
     "sensors": {
       "intended_boiler_temperature": 0.0,
       "modulation_level": 0.0,
       "return_temperature": 37.1,
       "water_pressure": 1.4,
       "water_temperature": 37.3
-    },
-    "switches": {
-      "dhw_cm_switch": false
     },
     "vendor": "Remeha B.V."
   },

--- a/tests/data/adam/adam_jip.json
+++ b/tests/data/adam/adam_jip.json
@@ -349,7 +349,7 @@
     "model": "Generic heater",
     "model_id": "10.20",
     "name": "OpenTherm",
-    "water_heater_mode": "off",
+    "dhw_mode": "off",
     "sensors": {
       "intended_boiler_temperature": 0.0,
       "modulation_level": 0.0,

--- a/tests/data/adam/adam_onoff_cooling_fake_firmware.json
+++ b/tests/data/adam/adam_onoff_cooling_fake_firmware.json
@@ -27,7 +27,7 @@
     },
     "model": "Unknown",
     "name": "OnOff",
-    "water_heater_mode": "comfort",
+    "dhw_mode": "comfort",
     "sensors": {
       "dhw_temperature": 63.5,
       "intended_boiler_temperature": 0.0,

--- a/tests/data/adam/adam_onoff_cooling_fake_firmware.json
+++ b/tests/data/adam/adam_onoff_cooling_fake_firmware.json
@@ -9,6 +9,10 @@
     },
     "dev_class": "heater_central",
     "location": "eedadcb297564f1483faa509179aebed",
+    "dhw_modes": [
+      "comfort",
+      "off"
+    ],
     "max_dhw_temperature": {
       "lower_bound": 40.0,
       "resolution": 0.01,
@@ -23,6 +27,7 @@
     },
     "model": "Unknown",
     "name": "OnOff",
+    "select_dhw_mode": "comfort",
     "sensors": {
       "dhw_temperature": 63.5,
       "intended_boiler_temperature": 0.0,
@@ -31,9 +36,6 @@
       "return_temperature": 24.9,
       "water_pressure": 2.0,
       "water_temperature": 24.5
-    },
-    "switches": {
-      "dhw_cm_switch": true
     }
   },
   "7d97fc3117784cfdafe347bcedcbbbcb": {

--- a/tests/data/adam/adam_onoff_cooling_fake_firmware.json
+++ b/tests/data/adam/adam_onoff_cooling_fake_firmware.json
@@ -27,7 +27,7 @@
     },
     "model": "Unknown",
     "name": "OnOff",
-    "select_dhw_mode": "comfort",
+    "water_heater_mode": "comfort",
     "sensors": {
       "dhw_temperature": 63.5,
       "intended_boiler_temperature": 0.0,

--- a/tests/data/adam/adam_plus_anna.json
+++ b/tests/data/adam/adam_plus_anna.json
@@ -35,6 +35,10 @@
     },
     "dev_class": "heater_central",
     "location": "07d618f0bb80412687f065b8698ce3e7",
+    "dhw_modes": [
+      "comfort",
+      "off"
+    ],
     "maximum_boiler_temperature": {
       "lower_bound": 0.0,
       "resolution": 1.0,
@@ -43,12 +47,10 @@
     },
     "model": "Generic heater",
     "name": "OpenTherm",
+    "select_dhw_mode": "off",
     "sensors": {
       "intended_boiler_temperature": 0.0,
       "water_temperature": 48.0
-    },
-    "switches": {
-      "dhw_cm_switch": false
     }
   },
   "aa6b0002df0a46e1b1eb94beb61eddfe": {

--- a/tests/data/adam/adam_plus_anna_new.json
+++ b/tests/data/adam/adam_plus_anna_new.json
@@ -8,6 +8,10 @@
     },
     "dev_class": "heater_central",
     "location": "bc93488efab249e5bc54fd7e175a6f91",
+    "dhw_modes": [
+      "comfort",
+      "off"
+    ],
     "maximum_boiler_temperature": {
       "lower_bound": 25.0,
       "resolution": 0.01,
@@ -16,12 +20,10 @@
     },
     "model": "Generic heater",
     "name": "OpenTherm",
+    "select_dhw_mode": "off",
     "sensors": {
       "intended_boiler_temperature": 22.5,
       "water_temperature": 43.0
-    },
-    "switches": {
-      "dhw_cm_switch": false
     }
   },
   "10016900610d4c7481df78c89606ef22": {

--- a/tests/data/adam/adam_plus_anna_new_regulation_off.json
+++ b/tests/data/adam/adam_plus_anna_new_regulation_off.json
@@ -8,6 +8,10 @@
     },
     "dev_class": "heater_central",
     "location": "bc93488efab249e5bc54fd7e175a6f91",
+    "dhw_modes": [
+      "comfort",
+      "off"
+    ],
     "maximum_boiler_temperature": {
       "lower_bound": 25.0,
       "resolution": 0.01,
@@ -16,12 +20,10 @@
     },
     "model": "Generic heater",
     "name": "OpenTherm",
+    "select_dhw_mode": "off",
     "sensors": {
       "intended_boiler_temperature": 0.0,
       "water_temperature": 30.0
-    },
-    "switches": {
-      "dhw_cm_switch": false
     }
   },
   "10016900610d4c7481df78c89606ef22": {

--- a/tests/data/anna/anna_elga_2.json
+++ b/tests/data/anna/anna_elga_2.json
@@ -11,9 +11,14 @@
       "secondary_boiler_state": true
     },
     "dev_class": "heater_central",
+    "dhw_modes": [
+      "comfort",
+      "off"
+    ],
     "location": "d34dfe6ab90b410c98068e75de3eb631",
     "model": "Generic heater/cooler",
     "name": "OpenTherm",
+    "select_dhw_mode": "off",
     "sensors": {
       "domestic_hot_water_setpoint": 60.0,
       "intended_boiler_temperature": 58.3,
@@ -22,9 +27,6 @@
       "return_temperature": 35.5,
       "water_pressure": 0.5,
       "water_temperature": 42.6
-    },
-    "switches": {
-      "dhw_cm_switch": false
     },
     "vendor": "Techneco"
   },

--- a/tests/data/anna/anna_elga_2_cooling.json
+++ b/tests/data/anna/anna_elga_2_cooling.json
@@ -11,6 +11,10 @@
       "secondary_boiler_state": false
     },
     "dev_class": "heater_central",
+    "dhw_modes": [
+      "comfort",
+      "off"
+    ],
     "location": "d34dfe6ab90b410c98068e75de3eb631",
     "maximum_boiler_temperature": {
       "lower_bound": 0.0,
@@ -20,6 +24,7 @@
     },
     "model": "Generic heater/cooler",
     "name": "OpenTherm",
+    "select_dhw_mode": "comfort",
     "sensors": {
       "domestic_hot_water_setpoint": 60.0,
       "intended_boiler_temperature": 0.0,
@@ -28,9 +33,6 @@
       "return_temperature": 23.4,
       "water_pressure": 0.5,
       "water_temperature": 22.8
-    },
-    "switches": {
-      "dhw_cm_switch": true
     },
     "vendor": "Techneco"
   },

--- a/tests/data/anna/anna_elga_2_cooling_UPDATED_DATA.json
+++ b/tests/data/anna/anna_elga_2_cooling_UPDATED_DATA.json
@@ -11,6 +11,10 @@
       "secondary_boiler_state": false
     },
     "dev_class": "heater_central",
+    "dhw_modes": [
+      "comfort",
+      "off"
+    ],
     "location": "d34dfe6ab90b410c98068e75de3eb631",
     "maximum_boiler_temperature": {
       "lower_bound": 0.0,
@@ -20,6 +24,7 @@
     },
     "model": "Generic heater/cooler",
     "name": "OpenTherm",
+    "select_dhw_mode": "comfort",
     "sensors": {
       "domestic_hot_water_setpoint": 60.0,
       "intended_boiler_temperature": 0.0,
@@ -28,9 +33,6 @@
       "return_temperature": 23.4,
       "water_pressure": 0.5,
       "water_temperature": 22.8
-    },
-    "switches": {
-      "dhw_cm_switch": true
     },
     "vendor": "Techneco"
   },

--- a/tests/data/anna/anna_elga_2_schedule_off.json
+++ b/tests/data/anna/anna_elga_2_schedule_off.json
@@ -11,6 +11,10 @@
       "secondary_boiler_state": false
     },
     "dev_class": "heater_central",
+    "dhw_modes": [
+      "comfort",
+      "off"
+    ],
     "location": "d34dfe6ab90b410c98068e75de3eb631",
     "maximum_boiler_temperature": {
       "lower_bound": 0.0,
@@ -20,6 +24,7 @@
     },
     "model": "Generic heater/cooler",
     "name": "OpenTherm",
+    "select_dhw_mode": "comfort",
     "sensors": {
       "domestic_hot_water_setpoint": 60.0,
       "intended_boiler_temperature": 0.0,
@@ -28,9 +33,6 @@
       "return_temperature": 23.4,
       "water_pressure": 0.5,
       "water_temperature": 22.8
-    },
-    "switches": {
-      "dhw_cm_switch": true
     },
     "vendor": "Techneco"
   },

--- a/tests/data/anna/anna_elga_no_cooling.json
+++ b/tests/data/anna/anna_elga_no_cooling.json
@@ -46,7 +46,7 @@
     },
     "model": "Generic heater",
     "name": "OpenTherm",
-    "water_heater_mode": "off",
+    "dhw_mode": "off",
     "sensors": {
       "dhw_temperature": 46.3,
       "intended_boiler_temperature": 35.0,

--- a/tests/data/anna/anna_elga_no_cooling.json
+++ b/tests/data/anna/anna_elga_no_cooling.json
@@ -46,7 +46,7 @@
     },
     "model": "Generic heater",
     "name": "OpenTherm",
-    "select_dhw_mode": "off",
+    "water_heater_mode": "off",
     "sensors": {
       "dhw_temperature": 46.3,
       "intended_boiler_temperature": 35.0,

--- a/tests/data/anna/anna_elga_no_cooling.json
+++ b/tests/data/anna/anna_elga_no_cooling.json
@@ -4,6 +4,10 @@
       "plugwise_notification": false
     },
     "dev_class": "gateway",
+    "dhw_modes": [
+      "comfort",
+      "off"
+    ],
     "firmware": "4.0.15",
     "hardware": "AME Smile 2.0 board",
     "location": "a57efe5f145f498c9be62a9b63626fbf",
@@ -42,6 +46,7 @@
     },
     "model": "Generic heater",
     "name": "OpenTherm",
+    "select_dhw_mode": "off",
     "sensors": {
       "dhw_temperature": 46.3,
       "intended_boiler_temperature": 35.0,
@@ -50,9 +55,6 @@
       "return_temperature": 25.1,
       "water_pressure": 1.57,
       "water_temperature": 29.1
-    },
-    "switches": {
-      "dhw_cm_switch": false
     },
     "vendor": "Techneco"
   },

--- a/tests/data/anna/anna_elga_no_cooling.json
+++ b/tests/data/anna/anna_elga_no_cooling.json
@@ -4,10 +4,6 @@
       "plugwise_notification": false
     },
     "dev_class": "gateway",
-    "dhw_modes": [
-      "comfort",
-      "off"
-    ],
     "firmware": "4.0.15",
     "hardware": "AME Smile 2.0 board",
     "location": "a57efe5f145f498c9be62a9b63626fbf",
@@ -31,6 +27,10 @@
       "secondary_boiler_state": false
     },
     "dev_class": "heater_central",
+    "dhw_modes": [
+      "comfort",
+      "off"
+    ],
     "location": "a57efe5f145f498c9be62a9b63626fbf",
     "max_dhw_temperature": {
       "lower_bound": 35.0,

--- a/tests/data/anna/anna_heatpump_cooling.json
+++ b/tests/data/anna/anna_heatpump_cooling.json
@@ -29,6 +29,10 @@
       "secondary_boiler_state": false
     },
     "dev_class": "heater_central",
+    "dhw_modes": [
+      "comfort",
+      "off"
+    ],
     "location": "a57efe5f145f498c9be62a9b63626fbf",
     "maximum_boiler_temperature": {
       "lower_bound": 0.0,
@@ -38,6 +42,7 @@
     },
     "model": "Generic heater/cooler",
     "name": "OpenTherm",
+    "select_dhw_mode": "off",
     "sensors": {
       "dhw_temperature": 41.5,
       "domestic_hot_water_setpoint": 60.0,
@@ -47,9 +52,6 @@
       "return_temperature": 23.8,
       "water_pressure": 1.61,
       "water_temperature": 24.7
-    },
-    "switches": {
-      "dhw_cm_switch": false
     },
     "vendor": "Techneco"
   },

--- a/tests/data/anna/anna_heatpump_cooling_fake_firmware.json
+++ b/tests/data/anna/anna_heatpump_cooling_fake_firmware.json
@@ -29,6 +29,10 @@
       "secondary_boiler_state": false
     },
     "dev_class": "heater_central",
+    "dhw_modes": [
+      "comfort",
+      "off"
+    ],
     "location": "a57efe5f145f498c9be62a9b63626fbf",
     "maximum_boiler_temperature": {
       "lower_bound": 0.0,
@@ -38,6 +42,7 @@
     },
     "model": "Generic heater/cooler",
     "name": "OpenTherm",
+    "select_dhw_mode": "off",
     "sensors": {
       "dhw_temperature": 41.5,
       "domestic_hot_water_setpoint": 60.0,
@@ -47,9 +52,6 @@
       "return_temperature": 23.8,
       "water_pressure": 1.61,
       "water_temperature": 24.7
-    },
-    "switches": {
-      "dhw_cm_switch": false
     },
     "vendor": "Techneco"
   },

--- a/tests/data/anna/anna_heatpump_heating.json
+++ b/tests/data/anna/anna_heatpump_heating.json
@@ -48,7 +48,7 @@
     },
     "model": "Generic heater/cooler",
     "name": "OpenTherm",
-    "select_dhw_mode": "off",
+    "water_heater_mode": "off",
     "sensors": {
       "dhw_temperature": 46.3,
       "intended_boiler_temperature": 35.0,

--- a/tests/data/anna/anna_heatpump_heating.json
+++ b/tests/data/anna/anna_heatpump_heating.json
@@ -48,7 +48,7 @@
     },
     "model": "Generic heater/cooler",
     "name": "OpenTherm",
-    "water_heater_mode": "off",
+    "dhw_mode": "off",
     "sensors": {
       "dhw_temperature": 46.3,
       "intended_boiler_temperature": 35.0,

--- a/tests/data/anna/anna_heatpump_heating.json
+++ b/tests/data/anna/anna_heatpump_heating.json
@@ -29,6 +29,10 @@
       "secondary_boiler_state": false
     },
     "dev_class": "heater_central",
+    "dhw_modes": [
+      "comfort",
+      "off"
+    ],
     "location": "a57efe5f145f498c9be62a9b63626fbf",
     "max_dhw_temperature": {
       "lower_bound": 35.0,
@@ -44,6 +48,7 @@
     },
     "model": "Generic heater/cooler",
     "name": "OpenTherm",
+    "select_dhw_mode": "off",
     "sensors": {
       "dhw_temperature": 46.3,
       "intended_boiler_temperature": 35.0,
@@ -52,9 +57,6 @@
       "return_temperature": 25.1,
       "water_pressure": 1.57,
       "water_temperature": 29.1
-    },
-    "switches": {
-      "dhw_cm_switch": false
     },
     "vendor": "Techneco"
   },

--- a/tests/data/anna/anna_heatpump_heating_UPDATED_DATA.json
+++ b/tests/data/anna/anna_heatpump_heating_UPDATED_DATA.json
@@ -1,6 +1,10 @@
 {
   "1cbf783bb11e4a7c8a6843dee3a86927": {
     "dev_class": "heater_central",
+    "dhw_modes": [
+      "comfort",
+      "off"
+    ],
     "location": "a57efe5f145f498c9be62a9b63626fbf",
     "model": "Generic heater/cooler",
     "name": "OpenTherm",
@@ -21,6 +25,7 @@
       "secondary_boiler_state": false,
       "flame_state": false
     },
+    "select_dhw_mode": "off",
     "sensors": {
       "water_temperature": 29.1,
       "domestic_hot_water_setpoint": 60.0,
@@ -30,9 +35,7 @@
       "return_temperature": 25.1,
       "water_pressure": 1.57,
       "outdoor_air_temperature": 3.0
-    },
-    "switches": {
-      "dhw_cm_switch": false
+
     }
   }
 }

--- a/tests/data/anna/anna_loria_cooling_active.json
+++ b/tests/data/anna/anna_loria_cooling_active.json
@@ -78,7 +78,7 @@
     "model": "Generic heater/cooler",
     "model_id": "173",
     "name": "OpenTherm",
-    "select_dhw_mode": "auto",
+    "water_heater_mode": "auto",
     "sensors": {
       "dhw_temperature": 52.9,
       "intended_boiler_temperature": 0.0,

--- a/tests/data/anna/anna_loria_cooling_active.json
+++ b/tests/data/anna/anna_loria_cooling_active.json
@@ -78,7 +78,7 @@
     "model": "Generic heater/cooler",
     "model_id": "173",
     "name": "OpenTherm",
-    "water_heater_mode": "auto",
+    "dhw_mode": "auto",
     "sensors": {
       "dhw_temperature": 52.9,
       "intended_boiler_temperature": 0.0,

--- a/tests/data/anna/anna_loria_cooling_active.json
+++ b/tests/data/anna/anna_loria_cooling_active.json
@@ -88,8 +88,7 @@
       "water_temperature": 25.3
     },
     "switches": {
-      "cooling_ena_switch": true,
-      "dhw_cm_switch": true
+      "cooling_ena_switch": true
     },
     "vendor": "Atlantic"
   }

--- a/tests/data/anna/anna_loria_driessens.json
+++ b/tests/data/anna/anna_loria_driessens.json
@@ -84,7 +84,7 @@
     "model": "Generic heater/cooler",
     "model_id": "173",
     "name": "OpenTherm",
-    "select_dhw_mode": "auto",
+    "water_heater_mode": "auto",
     "sensors": {
       "dhw_temperature": 49.5,
       "intended_boiler_temperature": 0.0,

--- a/tests/data/anna/anna_loria_driessens.json
+++ b/tests/data/anna/anna_loria_driessens.json
@@ -94,8 +94,7 @@
       "water_temperature": 23.3
     },
     "switches": {
-      "cooling_ena_switch": false,
-      "dhw_cm_switch": true
+      "cooling_ena_switch": false
     },
     "vendor": "Atlantic"
   }

--- a/tests/data/anna/anna_loria_driessens.json
+++ b/tests/data/anna/anna_loria_driessens.json
@@ -84,7 +84,7 @@
     "model": "Generic heater/cooler",
     "model_id": "173",
     "name": "OpenTherm",
-    "water_heater_mode": "auto",
+    "dhw_mode": "auto",
     "sensors": {
       "dhw_temperature": 49.5,
       "intended_boiler_temperature": 0.0,

--- a/tests/data/anna/anna_loria_heating_idle.json
+++ b/tests/data/anna/anna_loria_heating_idle.json
@@ -78,7 +78,7 @@
     "model": "Generic heater/cooler",
     "model_id": "173",
     "name": "OpenTherm",
-    "select_dhw_mode": "auto",
+    "water_heater_mode": "auto",
     "sensors": {
       "dhw_temperature": 52.9,
       "intended_boiler_temperature": 0.0,

--- a/tests/data/anna/anna_loria_heating_idle.json
+++ b/tests/data/anna/anna_loria_heating_idle.json
@@ -78,7 +78,7 @@
     "model": "Generic heater/cooler",
     "model_id": "173",
     "name": "OpenTherm",
-    "water_heater_mode": "auto",
+    "dhw_mode": "auto",
     "sensors": {
       "dhw_temperature": 52.9,
       "intended_boiler_temperature": 0.0,

--- a/tests/data/anna/anna_loria_heating_idle.json
+++ b/tests/data/anna/anna_loria_heating_idle.json
@@ -88,8 +88,7 @@
       "water_temperature": 25.3
     },
     "switches": {
-      "cooling_ena_switch": false,
-      "dhw_cm_switch": true
+      "cooling_ena_switch": false
     },
     "vendor": "Atlantic"
   }

--- a/tests/data/anna/anna_p1.json
+++ b/tests/data/anna/anna_p1.json
@@ -39,18 +39,17 @@
       "heating_state": false
     },
     "dev_class": "heater_central",
+    "dhw_modes": ["comfort", "off"],
     "location": "da7be222ab3b420c927f3e49fade0304",
     "model": "Generic heater",
     "model_id": "HR24",
     "name": "OpenTherm",
+    "select_dhw_mode": "comfort",
     "sensors": {
       "intended_boiler_temperature": 0.0,
       "modulation_level": 0.0,
       "water_pressure": 6.0,
       "water_temperature": 35.0
-    },
-    "switches": {
-      "dhw_cm_switch": true
     },
     "vendor": "Intergas"
   },

--- a/tests/data/anna/anna_v4.json
+++ b/tests/data/anna/anna_v4.json
@@ -74,7 +74,7 @@
     "model": "Generic heater",
     "model_id": "2.32",
     "name": "OpenTherm",
-    "select_dhw_mode": "off",
+    "water_heater_mode": "off",
     "sensors": {
       "intended_boiler_temperature": 39.9,
       "modulation_level": 0.0,

--- a/tests/data/anna/anna_v4.json
+++ b/tests/data/anna/anna_v4.json
@@ -74,7 +74,7 @@
     "model": "Generic heater",
     "model_id": "2.32",
     "name": "OpenTherm",
-    "water_heater_mode": "off",
+    "dhw_mode": "off",
     "sensors": {
       "intended_boiler_temperature": 39.9,
       "modulation_level": 0.0,

--- a/tests/data/anna/anna_v4.json
+++ b/tests/data/anna/anna_v4.json
@@ -57,6 +57,7 @@
       "heating_state": true
     },
     "dev_class": "heater_central",
+    "dhw_modes": ["comfort", "off"],
     "location": "94c107dc6ac84ed98e9f68c0dd06bf71",
     "max_dhw_temperature": {
       "lower_bound": 30.0,
@@ -73,15 +74,13 @@
     "model": "Generic heater",
     "model_id": "2.32",
     "name": "OpenTherm",
+    "select_dhw_mode": "off",
     "sensors": {
       "intended_boiler_temperature": 39.9,
       "modulation_level": 0.0,
       "return_temperature": 32.0,
       "water_pressure": 2.2,
       "water_temperature": 45.0
-    },
-    "switches": {
-      "dhw_cm_switch": false
     },
     "vendor": "Bosch Thermotechniek B.V."
   }

--- a/tests/data/anna/anna_v4_UPDATED_DATA.json
+++ b/tests/data/anna/anna_v4_UPDATED_DATA.json
@@ -1,5 +1,6 @@
 {
   "cd0e6156b1f04d5f952349ffbe397481": {
+    "dhw_modes": ["comfort", "off"],
     "maximum_boiler_temperature": {
       "setpoint": 69.0,
       "lower_bound": 0.0,
@@ -17,15 +18,13 @@
       "heating_state": false,
       "flame_state": false
     },
+    "select_dhw_mode": "off",
     "sensors": {
       "water_temperature": 51.0,
       "intended_boiler_temperature": 0.0,
       "modulation_level": 0,
       "return_temperature": 41.0,
       "water_pressure": 2.1
-    },
-    "switches": {
-      "dhw_cm_switch": true
     }
   },
   "01b85360fdd243d0aaad4d6ac2a5ba7e": {

--- a/tests/data/anna/anna_v4_UPDATED_DATA.json
+++ b/tests/data/anna/anna_v4_UPDATED_DATA.json
@@ -18,7 +18,7 @@
       "heating_state": false,
       "flame_state": false
     },
-    "select_dhw_mode": "off",
+    "select_dhw_mode": "comfort",
     "sensors": {
       "water_temperature": 51.0,
       "intended_boiler_temperature": 0.0,

--- a/tests/data/anna/anna_v4_UPDATED_DATA.json
+++ b/tests/data/anna/anna_v4_UPDATED_DATA.json
@@ -18,7 +18,7 @@
       "heating_state": false,
       "flame_state": false
     },
-    "water_heater_mode": "comfort",
+    "dhw_mode": "comfort",
     "sensors": {
       "water_temperature": 51.0,
       "intended_boiler_temperature": 0.0,

--- a/tests/data/anna/anna_v4_UPDATED_DATA.json
+++ b/tests/data/anna/anna_v4_UPDATED_DATA.json
@@ -18,7 +18,7 @@
       "heating_state": false,
       "flame_state": false
     },
-    "select_dhw_mode": "comfort",
+    "water_heater_mode": "comfort",
     "sensors": {
       "water_temperature": 51.0,
       "intended_boiler_temperature": 0.0,

--- a/tests/data/anna/anna_v4_dhw.json
+++ b/tests/data/anna/anna_v4_dhw.json
@@ -74,7 +74,7 @@
     "model": "Generic heater",
     "model_id": "2.32",
     "name": "OpenTherm",
-    "select_dhw_mode": "off",
+    "water_heater_mode": "off",
     "sensors": {
       "intended_boiler_temperature": 39.9,
       "modulation_level": 0.0,

--- a/tests/data/anna/anna_v4_dhw.json
+++ b/tests/data/anna/anna_v4_dhw.json
@@ -57,6 +57,7 @@
       "heating_state": false
     },
     "dev_class": "heater_central",
+    "dhw_modes": ["comfort", "off"],
     "location": "94c107dc6ac84ed98e9f68c0dd06bf71",
     "max_dhw_temperature": {
       "lower_bound": 30.0,
@@ -73,15 +74,13 @@
     "model": "Generic heater",
     "model_id": "2.32",
     "name": "OpenTherm",
+    "select_dhw_mode": "off",
     "sensors": {
       "intended_boiler_temperature": 39.9,
       "modulation_level": 0.0,
       "return_temperature": 32.0,
       "water_pressure": 2.2,
       "water_temperature": 45.0
-    },
-    "switches": {
-      "dhw_cm_switch": false
     },
     "vendor": "Bosch Thermotechniek B.V."
   }

--- a/tests/data/anna/anna_v4_dhw.json
+++ b/tests/data/anna/anna_v4_dhw.json
@@ -74,7 +74,7 @@
     "model": "Generic heater",
     "model_id": "2.32",
     "name": "OpenTherm",
-    "water_heater_mode": "off",
+    "dhw_mode": "off",
     "sensors": {
       "intended_boiler_temperature": 39.9,
       "modulation_level": 0.0,

--- a/tests/data/anna/anna_v4_no_tag.json
+++ b/tests/data/anna/anna_v4_no_tag.json
@@ -74,7 +74,7 @@
     "model": "Generic heater",
     "model_id": "2.32",
     "name": "OpenTherm",
-    "select_dhw_mode": "off",
+    "water_heater_mode": "off",
     "sensors": {
       "intended_boiler_temperature": 39.9,
       "modulation_level": 0.0,

--- a/tests/data/anna/anna_v4_no_tag.json
+++ b/tests/data/anna/anna_v4_no_tag.json
@@ -74,7 +74,7 @@
     "model": "Generic heater",
     "model_id": "2.32",
     "name": "OpenTherm",
-    "water_heater_mode": "off",
+    "dhw_mode": "off",
     "sensors": {
       "intended_boiler_temperature": 39.9,
       "modulation_level": 0.0,

--- a/tests/data/anna/anna_v4_no_tag.json
+++ b/tests/data/anna/anna_v4_no_tag.json
@@ -57,6 +57,7 @@
       "heating_state": true
     },
     "dev_class": "heater_central",
+    "dhw_modes": ["comfort", "off"],
     "location": "94c107dc6ac84ed98e9f68c0dd06bf71",
     "max_dhw_temperature": {
       "lower_bound": 30.0,
@@ -73,15 +74,13 @@
     "model": "Generic heater",
     "model_id": "2.32",
     "name": "OpenTherm",
+    "select_dhw_mode": "off",
     "sensors": {
       "intended_boiler_temperature": 39.9,
       "modulation_level": 0.0,
       "return_temperature": 32.0,
       "water_pressure": 2.2,
       "water_temperature": 45.0
-    },
-    "switches": {
-      "dhw_cm_switch": false
     },
     "vendor": "Bosch Thermotechniek B.V."
   }

--- a/tests/test_adam.py
+++ b/tests/test_adam.py
@@ -138,7 +138,7 @@ class TestPlugwiseAdam(TestPlugwise):  # pylint: disable=attribute-defined-outsi
             "854f8a9b0e7e425db97f1f110e1ce4b3",
         )
 
-        tinkered = await self.tinker_dhw_mode(api, "056ee145a816487eaa69243c3280f8bf")
+        tinkered = await self.tinker_dhw_mode(api, "056ee145a816487eaa69243c3280f8bf", 2)
         assert not tinkered
 
         tinkered = await self.tinker_gateway_mode(api)
@@ -459,7 +459,7 @@ class TestPlugwiseAdam(TestPlugwise):  # pylint: disable=attribute-defined-outsi
         )
         assert result
 
-        tinkered = await self.tinker_dhw_mode(api, "e4684553153b44afbef2200885f379dc")
+        tinkered = await self.tinker_dhw_mode(api, "e4684553153b44afbef2200885f379dc", 2)
         assert not tinkered
 
         await api.close_connection()

--- a/tests/test_adam.py
+++ b/tests/test_adam.py
@@ -139,7 +139,7 @@ class TestPlugwiseAdam(TestPlugwise):  # pylint: disable=attribute-defined-outsi
         )
 
         tinkered = await self.tinker_dhw_mode(
-            api, "056ee145a816487eaa69243c3280f8bf", 2
+            api, "056ee145a816487eaa69243c3280f8bf", "select_dhw_mode", 2
         )
         assert not tinkered
 
@@ -462,7 +462,7 @@ class TestPlugwiseAdam(TestPlugwise):  # pylint: disable=attribute-defined-outsi
         assert result
 
         tinkered = await self.tinker_dhw_mode(
-            api, "e4684553153b44afbef2200885f379dc", 2
+            api, "e4684553153b44afbef2200885f379dc", "dhw_mode", 2
         )
         assert not tinkered
 

--- a/tests/test_adam.py
+++ b/tests/test_adam.py
@@ -138,6 +138,9 @@ class TestPlugwiseAdam(TestPlugwise):  # pylint: disable=attribute-defined-outsi
             "854f8a9b0e7e425db97f1f110e1ce4b3",
         )
 
+        tinkered = await self.tinker_dhw_mode(api, "056ee145a816487eaa69243c3280f8bf")
+        assert not tinkered
+
         tinkered = await self.tinker_gateway_mode(api)
         assert not tinkered
 

--- a/tests/test_adam.py
+++ b/tests/test_adam.py
@@ -138,7 +138,9 @@ class TestPlugwiseAdam(TestPlugwise):  # pylint: disable=attribute-defined-outsi
             "854f8a9b0e7e425db97f1f110e1ce4b3",
         )
 
-        tinkered = await self.tinker_dhw_mode(api, "056ee145a816487eaa69243c3280f8bf", 2)
+        tinkered = await self.tinker_dhw_mode(
+            api, "056ee145a816487eaa69243c3280f8bf", 2
+        )
         assert not tinkered
 
         tinkered = await self.tinker_gateway_mode(api)
@@ -459,7 +461,9 @@ class TestPlugwiseAdam(TestPlugwise):  # pylint: disable=attribute-defined-outsi
         )
         assert result
 
-        tinkered = await self.tinker_dhw_mode(api, "e4684553153b44afbef2200885f379dc", 2)
+        tinkered = await self.tinker_dhw_mode(
+            api, "e4684553153b44afbef2200885f379dc", 2
+        )
         assert not tinkered
 
         await api.close_connection()

--- a/tests/test_adam.py
+++ b/tests/test_adam.py
@@ -455,5 +455,9 @@ class TestPlugwiseAdam(TestPlugwise):  # pylint: disable=attribute-defined-outsi
             good_schedules=[None],
         )
         assert result
+
+        tinkered = await self.tinker_dhw_mode(api, "e4684553153b44afbef2200885f379dc")
+        assert not tinkered
+
         await api.close_connection()
         await self.disconnect(server, client)

--- a/tests/test_adam.py
+++ b/tests/test_adam.py
@@ -47,7 +47,7 @@ class TestPlugwiseAdam(TestPlugwise):  # pylint: disable=attribute-defined-outsi
 
         test_items = await self.device_test(api, "2025-10-12 00:00:01", testdata)
         assert api.gateway_id == "da224107914542988a88561b4452b0f6"
-        assert self.entity_items == 231
+        assert self.entity_items == 232
         assert test_items == self.entity_items
         assert self.entity_list == [
             "da224107914542988a88561b4452b0f6",

--- a/tests/test_adam.py
+++ b/tests/test_adam.py
@@ -346,7 +346,7 @@ class TestPlugwiseAdam(TestPlugwise):  # pylint: disable=attribute-defined-outsi
         server, api, client = await self.connect_wrapper()
 
         test_items = await self.device_test(api, "2022-01-02 00:00:01", testdata)
-        assert self.entity_items == 539
+        assert self.entity_items == 540
         assert test_items == self.entity_items
         assert self.cooling_present
         assert self._cooling_enabled
@@ -370,7 +370,7 @@ class TestPlugwiseAdam(TestPlugwise):  # pylint: disable=attribute-defined-outsi
         )
 
         test_items = await self.device_test(api, "2022-01-02 00:00:01", testdata)
-        assert self.entity_items == 70
+        assert self.entity_items == 71
         assert test_items == self.entity_items
         assert self.cooling_present
         # assert self._cooling_enabled - no cooling_enabled indication present
@@ -395,7 +395,7 @@ class TestPlugwiseAdam(TestPlugwise):  # pylint: disable=attribute-defined-outsi
 
         test_items = await self.device_test(api, "2020-03-22 00:00:01", testdata)
         assert api.gateway_id == "b128b4bbbd1f47e9bf4d756e8fb5ee94"
-        assert self.entity_items == 82
+        assert self.entity_items == 83
         assert test_items == self.entity_items
         assert "6fb89e35caeb4b1cb275184895202d84" in self.notifications
 
@@ -436,7 +436,7 @@ class TestPlugwiseAdam(TestPlugwise):  # pylint: disable=attribute-defined-outsi
 
         test_items = await self.device_test(api, "2021-06-20 00:00:01", testdata)
         assert api.gateway_id == "b5c2386c6f6342669e50fe49dd05b188"
-        assert self.entity_items == 269
+        assert self.entity_items == 270
         assert test_items == self.entity_items
 
         # Negative test

--- a/tests/test_adam.py
+++ b/tests/test_adam.py
@@ -115,12 +115,6 @@ class TestPlugwiseAdam(TestPlugwise):  # pylint: disable=attribute-defined-outsi
             ["2568cc4b9c1e401495d4741a5f89bee1", "29542b2b6a6a4169acecc15c72a599b8"],
         )
         assert switch_change
-        switch_change = await self.tinker_switch(
-            api,
-            "056ee145a816487eaa69243c3280f8bf",
-            model="dhw_cm_switch",
-        )
-        assert switch_change
         # Test relay without lock-attribute
         switch_change = await self.tinker_switch(
             api,

--- a/tests/test_anna.py
+++ b/tests/test_anna.py
@@ -551,7 +551,7 @@ class TestPlugwiseAnna(TestPlugwise):  # pylint: disable=attribute-defined-outsi
         )
 
         await self.device_test(api, "2025-11-02 00:00:01", testdata)
-        assert self.entity_items == 76
+        assert self.entity_items == 77
 
         await api.close_connection()
         await self.disconnect(server, client)

--- a/tests/test_anna.py
+++ b/tests/test_anna.py
@@ -29,7 +29,7 @@ class TestPlugwiseAnna(TestPlugwise):  # pylint: disable=attribute-defined-outsi
 
         await self.device_test(api, "2020-04-05 00:00:01", testdata)
         assert api.gateway_id == "0466eae8520144c78afb29628384edeb"
-        assert self.entity_items == 60
+        assert self.entity_items == 61
         assert not self.notifications
 
         assert not self.cooling_present
@@ -101,7 +101,7 @@ class TestPlugwiseAnna(TestPlugwise):  # pylint: disable=attribute-defined-outsi
         )
 
         await self.device_test(api, "2020-04-05 00:00:01", testdata)
-        assert self.entity_items == 60
+        assert self.entity_items == 61
         assert not self.notifications
 
         result = await self.tinker_thermostat(

--- a/tests/test_anna.py
+++ b/tests/test_anna.py
@@ -474,7 +474,7 @@ class TestPlugwiseAnna(TestPlugwise):  # pylint: disable=attribute-defined-outsi
                 "ERROR raised setting block cooling: %s", exc.value
             )  # pragma: no cover
 
-        tinkered = await self.tinker_dhw_mode(api)
+        tinkered = await self.tinker_dhw_mode(api, "bfb5ee0a88e14e5f97bfa725a760cc49")
         assert not tinkered
 
         await api.close_connection()
@@ -483,7 +483,9 @@ class TestPlugwiseAnna(TestPlugwise):  # pylint: disable=attribute-defined-outsi
         server, api, client = await self.connect_wrapper(raise_timeout=True)
         await self.device_test(api, "2022-05-16 00:00:01", testdata, skip_testing=True)
 
-        tinkered = await self.tinker_dhw_mode(api, unhappy=True)
+        tinkered = await self.tinker_dhw_mode(
+            api, "bfb5ee0a88e14e5f97bfa725a760cc49", unhappy=True
+        )
         assert tinkered
 
         await api.close_connection()

--- a/tests/test_anna.py
+++ b/tests/test_anna.py
@@ -474,7 +474,9 @@ class TestPlugwiseAnna(TestPlugwise):  # pylint: disable=attribute-defined-outsi
                 "ERROR raised setting block cooling: %s", exc.value
             )  # pragma: no cover
 
-        tinkered = await self.tinker_dhw_mode(api, "bfb5ee0a88e14e5f97bfa725a760cc49", 4)
+        tinkered = await self.tinker_dhw_mode(
+            api, "bfb5ee0a88e14e5f97bfa725a760cc49", 4
+        )
         assert not tinkered
 
         await api.close_connection()

--- a/tests/test_anna.py
+++ b/tests/test_anna.py
@@ -474,7 +474,7 @@ class TestPlugwiseAnna(TestPlugwise):  # pylint: disable=attribute-defined-outsi
                 "ERROR raised setting block cooling: %s", exc.value
             )  # pragma: no cover
 
-        tinkered = await self.tinker_dhw_mode(api, "bfb5ee0a88e14e5f97bfa725a760cc49")
+        tinkered = await self.tinker_dhw_mode(api, "bfb5ee0a88e14e5f97bfa725a760cc49", 4)
         assert not tinkered
 
         await api.close_connection()
@@ -484,7 +484,7 @@ class TestPlugwiseAnna(TestPlugwise):  # pylint: disable=attribute-defined-outsi
         await self.device_test(api, "2022-05-16 00:00:01", testdata, skip_testing=True)
 
         tinkered = await self.tinker_dhw_mode(
-            api, "bfb5ee0a88e14e5f97bfa725a760cc49", unhappy=True
+            api, "bfb5ee0a88e14e5f97bfa725a760cc49", 4, unhappy=True
         )
         assert tinkered
 

--- a/tests/test_anna.py
+++ b/tests/test_anna.py
@@ -475,7 +475,7 @@ class TestPlugwiseAnna(TestPlugwise):  # pylint: disable=attribute-defined-outsi
             )  # pragma: no cover
 
         tinkered = await self.tinker_dhw_mode(
-            api, "bfb5ee0a88e14e5f97bfa725a760cc49", 4
+            api, "bfb5ee0a88e14e5f97bfa725a760cc49", "dhw_mode", 4
         )
         assert not tinkered
 
@@ -486,7 +486,7 @@ class TestPlugwiseAnna(TestPlugwise):  # pylint: disable=attribute-defined-outsi
         await self.device_test(api, "2022-05-16 00:00:01", testdata, skip_testing=True)
 
         tinkered = await self.tinker_dhw_mode(
-            api, "bfb5ee0a88e14e5f97bfa725a760cc49", 4, unhappy=True
+            api, "bfb5ee0a88e14e5f97bfa725a760cc49", "dhw_mode", 4, unhappy=True
         )
         assert tinkered
 

--- a/tests/test_anna.py
+++ b/tests/test_anna.py
@@ -475,7 +475,7 @@ class TestPlugwiseAnna(TestPlugwise):  # pylint: disable=attribute-defined-outsi
             )  # pragma: no cover
 
         tinkered = await self.tinker_dhw_mode(
-            api, "bfb5ee0a88e14e5f97bfa725a760cc49", "dhw_mode", 4
+            api, "bfb5ee0a88e14e5f97bfa725a760cc49", "dhw_mode", 5
         )
         assert not tinkered
 

--- a/tests/test_anna.py
+++ b/tests/test_anna.py
@@ -130,7 +130,7 @@ class TestPlugwiseAnna(TestPlugwise):  # pylint: disable=attribute-defined-outsi
         )
 
         await self.device_test(api, "2020-04-05 00:00:01", testdata)
-        assert self.entity_items == 60
+        assert self.entity_items == 61
 
         result = await self.tinker_thermostat(
             api,
@@ -186,7 +186,7 @@ class TestPlugwiseAnna(TestPlugwise):  # pylint: disable=attribute-defined-outsi
 
         await self.device_test(api, "2020-04-12 00:00:01", testdata)
         assert api.gateway_id == "015ae9ea3f964e668e490fa39da3870b"
-        assert self.entity_items == 69
+        assert self.entity_items == 70
         assert not self.notifications
         assert self.cooling_present
         assert not self._cooling_enabled
@@ -216,7 +216,7 @@ class TestPlugwiseAnna(TestPlugwise):  # pylint: disable=attribute-defined-outsi
         await self.device_test(
             api, "2020-04-13 00:00:01", testdata_updated, initialize=False
         )
-        assert self.entity_items == 66
+        assert self.entity_items == 67
         await api.close_connection()
         await self.disconnect(server, client)
 
@@ -241,7 +241,7 @@ class TestPlugwiseAnna(TestPlugwise):  # pylint: disable=attribute-defined-outsi
         )
 
         await self.device_test(api, "2020-04-19 00:00:01", testdata)
-        assert self.entity_items == 66
+        assert self.entity_items == 67
         assert self.cooling_present
         assert not self.notifications
 
@@ -287,7 +287,7 @@ class TestPlugwiseAnna(TestPlugwise):  # pylint: disable=attribute-defined-outsi
         )
 
         await self.device_test(api, "2020-04-19 00:00:01", testdata)
-        assert self.entity_items == 66
+        assert self.entity_items == 67
         assert self.cooling_present
         assert self._cooling_enabled
         assert self._cooling_active
@@ -313,7 +313,7 @@ class TestPlugwiseAnna(TestPlugwise):  # pylint: disable=attribute-defined-outsi
 
         await self.device_test(api, "2020-04-12 00:00:01", testdata)
         assert api.gateway_id == "015ae9ea3f964e668e490fa39da3870b"
-        assert self.entity_items == 65
+        assert self.entity_items == 66
         assert not self.notifications
         assert not self.cooling_present
 
@@ -336,7 +336,7 @@ class TestPlugwiseAnna(TestPlugwise):  # pylint: disable=attribute-defined-outsi
         )
 
         await self.device_test(api, "2022-03-13 00:00:01", testdata)
-        assert self.entity_items == 61
+        assert self.entity_items == 62
         assert api.gateway_id == "fb49af122f6e4b0f91267e1cf7666d6f"
         assert self.cooling_present
         assert not self._cooling_enabled
@@ -356,7 +356,7 @@ class TestPlugwiseAnna(TestPlugwise):  # pylint: disable=attribute-defined-outsi
 
         await self.device_test(api, "2022-03-13 00:00:01", testdata)
         assert not self._cooling_enabled
-        assert self.entity_items == 65
+        assert self.entity_items == 66
 
         result = await self.tinker_thermostat(
             api,
@@ -387,7 +387,7 @@ class TestPlugwiseAnna(TestPlugwise):  # pylint: disable=attribute-defined-outsi
         )
 
         await self.device_test(api, "2022-03-10 00:00:01", testdata)
-        assert self.entity_items == 65
+        assert self.entity_items == 66
         assert not self.notifications
 
         assert self.cooling_present
@@ -440,7 +440,7 @@ class TestPlugwiseAnna(TestPlugwise):  # pylint: disable=attribute-defined-outsi
         )
 
         await self.device_test(api, "2022-05-16 00:00:01", testdata)
-        assert self.entity_items == 68
+        assert self.entity_items == 67
         assert self.cooling_present
         assert not self._cooling_enabled
 
@@ -505,7 +505,7 @@ class TestPlugwiseAnna(TestPlugwise):  # pylint: disable=attribute-defined-outsi
         )
 
         await self.device_test(api, "2022-05-16 00:00:01", testdata)
-        assert self.entity_items == 68
+        assert self.entity_items == 67
         assert self.cooling_present
         assert self._cooling_enabled
 
@@ -528,7 +528,7 @@ class TestPlugwiseAnna(TestPlugwise):  # pylint: disable=attribute-defined-outsi
         )
 
         await self.device_test(api, "2022-05-16 00:00:01", testdata)
-        assert self.entity_items == 68
+        assert self.entity_items == 67
         assert self.cooling_present
         assert not self._cooling_enabled
 

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -852,7 +852,7 @@ class TestPlugwise:  # pylint: disable=attribute-defined-outside-init
     async def tinker_dhw_mode(api, appliance, key, length, unhappy=False):
         """Toggle dhw to test functionality."""
         tinker_dhw_mode_passed = False
-        for mode in ["comfort", "auto", BOGUS]:
+        for mode in ["off", "comfort", "auto", BOGUS]:
             warning = ""
             if mode[0] == "!":
                 warning = " TD Negative test"

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -849,7 +849,7 @@ class TestPlugwise:  # pylint: disable=attribute-defined-outside-init
         return result_1 and result_2 and result_3
 
     @staticmethod
-    async def tinker_dhw_mode(api, unhappy=False):
+    async def tinker_dhw_mode(api, appliance, unhappy=False):
         """Toggle dhw to test functionality."""
         tinker_dhw_mode_passed = False
         for mode in ["auto", "boost", BOGUS]:
@@ -859,7 +859,7 @@ class TestPlugwise:  # pylint: disable=attribute-defined-outside-init
                 mode = mode[1:]
             _LOGGER.info("%s", f"- Adjusting dhw mode to {mode}{warning}")
             try:
-                await api.set_dhw_mode("select_dhw_mode", 4, mode)
+                await api.set_dhw_mode(appliance, 4, mode)
                 _LOGGER.info("  + tinker_dhw_mode worked as intended")
                 tinker_dhw_mode_passed = True
             except pw_exceptions.PlugwiseError:

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -849,7 +849,7 @@ class TestPlugwise:  # pylint: disable=attribute-defined-outside-init
         return result_1 and result_2 and result_3
 
     @staticmethod
-    async def tinker_dhw_mode(api, appliance, length, unhappy=False):
+    async def tinker_dhw_mode(api, appliance, key, length, unhappy=False):
         """Toggle dhw to test functionality."""
         tinker_dhw_mode_passed = False
         for mode in ["comfort", "auto", BOGUS]:
@@ -859,7 +859,7 @@ class TestPlugwise:  # pylint: disable=attribute-defined-outside-init
                 mode = mode[1:]
             _LOGGER.info("%s", f"- Adjusting dhw mode to {mode}{warning}")
             try:
-                await api.set_dhw_mode(appliance, length, mode)
+                await api.set_dhw_mode(key, appliance, length, mode)
                 _LOGGER.info("  + tinker_dhw_mode worked as intended")
                 tinker_dhw_mode_passed = True
             except pw_exceptions.PlugwiseError:

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -115,22 +115,23 @@ class TestPlugwise:  # pylint: disable=attribute-defined-outside-init
         # Introducte timeout with 2 seconds, test by setting response to 10ms
         # Don't actually wait 2 seconds as this will prolongue testing
         if not raise_timeout:
+            app.router.add_route("POST", CORE_APPLIANCES_TAIL, self.smile_http_accept)
+            app.router.add_route("PUT", CORE_APPLIANCES_TAIL, self.smile_http_accept)
             app.router.add_route("POST", CORE_GATEWAYS_TAIL, self.smile_http_accept)
-            app.router.add_route("PUT", CORE_LOCATIONS_TAIL, self.smile_http_accept)
             app.router.add_route("POST", CORE_LOCATIONS_TAIL, self.smile_http_accept)
+            app.router.add_route("PUT", CORE_LOCATIONS_TAIL, self.smile_http_accept)
             app.router.add_route(
                 "DELETE", CORE_NOTIFICATIONS_TAIL, self.smile_http_accept
             )
             app.router.add_route("PUT", CORE_RULES_TAIL, self.smile_http_accept)
-            app.router.add_route("PUT", CORE_APPLIANCES_TAIL, self.smile_http_accept)
         else:
-            app.router.add_route("POST", CORE_GATEWAYS_TAIL, self.smile_timeout)
-            app.router.add_route("PUT", CORE_LOCATIONS_TAIL, self.smile_timeout)
-            app.router.add_route("POST", CORE_LOCATIONS_TAIL, self.smile_timeout)
-            app.router.add_route("PUT", CORE_RULES_TAIL, self.smile_timeout)
+            app.router.add_route("POST", CORE_APPLIANCES_TAIL, self.smile_timeout)
             app.router.add_route("PUT", CORE_APPLIANCES_TAIL, self.smile_timeout)
+            app.router.add_route("POST", CORE_GATEWAYS_TAIL, self.smile_timeout)
+            app.router.add_route("POST", CORE_LOCATIONS_TAIL, self.smile_timeout)
+            app.router.add_route("PUT", CORE_LOCATIONS_TAIL, self.smile_timeout)
             app.router.add_route("DELETE", CORE_NOTIFICATIONS_TAIL, self.smile_timeout)
-
+            app.router.add_route("PUT", CORE_RULES_TAIL, self.smile_timeout)
         return app
 
     def setup_legacy_app(

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -849,7 +849,7 @@ class TestPlugwise:  # pylint: disable=attribute-defined-outside-init
         return result_1 and result_2 and result_3
 
     @staticmethod
-    async def tinker_dhw_mode(api, appliance, unhappy=False):
+    async def tinker_dhw_mode(api, appliance, length, unhappy=False):
         """Toggle dhw to test functionality."""
         tinker_dhw_mode_passed = False
         for mode in ["comfort", "auto", BOGUS]:
@@ -859,7 +859,7 @@ class TestPlugwise:  # pylint: disable=attribute-defined-outside-init
                 mode = mode[1:]
             _LOGGER.info("%s", f"- Adjusting dhw mode to {mode}{warning}")
             try:
-                await api.set_dhw_mode(appliance, 4, mode)
+                await api.set_dhw_mode(appliance, lenght, mode)
                 _LOGGER.info("  + tinker_dhw_mode worked as intended")
                 tinker_dhw_mode_passed = True
             except pw_exceptions.PlugwiseError:

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -859,7 +859,7 @@ class TestPlugwise:  # pylint: disable=attribute-defined-outside-init
                 mode = mode[1:]
             _LOGGER.info("%s", f"- Adjusting dhw mode to {mode}{warning}")
             try:
-                await api.set_select("select_dhw_mode", "dummy", mode)
+                await api.set_dhw_mode("select_dhw_mode", 4, mode)
                 _LOGGER.info("  + tinker_dhw_mode worked as intended")
                 tinker_dhw_mode_passed = True
             except pw_exceptions.PlugwiseError:

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -852,7 +852,7 @@ class TestPlugwise:  # pylint: disable=attribute-defined-outside-init
     async def tinker_dhw_mode(api, appliance, unhappy=False):
         """Toggle dhw to test functionality."""
         tinker_dhw_mode_passed = False
-        for mode in ["auto", "boost", BOGUS]:
+        for mode in ["comfort", "auto", BOGUS]:
             warning = ""
             if mode[0] == "!":
                 warning = " TD Negative test"

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -859,7 +859,7 @@ class TestPlugwise:  # pylint: disable=attribute-defined-outside-init
                 mode = mode[1:]
             _LOGGER.info("%s", f"- Adjusting dhw mode to {mode}{warning}")
             try:
-                await api.set_dhw_mode(appliance, lenght, mode)
+                await api.set_dhw_mode(appliance, length, mode)
                 _LOGGER.info("  + tinker_dhw_mode worked as intended")
                 tinker_dhw_mode_passed = True
             except pw_exceptions.PlugwiseError:


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Heater devices now expose explicit DHW mode selection with modes **“comfort”** and **“off”**, using unified selector/state fields compatible with Home Assistant.
* **Bug Fixes**
  * Removed the legacy DHW toggle/switch representation and improved DHW mode detection, initialization, and selection (including heater-central devices).
* **Tests**
  * Updated fixtures and async assertions to match the new DHW mode model and changed entity counts.
* **Documentation**
  * Updated the **v1.12.0** release notes and bumped the package version to **1.12.0**.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->