### PR TITLE
Further improvement on HA water_heater related output data

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,10 +1,8 @@
 # Changelog
 
-## Ongoing
-
+- Improve on v1.12.0 update by outputting dedicated boiler_ and dhw_temperature dicts with current-key added. Rename dhw_mode off to eco for standard cv-heaters.
 - Add PEP 740 digital attestations (workaround until included in `uv publish`), pin GitHub acions including our own from gh-actions, via PR [#891](https://github.com/plugwise/python-plugwise/pull/891)
 - Solve aiohttp BasicAuth deprecation via PR [#890](https://github.com/plugwise/python-plugwise/pull/890)
-
 ## v1.12.0
 
 - Replace the DHW-comfort-mode switch by a DHW mode selector to match the new HA select or water_heater platform updates, via PR [#883](https://github.com/plugwise/python-plugwise/pull/883)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,12 @@
 # Changelog
 
+## v1.13.0
+
 - Improve on v1.12.0 update by outputting dedicated boiler_ and dhw_temperature dicts with current-key added. Rename dhw_mode off to eco for standard cv-heaters.
+  Via PR [#888](https://github.com/plugwise/python-plugwise/pull/888)
 - Add PEP 740 digital attestations (workaround until included in `uv publish`), pin GitHub acions including our own from gh-actions, via PR [#891](https://github.com/plugwise/python-plugwise/pull/891)
 - Solve aiohttp BasicAuth deprecation via PR [#890](https://github.com/plugwise/python-plugwise/pull/890)
+
 ## v1.12.0
 
 - Replace the DHW-comfort-mode switch by a DHW mode selector to match the new HA select or water_heater platform updates, via PR [#883](https://github.com/plugwise/python-plugwise/pull/883)

--- a/fixtures/adam_bad_thermostat/data.json
+++ b/fixtures/adam_bad_thermostat/data.json
@@ -6,24 +6,35 @@
       "flame_state": false,
       "heating_state": false
     },
+    "boiler_temperature": {
+      "current": 20.9,
+      "lower_bound": 25.0,
+      "resolution": 0.01,
+      "setpoint": 38.0,
+      "upper_bound": 45.0
+    },
     "dev_class": "heater_central",
+    "dhw_mode": "off",
     "dhw_modes": [
       "comfort",
       "off"
     ],
+    "dhw_temperature": {
+      "current": 49.9,
+      "lower_bound": 0.0,
+      "resolution": 1.0,
+      "setpoint": 50.0,
+      "upper_bound": 100.0
+    },
     "location": "856285a783f24bf4b2573c8bc510eabf",
     "model": "Generic heater",
     "model_id": "1.1",
     "name": "OpenTherm",
-    "select_dhw_mode": "off",
     "sensors": {
-      "dhw_temperature": 49.9,
-      "domestic_hot_water_setpoint": 50.0,
       "intended_boiler_temperature": 0.0,
       "modulation_level": 0.0,
       "outdoor_air_temperature": 13.6,
-      "return_temperature": 33.0,
-      "water_temperature": 20.9
+      "return_temperature": 33.0
     },
     "vendor": "WeHeat"
   },

--- a/fixtures/adam_bad_thermostat/data.json
+++ b/fixtures/adam_bad_thermostat/data.json
@@ -14,10 +14,10 @@
       "upper_bound": 45.0
     },
     "dev_class": "heater_central",
-    "dhw_mode": "off",
+    "dhw_mode": "eco",
     "dhw_modes": [
       "comfort",
-      "off"
+      "eco"
     ],
     "dhw_temperature": {
       "current": 49.9,

--- a/fixtures/adam_bad_thermostat/data.json
+++ b/fixtures/adam_bad_thermostat/data.json
@@ -7,29 +7,18 @@
       "heating_state": false
     },
     "dev_class": "heater_central",
-    "dhw_mode": "off",
     "dhw_modes": [
       "comfort",
       "off"
     ],
     "location": "856285a783f24bf4b2573c8bc510eabf",
-    "max_dhw_temperature": {
-      "lower_bound": 0.0,
-      "resolution": 1.0,
-      "setpoint": 50.0,
-      "upper_bound": 100.0
-    },
-    "maximum_boiler_temperature": {
-      "lower_bound": 25.0,
-      "resolution": 0.01,
-      "setpoint": 38.0,
-      "upper_bound": 45.0
-    },
     "model": "Generic heater",
     "model_id": "1.1",
     "name": "OpenTherm",
+    "select_dhw_mode": "off",
     "sensors": {
       "dhw_temperature": 49.9,
+      "domestic_hot_water_setpoint": 50.0,
       "intended_boiler_temperature": 0.0,
       "modulation_level": 0.0,
       "outdoor_air_temperature": 13.6,

--- a/fixtures/adam_heatpump_cooling/data.json
+++ b/fixtures/adam_heatpump_cooling/data.json
@@ -54,36 +54,36 @@
       "flame_state": false,
       "heating_state": false
     },
+    "boiler_temperature": {
+      "current": 24.5,
+      "lower_bound": 7.0,
+      "resolution": 0.01,
+      "setpoint": 35.0,
+      "upper_bound": 50.0
+    },
     "dev_class": "heater_central",
     "dhw_mode": "comfort",
     "dhw_modes": [
       "comfort",
       "off"
     ],
-    "location": "eedadcb297564f1483faa509179aebed",
-    "max_dhw_temperature": {
+    "dhw_temperature": {
+      "current": 63.5,
       "lower_bound": 40.0,
       "resolution": 0.01,
       "setpoint": 60.0,
       "upper_bound": 65.0
     },
-    "maximum_boiler_temperature": {
-      "lower_bound": 7.0,
-      "resolution": 0.01,
-      "setpoint": 35.0,
-      "upper_bound": 50.0
-    },
+    "location": "eedadcb297564f1483faa509179aebed",
     "model": "Generic heater/cooler",
     "model_id": "17.1",
     "name": "OpenTherm",
     "sensors": {
-      "dhw_temperature": 63.5,
       "intended_boiler_temperature": 0.0,
       "modulation_level": 0.0,
       "outdoor_air_temperature": 13.5,
       "return_temperature": 24.9,
-      "water_pressure": 2.0,
-      "water_temperature": 24.5
+      "water_pressure": 2.0
     },
     "vendor": "Remeha B.V."
   },

--- a/fixtures/adam_heatpump_cooling/data.json
+++ b/fixtures/adam_heatpump_cooling/data.json
@@ -65,7 +65,7 @@
     "dhw_mode": "comfort",
     "dhw_modes": [
       "comfort",
-      "off"
+      "eco"
     ],
     "dhw_temperature": {
       "current": 63.5,

--- a/fixtures/adam_jip/data.json
+++ b/fixtures/adam_jip/data.json
@@ -401,10 +401,10 @@
       "upper_bound": 90.0
     },
     "dev_class": "heater_central",
-    "dhw_mode": "off",
+    "dhw_mode": "eco",
     "dhw_modes": [
       "comfort",
-      "off"
+      "eco"
     ],
     "dhw_temperature": {
       "current": 37.3,

--- a/fixtures/adam_jip/data.json
+++ b/fixtures/adam_jip/data.json
@@ -393,25 +393,27 @@
       "flame_state": false,
       "heating_state": false
     },
+    "boiler_temperature": {
+      "current": 37.3,
+      "lower_bound": 20.0,
+      "resolution": 0.01,
+      "setpoint": 90.0,
+      "upper_bound": 90.0
+    },
     "dev_class": "heater_central",
     "dhw_mode": "off",
     "dhw_modes": [
       "comfort",
       "off"
     ],
-    "location": "9e4433a9d69f40b3aefd15e74395eaec",
-    "max_dhw_temperature": {
+    "dhw_temperature": {
+      "current": 37.3,
       "lower_bound": 40.0,
       "resolution": 0.01,
       "setpoint": 60.0,
       "upper_bound": 60.0
     },
-    "maximum_boiler_temperature": {
-      "lower_bound": 20.0,
-      "resolution": 0.01,
-      "setpoint": 90.0,
-      "upper_bound": 90.0
-    },
+    "location": "9e4433a9d69f40b3aefd15e74395eaec",
     "model": "Generic heater",
     "model_id": "10.20",
     "name": "OpenTherm",
@@ -419,8 +421,7 @@
       "intended_boiler_temperature": 0.0,
       "modulation_level": 0.0,
       "return_temperature": 37.1,
-      "water_pressure": 1.4,
-      "water_temperature": 37.3
+      "water_pressure": 1.4
     },
     "vendor": "Remeha B.V."
   },

--- a/fixtures/adam_onoff_cooling_fake_firmware/data.json
+++ b/fixtures/adam_onoff_cooling_fake_firmware/data.json
@@ -7,35 +7,35 @@
       "flame_state": false,
       "heating_state": false
     },
+    "boiler_temperature": {
+      "current": 24.5,
+      "lower_bound": 7.0,
+      "resolution": 0.01,
+      "setpoint": 35.0,
+      "upper_bound": 50.0
+    },
     "dev_class": "heater_central",
     "dhw_mode": "comfort",
     "dhw_modes": [
       "comfort",
       "off"
     ],
-    "location": "eedadcb297564f1483faa509179aebed",
-    "max_dhw_temperature": {
+    "dhw_temperature": {
+      "current": 63.5,
       "lower_bound": 40.0,
       "resolution": 0.01,
       "setpoint": 60.0,
       "upper_bound": 65.0
     },
-    "maximum_boiler_temperature": {
-      "lower_bound": 7.0,
-      "resolution": 0.01,
-      "setpoint": 35.0,
-      "upper_bound": 50.0
-    },
+    "location": "eedadcb297564f1483faa509179aebed",
     "model": "Unknown",
     "name": "OnOff",
     "sensors": {
-      "dhw_temperature": 63.5,
       "intended_boiler_temperature": 0.0,
       "modulation_level": 0.0,
       "outdoor_air_temperature": 13.5,
       "return_temperature": 24.9,
-      "water_pressure": 2.0,
-      "water_temperature": 24.5
+      "water_pressure": 2.0
     }
   },
   "7d97fc3117784cfdafe347bcedcbbbcb": {

--- a/fixtures/adam_onoff_cooling_fake_firmware/data.json
+++ b/fixtures/adam_onoff_cooling_fake_firmware/data.json
@@ -18,7 +18,7 @@
     "dhw_mode": "comfort",
     "dhw_modes": [
       "comfort",
-      "off"
+      "eco"
     ],
     "dhw_temperature": {
       "current": 63.5,

--- a/fixtures/adam_plus_anna/data.json
+++ b/fixtures/adam_plus_anna/data.json
@@ -54,12 +54,12 @@
     "dev_class": "heater_central",
     "dhw_modes": [
       "comfort",
-      "off"
+      "eco"
     ],
     "location": "07d618f0bb80412687f065b8698ce3e7",
     "model": "Generic heater",
     "name": "OpenTherm",
-    "select_dhw_mode": "off",
+    "select_dhw_mode": "eco",
     "sensors": {
       "intended_boiler_temperature": 0.0
     }

--- a/fixtures/adam_plus_anna/data.json
+++ b/fixtures/adam_plus_anna/data.json
@@ -44,24 +44,24 @@
       "flame_state": false,
       "heating_state": false
     },
+    "boiler_temperature": {
+      "current": 48.0,
+      "lower_bound": 0.0,
+      "resolution": 1.0,
+      "setpoint": 80.0,
+      "upper_bound": 100.0
+    },
     "dev_class": "heater_central",
     "dhw_modes": [
       "comfort",
       "off"
     ],
     "location": "07d618f0bb80412687f065b8698ce3e7",
-    "maximum_boiler_temperature": {
-      "lower_bound": 0.0,
-      "resolution": 1.0,
-      "setpoint": 80.0,
-      "upper_bound": 100.0
-    },
     "model": "Generic heater",
     "name": "OpenTherm",
     "select_dhw_mode": "off",
     "sensors": {
-      "intended_boiler_temperature": 0.0,
-      "water_temperature": 48.0
+      "intended_boiler_temperature": 0.0
     }
   },
   "aa6b0002df0a46e1b1eb94beb61eddfe": {

--- a/fixtures/adam_plus_anna_new/data.json
+++ b/fixtures/adam_plus_anna_new/data.json
@@ -6,24 +6,24 @@
       "flame_state": true,
       "heating_state": true
     },
+    "boiler_temperature": {
+      "current": 43.0,
+      "lower_bound": 25.0,
+      "resolution": 0.01,
+      "setpoint": 50.0,
+      "upper_bound": 95.0
+    },
     "dev_class": "heater_central",
     "dhw_modes": [
       "comfort",
       "off"
     ],
     "location": "bc93488efab249e5bc54fd7e175a6f91",
-    "maximum_boiler_temperature": {
-      "lower_bound": 25.0,
-      "resolution": 0.01,
-      "setpoint": 50.0,
-      "upper_bound": 95.0
-    },
     "model": "Generic heater",
     "name": "OpenTherm",
     "select_dhw_mode": "off",
     "sensors": {
-      "intended_boiler_temperature": 22.5,
-      "water_temperature": 43.0
+      "intended_boiler_temperature": 22.5
     }
   },
   "10016900610d4c7481df78c89606ef22": {

--- a/fixtures/adam_plus_anna_new/data.json
+++ b/fixtures/adam_plus_anna_new/data.json
@@ -16,12 +16,12 @@
     "dev_class": "heater_central",
     "dhw_modes": [
       "comfort",
-      "off"
+      "eco"
     ],
     "location": "bc93488efab249e5bc54fd7e175a6f91",
     "model": "Generic heater",
     "name": "OpenTherm",
-    "select_dhw_mode": "off",
+    "select_dhw_mode": "eco",
     "sensors": {
       "intended_boiler_temperature": 22.5
     }

--- a/fixtures/adam_plus_anna_new_regulation_off/data.json
+++ b/fixtures/adam_plus_anna_new_regulation_off/data.json
@@ -16,12 +16,12 @@
     "dev_class": "heater_central",
     "dhw_modes": [
       "comfort",
-      "off"
+      "eco"
     ],
     "location": "bc93488efab249e5bc54fd7e175a6f91",
     "model": "Generic heater",
     "name": "OpenTherm",
-    "select_dhw_mode": "off",
+    "select_dhw_mode": "eco",
     "sensors": {
       "intended_boiler_temperature": 0.0
     }

--- a/fixtures/adam_plus_anna_new_regulation_off/data.json
+++ b/fixtures/adam_plus_anna_new_regulation_off/data.json
@@ -6,24 +6,24 @@
       "flame_state": false,
       "heating_state": false
     },
+    "boiler_temperature": {
+      "current": 30.0,
+      "lower_bound": 25.0,
+      "resolution": 0.01,
+      "setpoint": 50.0,
+      "upper_bound": 95.0
+    },
     "dev_class": "heater_central",
     "dhw_modes": [
       "comfort",
       "off"
     ],
     "location": "bc93488efab249e5bc54fd7e175a6f91",
-    "maximum_boiler_temperature": {
-      "lower_bound": 25.0,
-      "resolution": 0.01,
-      "setpoint": 50.0,
-      "upper_bound": 95.0
-    },
     "model": "Generic heater",
     "name": "OpenTherm",
     "select_dhw_mode": "off",
     "sensors": {
-      "intended_boiler_temperature": 0.0,
-      "water_temperature": 30.0
+      "intended_boiler_temperature": 0.0
     }
   },
   "10016900610d4c7481df78c89606ef22": {

--- a/fixtures/anna_elga_2/data.json
+++ b/fixtures/anna_elga_2/data.json
@@ -13,12 +13,12 @@
     "dev_class": "heater_central",
     "dhw_modes": [
       "comfort",
-      "off"
+      "eco"
     ],
     "location": "d34dfe6ab90b410c98068e75de3eb631",
     "model": "Generic heater/cooler",
     "name": "OpenTherm",
-    "select_dhw_mode": "off",
+    "select_dhw_mode": "eco",
     "sensors": {
       "domestic_hot_water_setpoint": 60.0,
       "intended_boiler_temperature": 58.3,

--- a/fixtures/anna_elga_2_cooling/data.json
+++ b/fixtures/anna_elga_2_cooling/data.json
@@ -20,7 +20,7 @@
     "dev_class": "heater_central",
     "dhw_modes": [
       "comfort",
-      "off"
+      "eco"
     ],
     "location": "d34dfe6ab90b410c98068e75de3eb631",
     "model": "Generic heater/cooler",

--- a/fixtures/anna_elga_2_cooling/data.json
+++ b/fixtures/anna_elga_2_cooling/data.json
@@ -10,18 +10,19 @@
       "heating_state": false,
       "secondary_boiler_state": false
     },
+    "boiler_temperature": {
+      "current": 22.8,
+      "lower_bound": 0.0,
+      "resolution": 1.0,
+      "setpoint": 60.0,
+      "upper_bound": 100.0
+    },
     "dev_class": "heater_central",
     "dhw_modes": [
       "comfort",
       "off"
     ],
     "location": "d34dfe6ab90b410c98068e75de3eb631",
-    "maximum_boiler_temperature": {
-      "lower_bound": 0.0,
-      "resolution": 1.0,
-      "setpoint": 60.0,
-      "upper_bound": 100.0
-    },
     "model": "Generic heater/cooler",
     "name": "OpenTherm",
     "select_dhw_mode": "comfort",
@@ -31,8 +32,7 @@
       "modulation_level": 0.0,
       "outdoor_air_temperature": 30.0,
       "return_temperature": 23.4,
-      "water_pressure": 0.5,
-      "water_temperature": 22.8
+      "water_pressure": 0.5
     },
     "vendor": "Techneco"
   },

--- a/fixtures/anna_elga_2_schedule_off/data.json
+++ b/fixtures/anna_elga_2_schedule_off/data.json
@@ -10,18 +10,19 @@
       "heating_state": false,
       "secondary_boiler_state": false
     },
+    "boiler_temperature": {
+      "current": 22.8,
+      "lower_bound": 0.0,
+      "resolution": 1.0,
+      "setpoint": 60.0,
+      "upper_bound": 100.0
+    },
     "dev_class": "heater_central",
     "dhw_modes": [
       "comfort",
       "off"
     ],
     "location": "d34dfe6ab90b410c98068e75de3eb631",
-    "maximum_boiler_temperature": {
-      "lower_bound": 0.0,
-      "resolution": 1.0,
-      "setpoint": 60.0,
-      "upper_bound": 100.0
-    },
     "model": "Generic heater/cooler",
     "name": "OpenTherm",
     "select_dhw_mode": "comfort",
@@ -31,8 +32,7 @@
       "modulation_level": 0.0,
       "outdoor_air_temperature": 13.0,
       "return_temperature": 23.4,
-      "water_pressure": 0.5,
-      "water_temperature": 22.8
+      "water_pressure": 0.5
     },
     "vendor": "Techneco"
   },

--- a/fixtures/anna_elga_2_schedule_off/data.json
+++ b/fixtures/anna_elga_2_schedule_off/data.json
@@ -20,7 +20,7 @@
     "dev_class": "heater_central",
     "dhw_modes": [
       "comfort",
-      "off"
+      "eco"
     ],
     "location": "d34dfe6ab90b410c98068e75de3eb631",
     "model": "Generic heater/cooler",

--- a/fixtures/anna_elga_no_cooling/data.json
+++ b/fixtures/anna_elga_no_cooling/data.json
@@ -34,10 +34,10 @@
       "upper_bound": 100.0
     },
     "dev_class": "heater_central",
-    "dhw_mode": "off",
+    "dhw_mode": "eco",
     "dhw_modes": [
       "comfort",
-      "off"
+      "eco"
     ],
     "dhw_temperature": {
       "current": 46.3,

--- a/fixtures/anna_elga_no_cooling/data.json
+++ b/fixtures/anna_elga_no_cooling/data.json
@@ -26,35 +26,35 @@
       "heating_state": true,
       "secondary_boiler_state": false
     },
+    "boiler_temperature": {
+      "current": 29.1,
+      "lower_bound": 0.0,
+      "resolution": 1.0,
+      "setpoint": 60.0,
+      "upper_bound": 100.0
+    },
     "dev_class": "heater_central",
     "dhw_mode": "off",
     "dhw_modes": [
       "comfort",
       "off"
     ],
-    "location": "a57efe5f145f498c9be62a9b63626fbf",
-    "max_dhw_temperature": {
+    "dhw_temperature": {
+      "current": 46.3,
       "lower_bound": 35.0,
       "resolution": 0.01,
       "setpoint": 53.0,
       "upper_bound": 60.0
     },
-    "maximum_boiler_temperature": {
-      "lower_bound": 0.0,
-      "resolution": 1.0,
-      "setpoint": 60.0,
-      "upper_bound": 100.0
-    },
+    "location": "a57efe5f145f498c9be62a9b63626fbf",
     "model": "Generic heater",
     "name": "OpenTherm",
     "sensors": {
-      "dhw_temperature": 46.3,
       "intended_boiler_temperature": 35.0,
       "modulation_level": 52,
       "outdoor_air_temperature": 3.0,
       "return_temperature": 25.1,
-      "water_pressure": 1.57,
-      "water_temperature": 29.1
+      "water_pressure": 1.57
     },
     "vendor": "Techneco"
   },

--- a/fixtures/anna_heatpump_cooling/data.json
+++ b/fixtures/anna_heatpump_cooling/data.json
@@ -28,18 +28,19 @@
       "heating_state": false,
       "secondary_boiler_state": false
     },
+    "boiler_temperature": {
+      "current": 24.7,
+      "lower_bound": 0.0,
+      "resolution": 1.0,
+      "setpoint": 60.0,
+      "upper_bound": 100.0
+    },
     "dev_class": "heater_central",
     "dhw_modes": [
       "comfort",
       "off"
     ],
     "location": "a57efe5f145f498c9be62a9b63626fbf",
-    "maximum_boiler_temperature": {
-      "lower_bound": 0.0,
-      "resolution": 1.0,
-      "setpoint": 60.0,
-      "upper_bound": 100.0
-    },
     "model": "Generic heater/cooler",
     "name": "OpenTherm",
     "select_dhw_mode": "off",
@@ -50,8 +51,7 @@
       "modulation_level": 40,
       "outdoor_air_temperature": 22.0,
       "return_temperature": 23.8,
-      "water_pressure": 1.61,
-      "water_temperature": 24.7
+      "water_pressure": 1.61
     },
     "vendor": "Techneco"
   },

--- a/fixtures/anna_heatpump_cooling/data.json
+++ b/fixtures/anna_heatpump_cooling/data.json
@@ -38,12 +38,12 @@
     "dev_class": "heater_central",
     "dhw_modes": [
       "comfort",
-      "off"
+      "eco"
     ],
     "location": "a57efe5f145f498c9be62a9b63626fbf",
     "model": "Generic heater/cooler",
     "name": "OpenTherm",
-    "select_dhw_mode": "off",
+    "select_dhw_mode": "eco",
     "sensors": {
       "dhw_temperature": 41.5,
       "domestic_hot_water_setpoint": 60.0,

--- a/fixtures/anna_heatpump_cooling_fake_firmware/data.json
+++ b/fixtures/anna_heatpump_cooling_fake_firmware/data.json
@@ -28,18 +28,19 @@
       "heating_state": false,
       "secondary_boiler_state": false
     },
+    "boiler_temperature": {
+      "current": 24.7,
+      "lower_bound": 0.0,
+      "resolution": 1.0,
+      "setpoint": 60.0,
+      "upper_bound": 100.0
+    },
     "dev_class": "heater_central",
     "dhw_modes": [
       "comfort",
       "off"
     ],
     "location": "a57efe5f145f498c9be62a9b63626fbf",
-    "maximum_boiler_temperature": {
-      "lower_bound": 0.0,
-      "resolution": 1.0,
-      "setpoint": 60.0,
-      "upper_bound": 100.0
-    },
     "model": "Generic heater/cooler",
     "name": "OpenTherm",
     "select_dhw_mode": "off",
@@ -50,8 +51,7 @@
       "modulation_level": 100,
       "outdoor_air_temperature": 22.0,
       "return_temperature": 23.8,
-      "water_pressure": 1.61,
-      "water_temperature": 24.7
+      "water_pressure": 1.61
     },
     "vendor": "Techneco"
   },

--- a/fixtures/anna_heatpump_cooling_fake_firmware/data.json
+++ b/fixtures/anna_heatpump_cooling_fake_firmware/data.json
@@ -38,12 +38,12 @@
     "dev_class": "heater_central",
     "dhw_modes": [
       "comfort",
-      "off"
+      "eco"
     ],
     "location": "a57efe5f145f498c9be62a9b63626fbf",
     "model": "Generic heater/cooler",
     "name": "OpenTherm",
-    "select_dhw_mode": "off",
+    "select_dhw_mode": "eco",
     "sensors": {
       "dhw_temperature": 41.5,
       "domestic_hot_water_setpoint": 60.0,

--- a/fixtures/anna_heatpump_heating/data.json
+++ b/fixtures/anna_heatpump_heating/data.json
@@ -28,35 +28,35 @@
       "heating_state": true,
       "secondary_boiler_state": false
     },
+    "boiler_temperature": {
+      "current": 29.1,
+      "lower_bound": 0.0,
+      "resolution": 1.0,
+      "setpoint": 60.0,
+      "upper_bound": 100.0
+    },
     "dev_class": "heater_central",
     "dhw_mode": "off",
     "dhw_modes": [
       "comfort",
       "off"
     ],
-    "location": "a57efe5f145f498c9be62a9b63626fbf",
-    "max_dhw_temperature": {
+    "dhw_temperature": {
+      "current": 46.3,
       "lower_bound": 35.0,
       "resolution": 0.01,
       "setpoint": 53.0,
       "upper_bound": 60.0
     },
-    "maximum_boiler_temperature": {
-      "lower_bound": 0.0,
-      "resolution": 1.0,
-      "setpoint": 60.0,
-      "upper_bound": 100.0
-    },
+    "location": "a57efe5f145f498c9be62a9b63626fbf",
     "model": "Generic heater/cooler",
     "name": "OpenTherm",
     "sensors": {
-      "dhw_temperature": 46.3,
       "intended_boiler_temperature": 35.0,
       "modulation_level": 52,
       "outdoor_air_temperature": 3.0,
       "return_temperature": 25.1,
-      "water_pressure": 1.57,
-      "water_temperature": 29.1
+      "water_pressure": 1.57
     },
     "vendor": "Techneco"
   },

--- a/fixtures/anna_heatpump_heating/data.json
+++ b/fixtures/anna_heatpump_heating/data.json
@@ -36,10 +36,10 @@
       "upper_bound": 100.0
     },
     "dev_class": "heater_central",
-    "dhw_mode": "off",
+    "dhw_mode": "eco",
     "dhw_modes": [
       "comfort",
-      "off"
+      "eco"
     ],
     "dhw_temperature": {
       "current": 46.3,

--- a/fixtures/anna_loria_cooling_active/data.json
+++ b/fixtures/anna_loria_cooling_active/data.json
@@ -70,6 +70,13 @@
       "flame_state": false,
       "heating_state": false
     },
+    "boiler_temperature": {
+      "current": 25.3,
+      "lower_bound": 25.0,
+      "resolution": 0.01,
+      "setpoint": 40.0,
+      "upper_bound": 45.0
+    },
     "dev_class": "heater_central",
     "dhw_mode": "auto",
     "dhw_modes": [
@@ -79,29 +86,22 @@
       "eco",
       "comfort"
     ],
-    "location": "674b657c138a41a291d315d7471deb06",
-    "max_dhw_temperature": {
+    "dhw_temperature": {
+      "current": 52.9,
       "lower_bound": 35.0,
       "resolution": 0.01,
       "setpoint": 53.0,
       "upper_bound": 60.0
     },
-    "maximum_boiler_temperature": {
-      "lower_bound": 25.0,
-      "resolution": 0.01,
-      "setpoint": 40.0,
-      "upper_bound": 45.0
-    },
+    "location": "674b657c138a41a291d315d7471deb06",
     "model": "Generic heater/cooler",
     "model_id": "173",
     "name": "OpenTherm",
     "sensors": {
-      "dhw_temperature": 52.9,
       "intended_boiler_temperature": 0.0,
       "modulation_level": 100,
       "outdoor_air_temperature": 17.2,
-      "return_temperature": 26.3,
-      "water_temperature": 25.3
+      "return_temperature": 26.3
     },
     "switches": {
       "cooling_ena_switch": true

--- a/fixtures/anna_loria_driessens/data.json
+++ b/fixtures/anna_loria_driessens/data.json
@@ -72,6 +72,13 @@
       "flame_state": false,
       "heating_state": false
     },
+    "boiler_temperature": {
+      "current": 23.3,
+      "lower_bound": 25.0,
+      "resolution": 0.01,
+      "setpoint": 45.0,
+      "upper_bound": 45.0
+    },
     "dev_class": "heater_central",
     "dhw_mode": "auto",
     "dhw_modes": [
@@ -81,29 +88,22 @@
       "boost",
       "auto"
     ],
-    "location": "82c15f65c9bf44c592d69e16139355e3",
-    "max_dhw_temperature": {
+    "dhw_temperature": {
+      "current": 49.5,
       "lower_bound": 35.0,
       "resolution": 0.01,
       "setpoint": 53.0,
       "upper_bound": 60.0
     },
-    "maximum_boiler_temperature": {
-      "lower_bound": 25.0,
-      "resolution": 0.01,
-      "setpoint": 45.0,
-      "upper_bound": 45.0
-    },
+    "location": "82c15f65c9bf44c592d69e16139355e3",
     "model": "Generic heater/cooler",
     "model_id": "173",
     "name": "OpenTherm",
     "sensors": {
-      "dhw_temperature": 49.5,
       "intended_boiler_temperature": 0.0,
       "modulation_level": 0.0,
       "outdoor_air_temperature": 7.5,
-      "return_temperature": 23.0,
-      "water_temperature": 23.3
+      "return_temperature": 23.0
     },
     "switches": {
       "cooling_ena_switch": false

--- a/fixtures/anna_loria_heating_idle/data.json
+++ b/fixtures/anna_loria_heating_idle/data.json
@@ -70,6 +70,13 @@
       "flame_state": false,
       "heating_state": false
     },
+    "boiler_temperature": {
+      "current": 25.3,
+      "lower_bound": 25.0,
+      "resolution": 0.01,
+      "setpoint": 40.0,
+      "upper_bound": 45.0
+    },
     "dev_class": "heater_central",
     "dhw_mode": "auto",
     "dhw_modes": [
@@ -79,29 +86,22 @@
       "eco",
       "comfort"
     ],
-    "location": "674b657c138a41a291d315d7471deb06",
-    "max_dhw_temperature": {
+    "dhw_temperature": {
+      "current": 52.9,
       "lower_bound": 35.0,
       "resolution": 0.01,
       "setpoint": 53.0,
       "upper_bound": 60.0
     },
-    "maximum_boiler_temperature": {
-      "lower_bound": 25.0,
-      "resolution": 0.01,
-      "setpoint": 40.0,
-      "upper_bound": 45.0
-    },
+    "location": "674b657c138a41a291d315d7471deb06",
     "model": "Generic heater/cooler",
     "model_id": "173",
     "name": "OpenTherm",
     "sensors": {
-      "dhw_temperature": 52.9,
       "intended_boiler_temperature": 0.0,
       "modulation_level": 0.0,
       "outdoor_air_temperature": 17.2,
-      "return_temperature": 26.3,
-      "water_temperature": 25.3
+      "return_temperature": 26.3
     },
     "switches": {
       "cooling_ena_switch": false

--- a/fixtures/anna_p1/data.json
+++ b/fixtures/anna_p1/data.json
@@ -50,7 +50,7 @@
     "dev_class": "heater_central",
     "dhw_modes": [
       "comfort",
-      "off"
+      "eco"
     ],
     "location": "da7be222ab3b420c927f3e49fade0304",
     "model": "Generic heater",

--- a/fixtures/anna_v4/data.json
+++ b/fixtures/anna_v4/data.json
@@ -74,10 +74,10 @@
       "upper_bound": 100.0
     },
     "dev_class": "heater_central",
-    "dhw_mode": "off",
+    "dhw_mode": "eco",
     "dhw_modes": [
       "comfort",
-      "off"
+      "eco"
     ],
     "dhw_temperature": {
       "current": 45.0,

--- a/fixtures/anna_v4/data.json
+++ b/fixtures/anna_v4/data.json
@@ -66,25 +66,27 @@
       "flame_state": false,
       "heating_state": true
     },
+    "boiler_temperature": {
+      "current": 45.0,
+      "lower_bound": 0.0,
+      "resolution": 1.0,
+      "setpoint": 70.0,
+      "upper_bound": 100.0
+    },
     "dev_class": "heater_central",
     "dhw_mode": "off",
     "dhw_modes": [
       "comfort",
       "off"
     ],
-    "location": "94c107dc6ac84ed98e9f68c0dd06bf71",
-    "max_dhw_temperature": {
+    "dhw_temperature": {
+      "current": 45.0,
       "lower_bound": 30.0,
       "resolution": 0.01,
       "setpoint": 60.0,
       "upper_bound": 60.0
     },
-    "maximum_boiler_temperature": {
-      "lower_bound": 0.0,
-      "resolution": 1.0,
-      "setpoint": 70.0,
-      "upper_bound": 100.0
-    },
+    "location": "94c107dc6ac84ed98e9f68c0dd06bf71",
     "model": "Generic heater",
     "model_id": "2.32",
     "name": "OpenTherm",
@@ -92,8 +94,7 @@
       "intended_boiler_temperature": 39.9,
       "modulation_level": 0.0,
       "return_temperature": 32.0,
-      "water_pressure": 2.2,
-      "water_temperature": 45.0
+      "water_pressure": 2.2
     },
     "vendor": "Bosch Thermotechniek B.V."
   }

--- a/fixtures/anna_v4_dhw/data.json
+++ b/fixtures/anna_v4_dhw/data.json
@@ -74,10 +74,10 @@
       "upper_bound": 100.0
     },
     "dev_class": "heater_central",
-    "dhw_mode": "off",
+    "dhw_mode": "eco",
     "dhw_modes": [
       "comfort",
-      "off"
+      "eco"
     ],
     "dhw_temperature": {
       "current": 45.0,

--- a/fixtures/anna_v4_dhw/data.json
+++ b/fixtures/anna_v4_dhw/data.json
@@ -66,25 +66,27 @@
       "flame_state": true,
       "heating_state": false
     },
+    "boiler_temperature": {
+      "current": 45.0,
+      "lower_bound": 0.0,
+      "resolution": 1.0,
+      "setpoint": 70.0,
+      "upper_bound": 100.0
+    },
     "dev_class": "heater_central",
     "dhw_mode": "off",
     "dhw_modes": [
       "comfort",
       "off"
     ],
-    "location": "94c107dc6ac84ed98e9f68c0dd06bf71",
-    "max_dhw_temperature": {
+    "dhw_temperature": {
+      "current": 45.0,
       "lower_bound": 30.0,
       "resolution": 0.01,
       "setpoint": 60.0,
       "upper_bound": 60.0
     },
-    "maximum_boiler_temperature": {
-      "lower_bound": 0.0,
-      "resolution": 1.0,
-      "setpoint": 70.0,
-      "upper_bound": 100.0
-    },
+    "location": "94c107dc6ac84ed98e9f68c0dd06bf71",
     "model": "Generic heater",
     "model_id": "2.32",
     "name": "OpenTherm",
@@ -92,8 +94,7 @@
       "intended_boiler_temperature": 39.9,
       "modulation_level": 0.0,
       "return_temperature": 32.0,
-      "water_pressure": 2.2,
-      "water_temperature": 45.0
+      "water_pressure": 2.2
     },
     "vendor": "Bosch Thermotechniek B.V."
   }

--- a/fixtures/anna_v4_no_tag/data.json
+++ b/fixtures/anna_v4_no_tag/data.json
@@ -74,10 +74,10 @@
       "upper_bound": 100.0
     },
     "dev_class": "heater_central",
-    "dhw_mode": "off",
+    "dhw_mode": "eco",
     "dhw_modes": [
       "comfort",
-      "off"
+      "eco"
     ],
     "dhw_temperature": {
       "current": 45.0,

--- a/fixtures/anna_v4_no_tag/data.json
+++ b/fixtures/anna_v4_no_tag/data.json
@@ -66,25 +66,27 @@
       "flame_state": false,
       "heating_state": true
     },
+    "boiler_temperature": {
+      "current": 45.0,
+      "lower_bound": 0.0,
+      "resolution": 1.0,
+      "setpoint": 70.0,
+      "upper_bound": 100.0
+    },
     "dev_class": "heater_central",
     "dhw_mode": "off",
     "dhw_modes": [
       "comfort",
       "off"
     ],
-    "location": "94c107dc6ac84ed98e9f68c0dd06bf71",
-    "max_dhw_temperature": {
+    "dhw_temperature": {
+      "current": 45.0,
       "lower_bound": 30.0,
       "resolution": 0.01,
       "setpoint": 60.0,
       "upper_bound": 60.0
     },
-    "maximum_boiler_temperature": {
-      "lower_bound": 0.0,
-      "resolution": 1.0,
-      "setpoint": 70.0,
-      "upper_bound": 100.0
-    },
+    "location": "94c107dc6ac84ed98e9f68c0dd06bf71",
     "model": "Generic heater",
     "model_id": "2.32",
     "name": "OpenTherm",
@@ -92,8 +94,7 @@
       "intended_boiler_temperature": 39.9,
       "modulation_level": 0.0,
       "return_temperature": 32.0,
-      "water_pressure": 2.2,
-      "water_temperature": 45.0
+      "water_pressure": 2.2
     },
     "vendor": "Bosch Thermotechniek B.V."
   }

--- a/fixtures/m_adam_cooling/data.json
+++ b/fixtures/m_adam_cooling/data.json
@@ -17,12 +17,12 @@
     "dev_class": "heater_central",
     "dhw_modes": [
       "comfort",
-      "off"
+      "eco"
     ],
     "location": "bc93488efab249e5bc54fd7e175a6f91",
     "model": "Generic heater",
     "name": "OpenTherm",
-    "select_dhw_mode": "off",
+    "select_dhw_mode": "eco",
     "sensors": {
       "intended_boiler_temperature": 17.5
     }

--- a/fixtures/m_adam_cooling/data.json
+++ b/fixtures/m_adam_cooling/data.json
@@ -7,18 +7,19 @@
       "flame_state": false,
       "heating_state": false
     },
+    "boiler_temperature": {
+      "current": 43.0,
+      "lower_bound": 25.0,
+      "resolution": 0.01,
+      "setpoint": 50.0,
+      "upper_bound": 95.0
+    },
     "dev_class": "heater_central",
     "dhw_modes": [
       "comfort",
       "off"
     ],
     "location": "bc93488efab249e5bc54fd7e175a6f91",
-    "maximum_boiler_temperature": {
-      "lower_bound": 25.0,
-      "resolution": 0.01,
-      "setpoint": 50.0,
-      "upper_bound": 95.0
-    },
     "model": "Generic heater",
     "name": "OpenTherm",
     "select_dhw_mode": "off",

--- a/fixtures/m_adam_cooling/data.json
+++ b/fixtures/m_adam_cooling/data.json
@@ -8,7 +8,7 @@
       "heating_state": false
     },
     "boiler_temperature": {
-      "current": 43.0,
+      "current": 19.0,
       "lower_bound": 25.0,
       "resolution": 0.01,
       "setpoint": 50.0,
@@ -24,8 +24,7 @@
     "name": "OpenTherm",
     "select_dhw_mode": "off",
     "sensors": {
-      "intended_boiler_temperature": 17.5,
-      "water_temperature": 19.0
+      "intended_boiler_temperature": 17.5
     }
   },
   "14df5c4dc8cb4ba69f9d1ac0eaf7c5c6": {

--- a/fixtures/m_adam_heating/data.json
+++ b/fixtures/m_adam_heating/data.json
@@ -16,7 +16,7 @@
     "dev_class": "heater_central",
     "dhw_modes": [
       "comfort",
-      "off"
+      "eco"
     ],
     "dhw_temperature": {
       "current": 37.0,
@@ -28,7 +28,7 @@
     "location": "bc93488efab249e5bc54fd7e175a6f91",
     "model": "Generic heater",
     "name": "OpenTherm",
-    "select_dhw_mode": "off",
+    "select_dhw_mode": "eco",
     "sensors": {
       "intended_boiler_temperature": 38.1
     }

--- a/fixtures/m_adam_heating/data.json
+++ b/fixtures/m_adam_heating/data.json
@@ -7,7 +7,7 @@
       "heating_state": true
     },
     "boiler_temperature": {
-      "current": 43.0,
+      "current": 37.0,
       "lower_bound": 25.0,
       "resolution": 0.01,
       "setpoint": 50.0,
@@ -18,19 +18,19 @@
       "comfort",
       "off"
     ],
-    "location": "bc93488efab249e5bc54fd7e175a6f91",
-    "max_dhw_temperature": {
+    "dhw_temperature": {
+      "current": 37.0,
       "lower_bound": 40.0,
       "resolution": 0.01,
       "setpoint": 60.0,
       "upper_bound": 60.0
     },
+    "location": "bc93488efab249e5bc54fd7e175a6f91",
     "model": "Generic heater",
     "name": "OpenTherm",
     "select_dhw_mode": "off",
     "sensors": {
-      "intended_boiler_temperature": 38.1,
-      "water_temperature": 37.0
+      "intended_boiler_temperature": 38.1
     }
   },
   "14df5c4dc8cb4ba69f9d1ac0eaf7c5c6": {

--- a/fixtures/m_adam_heating/data.json
+++ b/fixtures/m_adam_heating/data.json
@@ -6,6 +6,13 @@
       "flame_state": false,
       "heating_state": true
     },
+    "boiler_temperature": {
+      "current": 43.0,
+      "lower_bound": 25.0,
+      "resolution": 0.01,
+      "setpoint": 50.0,
+      "upper_bound": 95.0
+    },
     "dev_class": "heater_central",
     "dhw_modes": [
       "comfort",
@@ -17,12 +24,6 @@
       "resolution": 0.01,
       "setpoint": 60.0,
       "upper_bound": 60.0
-    },
-    "maximum_boiler_temperature": {
-      "lower_bound": 25.0,
-      "resolution": 0.01,
-      "setpoint": 50.0,
-      "upper_bound": 95.0
     },
     "model": "Generic heater",
     "name": "OpenTherm",

--- a/fixtures/m_adam_heating_off_schedule/data.json
+++ b/fixtures/m_adam_heating_off_schedule/data.json
@@ -16,7 +16,7 @@
     "dev_class": "heater_central",
     "dhw_modes": [
       "comfort",
-      "off"
+      "eco"
     ],
     "dhw_temperature": {
       "current": 37.0,
@@ -28,7 +28,7 @@
     "location": "bc93488efab249e5bc54fd7e175a6f91",
     "model": "Generic heater",
     "name": "OpenTherm",
-    "select_dhw_mode": "off",
+    "select_dhw_mode": "eco",
     "sensors": {
       "intended_boiler_temperature": 0.0
     }

--- a/fixtures/m_adam_heating_off_schedule/data.json
+++ b/fixtures/m_adam_heating_off_schedule/data.json
@@ -6,6 +6,13 @@
       "flame_state": false,
       "heating_state": false
     },
+    "boiler_temperature": {
+      "current": 43.0,
+      "lower_bound": 25.0,
+      "resolution": 0.01,
+      "setpoint": 50.0,
+      "upper_bound": 95.0
+    },
     "dev_class": "heater_central",
     "dhw_modes": [
       "comfort",
@@ -17,12 +24,6 @@
       "resolution": 0.01,
       "setpoint": 60.0,
       "upper_bound": 60.0
-    },
-    "maximum_boiler_temperature": {
-      "lower_bound": 25.0,
-      "resolution": 0.01,
-      "setpoint": 50.0,
-      "upper_bound": 95.0
     },
     "model": "Generic heater",
     "name": "OpenTherm",

--- a/fixtures/m_adam_heating_off_schedule/data.json
+++ b/fixtures/m_adam_heating_off_schedule/data.json
@@ -7,7 +7,7 @@
       "heating_state": false
     },
     "boiler_temperature": {
-      "current": 43.0,
+      "current": 37.0,
       "lower_bound": 25.0,
       "resolution": 0.01,
       "setpoint": 50.0,
@@ -18,19 +18,19 @@
       "comfort",
       "off"
     ],
-    "location": "bc93488efab249e5bc54fd7e175a6f91",
-    "max_dhw_temperature": {
+    "dhw_temperature": {
+      "current": 37.0,
       "lower_bound": 40.0,
       "resolution": 0.01,
       "setpoint": 60.0,
       "upper_bound": 60.0
     },
+    "location": "bc93488efab249e5bc54fd7e175a6f91",
     "model": "Generic heater",
     "name": "OpenTherm",
     "select_dhw_mode": "off",
     "sensors": {
-      "intended_boiler_temperature": 0.0,
-      "water_temperature": 37.0
+      "intended_boiler_temperature": 0.0
     }
   },
   "14df5c4dc8cb4ba69f9d1ac0eaf7c5c6": {

--- a/fixtures/m_adam_jip/data.json
+++ b/fixtures/m_adam_jip/data.json
@@ -392,25 +392,27 @@
       "flame_state": false,
       "heating_state": false
     },
+    "boiler_temperature": {
+      "current": 37.3,
+      "lower_bound": 20.0,
+      "resolution": 0.01,
+      "setpoint": 90.0,
+      "upper_bound": 90.0
+    },
     "dev_class": "heater_central",
     "dhw_mode": "off",
     "dhw_modes": [
       "comfort",
       "off"
     ],
-    "location": "9e4433a9d69f40b3aefd15e74395eaec",
-    "max_dhw_temperature": {
+    "dhw_temperature": {
+      "current": 37.3,
       "lower_bound": 40.0,
       "resolution": 0.01,
       "setpoint": 60.0,
       "upper_bound": 60.0
     },
-    "maximum_boiler_temperature": {
-      "lower_bound": 20.0,
-      "resolution": 0.01,
-      "setpoint": 90.0,
-      "upper_bound": 90.0
-    },
+    "location": "9e4433a9d69f40b3aefd15e74395eaec",
     "model": "Generic heater",
     "model_id": "10.20",
     "name": "OpenTherm",
@@ -418,8 +420,7 @@
       "intended_boiler_temperature": 0.0,
       "modulation_level": 0.0,
       "return_temperature": 37.1,
-      "water_pressure": 1.4,
-      "water_temperature": 37.3
+      "water_pressure": 1.4
     },
     "vendor": "Remeha B.V."
   },

--- a/fixtures/m_adam_jip/data.json
+++ b/fixtures/m_adam_jip/data.json
@@ -400,10 +400,10 @@
       "upper_bound": 90.0
     },
     "dev_class": "heater_central",
-    "dhw_mode": "off",
+    "dhw_mode": "eco",
     "dhw_modes": [
       "comfort",
-      "off"
+      "eco"
     ],
     "dhw_temperature": {
       "current": 37.3,

--- a/fixtures/m_anna_heatpump_cooling/data.json
+++ b/fixtures/m_anna_heatpump_cooling/data.json
@@ -36,10 +36,10 @@
       "upper_bound": 100.0
     },
     "dev_class": "heater_central",
-    "dhw_mode": "off",
+    "dhw_mode": "eco",
     "dhw_modes": [
       "comfort",
-      "off"
+      "eco"
     ],
     "dhw_temperature": {
       "current": 41.5,

--- a/fixtures/m_anna_heatpump_cooling/data.json
+++ b/fixtures/m_anna_heatpump_cooling/data.json
@@ -29,7 +29,7 @@
       "secondary_boiler_state": false
     },
     "boiler_temperature": {
-      "current": 29.1,
+      "current": 22.7,
       "lower_bound": 0.0,
       "resolution": 1.0,
       "setpoint": 60.0,
@@ -42,7 +42,7 @@
       "off"
     ],
     "dhw_temperature": {
-      "current": 46.3,
+      "current": 41.5,
       "lower_bound": 35.0,
       "resolution": 0.01,
       "setpoint": 53.0,
@@ -52,13 +52,11 @@
     "model": "Generic heater/cooler",
     "name": "OpenTherm",
     "sensors": {
-      "dhw_temperature": 41.5,
       "intended_boiler_temperature": 0.0,
       "modulation_level": 40,
       "outdoor_air_temperature": 28.0,
       "return_temperature": 23.8,
-      "water_pressure": 1.57,
-      "water_temperature": 22.7
+      "water_pressure": 1.57
     },
     "vendor": "Techneco"
   },

--- a/fixtures/m_anna_heatpump_cooling/data.json
+++ b/fixtures/m_anna_heatpump_cooling/data.json
@@ -28,25 +28,27 @@
       "heating_state": false,
       "secondary_boiler_state": false
     },
+    "boiler_temperature": {
+      "current": 29.1,
+      "lower_bound": 0.0,
+      "resolution": 1.0,
+      "setpoint": 60.0,
+      "upper_bound": 100.0
+    },
     "dev_class": "heater_central",
     "dhw_mode": "off",
     "dhw_modes": [
       "comfort",
       "off"
     ],
-    "location": "a57efe5f145f498c9be62a9b63626fbf",
-    "max_dhw_temperature": {
+    "dhw_temperature": {
+      "current": 46.3,
       "lower_bound": 35.0,
       "resolution": 0.01,
       "setpoint": 53.0,
       "upper_bound": 60.0
     },
-    "maximum_boiler_temperature": {
-      "lower_bound": 0.0,
-      "resolution": 1.0,
-      "setpoint": 60.0,
-      "upper_bound": 100.0
-    },
+    "location": "a57efe5f145f498c9be62a9b63626fbf",
     "model": "Generic heater/cooler",
     "name": "OpenTherm",
     "sensors": {

--- a/fixtures/m_anna_heatpump_idle/data.json
+++ b/fixtures/m_anna_heatpump_idle/data.json
@@ -36,10 +36,10 @@
       "upper_bound": 100.0
     },
     "dev_class": "heater_central",
-    "dhw_mode": "off",
+    "dhw_mode": "eco",
     "dhw_modes": [
       "comfort",
-      "off"
+      "eco"
     ],
     "dhw_temperature": {
       "current": 46.3,

--- a/fixtures/m_anna_heatpump_idle/data.json
+++ b/fixtures/m_anna_heatpump_idle/data.json
@@ -29,7 +29,7 @@
       "secondary_boiler_state": false
     },
     "boiler_temperature": {
-      "current": 29.1,
+      "current": 19.1,
       "lower_bound": 0.0,
       "resolution": 1.0,
       "setpoint": 60.0,
@@ -52,13 +52,11 @@
     "model": "Generic heater/cooler",
     "name": "OpenTherm",
     "sensors": {
-      "dhw_temperature": 46.3,
       "intended_boiler_temperature": 18.0,
       "modulation_level": 0,
       "outdoor_air_temperature": 28.2,
       "return_temperature": 22.0,
-      "water_pressure": 1.57,
-      "water_temperature": 19.1
+      "water_pressure": 1.57
     },
     "vendor": "Techneco"
   },

--- a/fixtures/m_anna_heatpump_idle/data.json
+++ b/fixtures/m_anna_heatpump_idle/data.json
@@ -28,25 +28,27 @@
       "heating_state": false,
       "secondary_boiler_state": false
     },
+    "boiler_temperature": {
+      "current": 29.1,
+      "lower_bound": 0.0,
+      "resolution": 1.0,
+      "setpoint": 60.0,
+      "upper_bound": 100.0
+    },
     "dev_class": "heater_central",
     "dhw_mode": "off",
     "dhw_modes": [
       "comfort",
       "off"
     ],
-    "location": "a57efe5f145f498c9be62a9b63626fbf",
-    "max_dhw_temperature": {
+    "dhw_temperature": {
+      "current": 46.3,
       "lower_bound": 35.0,
       "resolution": 0.01,
       "setpoint": 53.0,
       "upper_bound": 60.0
     },
-    "maximum_boiler_temperature": {
-      "lower_bound": 0.0,
-      "resolution": 1.0,
-      "setpoint": 60.0,
-      "upper_bound": 100.0
-    },
+    "location": "a57efe5f145f498c9be62a9b63626fbf",
     "model": "Generic heater/cooler",
     "name": "OpenTherm",
     "sensors": {

--- a/plugwise/constants.py
+++ b/plugwise/constants.py
@@ -259,6 +259,8 @@ ACTUATOR_CLASSES: Final[tuple[str, ...]] = (
 ActuatorType = Literal[
     "boiler_temperature",
     "dhw_temperature",
+    "domestic_hot_water_setpoint",
+    "maximum_boiler_temperature",
     "temperature_offset",
     "thermostat",
 ]

--- a/plugwise/constants.py
+++ b/plugwise/constants.py
@@ -257,9 +257,8 @@ ACTUATOR_CLASSES: Final[tuple[str, ...]] = (
     "zone_thermostat",
 )
 ActuatorType = Literal[
-    "domestic_hot_water_setpoint",
-    "max_dhw_temperature",
-    "maximum_boiler_temperature",
+    "boiler_temperature",
+    "dhw_temperature",
     "temperature_offset",
     "thermostat",
 ]
@@ -277,6 +276,7 @@ ACTIVE_KEYS: Final[tuple[str, ...]] = (
 
 ActuatorDataType = Literal[
     "control_state",
+    "current",
     "lower_bound",
     "regulation_control",
     "resolution",
@@ -585,8 +585,8 @@ class GwEntityData(TypedDict, total=False):
 
     # Dict-types
     binary_sensors: SmileBinarySensors
-    max_dhw_temperature: ActuatorData
-    maximum_boiler_temperature: ActuatorData
+    boiler_temperature: ActuatorData
+    dhw_temperature: ActuatorData
     sensors: SmileSensors
     switches: SmileSwitches
     temperature_offset: ActuatorData

--- a/plugwise/constants.py
+++ b/plugwise/constants.py
@@ -520,6 +520,7 @@ class ActuatorData(TypedDict, total=False):
     """Actuator data for thermostat types."""
 
     control_state: str
+    current: float
     lower_bound: float
     regulation_control: str
     resolution: float
@@ -589,6 +590,7 @@ class GwEntityData(TypedDict, total=False):
     binary_sensors: SmileBinarySensors
     boiler_temperature: ActuatorData
     dhw_temperature: ActuatorData
+    maximum_boiler_temperature: ActuatorData
     sensors: SmileSensors
     switches: SmileSwitches
     temperature_offset: ActuatorData

--- a/plugwise/data.py
+++ b/plugwise/data.py
@@ -80,7 +80,7 @@ class SmileData(SmileHelper):
 
             # Replace select_dhw_mode with dhw_mode when applicable
             if (
-                "max_dhw_temperature" in entity
+                "dhw_temperature" in entity
                 and (mode := entity.get("select_dhw_mode")) is not None
             ):
                 entity.pop("select_dhw_mode")

--- a/plugwise/helper.py
+++ b/plugwise/helper.py
@@ -595,6 +595,11 @@ class SmileHelper(SmileCommon):
                         temp_dict["current"] = data["sensors"]["dhw_temperature"]
                         data["sensors"].pop("dhw_temperature")
 
+                if item == "maximum_boiler_temperature":
+                    if "water_temperature" in data["sensors"]:
+                        temp_dict["current"] = data["sensors"]["water_temperature"]
+                        data["sensors"].pop("water_temperature")
+
                 act_item = cast(ActuatorType, item)
                 data[act_item] = temp_dict
 

--- a/plugwise/helper.py
+++ b/plugwise/helper.py
@@ -535,9 +535,9 @@ class SmileHelper(SmileCommon):
         Add the resulting dict(s) to the entity's data.
         """
         for item in ACTIVE_ACTUATORS:
-            # Skip max_dhw_temperature, not initially valid,
+            # Skip dhw_temperature, not initially valid,
             # skip thermostat for all but zones with thermostats
-            if item == "max_dhw_temperature" or (
+            if item == "dhw_temperature" or (
                 item == "thermostat"
                 and (
                     entity["dev_class"] != "climate"
@@ -583,10 +583,11 @@ class SmileHelper(SmileCommon):
                         temp_dict[act_key] = str(pw_function.text)
 
             if temp_dict:
+                LOGGER.debug("HOI temp_dict: %s", temp_dict)
                 # If domestic_hot_water_setpoint is present as actuator,
                 # rename and remove as sensor
                 if item == DHW_SETPOINT:
-                    item = "max_dhw_temperature"
+                    item = "dhw_temperature"
                     if DHW_SETPOINT in data["sensors"]:
                         data["sensors"].pop(DHW_SETPOINT)
                         self._count -= 1

--- a/plugwise/helper.py
+++ b/plugwise/helper.py
@@ -594,6 +594,8 @@ class SmileHelper(SmileCommon):
                     if "dhw_temperature" in data["sensors"]:
                         temp_dict["current"] = data["sensors"]["dhw_temperature"]
                         data["sensors"].pop("dhw_temperature")
+                    elif "water_temperature" in data["sensors"]:
+                        temp_dict["current"] = data["sensors"]["water_temperature"]
 
                 if item == "maximum_boiler_temperature":
                     item = "boiler_temperature"

--- a/plugwise/helper.py
+++ b/plugwise/helper.py
@@ -535,9 +535,9 @@ class SmileHelper(SmileCommon):
         Add the resulting dict(s) to the entity's data.
         """
         for item in ACTIVE_ACTUATORS:
-            # Skip dhw_temperature, not initially valid,
+            # Skip boiler_ and dhw_temperature, not initially valid,
             # skip thermostat for all but zones with thermostats
-            if item == "dhw_temperature" or (
+            if item in ("boiler_temperature", "dhw_temperature") or (
                 item == "thermostat"
                 and (
                     entity["dev_class"] != "climate"
@@ -591,6 +591,9 @@ class SmileHelper(SmileCommon):
                     if DHW_SETPOINT in data["sensors"]:
                         data["sensors"].pop(DHW_SETPOINT)
                         self._count -= 1
+                    if "dhw_temperature" in data["sensors"]:
+                        temp_dict["current"] = data["sensors"]["dhw_temperature"]
+                        data["sensors"].pop("dhw_temperature")
 
                 act_item = cast(ActuatorType, item)
                 data[act_item] = temp_dict

--- a/plugwise/helper.py
+++ b/plugwise/helper.py
@@ -596,6 +596,7 @@ class SmileHelper(SmileCommon):
                         data["sensors"].pop("dhw_temperature")
 
                 if item == "maximum_boiler_temperature":
+                    item = "boiler_temperature"
                     if "water_temperature" in data["sensors"]:
                         temp_dict["current"] = data["sensors"]["water_temperature"]
                         data["sensors"].pop("water_temperature")

--- a/plugwise/helper.py
+++ b/plugwise/helper.py
@@ -583,28 +583,37 @@ class SmileHelper(SmileCommon):
                         temp_dict[act_key] = str(pw_function.text)
 
             if temp_dict:
-                # If domestic_hot_water_setpoint is present as actuator,
-                # rename and remove as sensor
-                if item == DHW_SETPOINT:
-                    item = "dhw_temperature"
-                    if DHW_SETPOINT in data["sensors"]:
-                        data["sensors"].pop(DHW_SETPOINT)
-                        self._count -= 1
-                    if "dhw_temperature" in data["sensors"]:
-                        temp_dict["current"] = data["sensors"]["dhw_temperature"]
-                        data["sensors"].pop("dhw_temperature")
-                    elif "water_temperature" in data["sensors"]:
-                        temp_dict["current"] = data["sensors"]["water_temperature"]
-                        self._count += 1
-
-                if item == "maximum_boiler_temperature":
-                    item = "boiler_temperature"
-                    if "water_temperature" in data["sensors"]:
-                        temp_dict["current"] = data["sensors"]["water_temperature"]
-                        data["sensors"].pop("water_temperature")
-
+                item, temp_dict = self._create_special_dicts(item, data, temp_dict)
                 act_item = cast(ActuatorType, item)
                 data[act_item] = temp_dict
+
+    def _create_special_dicts(
+        self, item: str, data: GwEntityData, temp_dict: ActuatorData
+    ) -> tuple[str, ActuatorData]:
+        """Create dhw_temperature and boiler_temperature dicts.
+
+        The initial item-names are updated and a current key is added.
+        Also, the copied sensor data is removed.
+        """
+        if item == DHW_SETPOINT:
+            item = "dhw_temperature"
+            if DHW_SETPOINT in data["sensors"]:
+                data["sensors"].pop(DHW_SETPOINT)
+                self._count -= 1
+            if "dhw_temperature" in data["sensors"]:
+                temp_dict["current"] = data["sensors"]["dhw_temperature"]
+                data["sensors"].pop("dhw_temperature")
+            elif "water_temperature" in data["sensors"]:
+                temp_dict["current"] = data["sensors"]["water_temperature"]
+                self._count += 1
+
+        if item == "maximum_boiler_temperature":
+            item = "boiler_temperature"
+            if "water_temperature" in data["sensors"]:
+                temp_dict["current"] = data["sensors"]["water_temperature"]
+                data["sensors"].pop("water_temperature")
+
+        return item, temp_dict
 
     def _get_actuator_mode(
         self, appliance: etree.Element, entity_id: str, key: str

--- a/plugwise/helper.py
+++ b/plugwise/helper.py
@@ -489,7 +489,7 @@ class SmileHelper(SmileCommon):
         if self._dhw_allowed_modes and "select_dhw_mode" not in data:
             data["select_dhw_mode"] = text
             if measurement == "domestic_hot_water_comfort_mode":
-                data["select_dhw_mode"] = "comfort" if text == "on" else "off"
+                data["select_dhw_mode"] = "comfort" if text == "on" else "eco"
 
     def _get_toggle_state(
         self,

--- a/plugwise/helper.py
+++ b/plugwise/helper.py
@@ -583,7 +583,6 @@ class SmileHelper(SmileCommon):
                         temp_dict[act_key] = str(pw_function.text)
 
             if temp_dict:
-                LOGGER.debug("HOI temp_dict: %s", temp_dict)
                 # If domestic_hot_water_setpoint is present as actuator,
                 # rename and remove as sensor
                 if item == DHW_SETPOINT:

--- a/plugwise/helper.py
+++ b/plugwise/helper.py
@@ -595,6 +595,7 @@ class SmileHelper(SmileCommon):
                         data["sensors"].pop("dhw_temperature")
                     elif "water_temperature" in data["sensors"]:
                         temp_dict["current"] = data["sensors"]["water_temperature"]
+                        self._count += 1
 
                 if item == "maximum_boiler_temperature":
                     item = "boiler_temperature"

--- a/plugwise/helper.py
+++ b/plugwise/helper.py
@@ -509,7 +509,7 @@ class SmileHelper(SmileCommon):
                     case "cooling_enabled":
                         data["switches"][name] = state.text == "on"
                     case "domestic_hot_water_comfort_mode":
-                        self._dhw_allowed_modes = ["comfort", "off"]
+                        self._dhw_allowed_modes = ["comfort", "eco"]
 
     def _get_plugwise_notifications(self) -> None:
         """Collect the Plugwise notifications."""

--- a/plugwise/legacy/helper.py
+++ b/plugwise/legacy/helper.py
@@ -346,13 +346,6 @@ class SmileLegacyHelper(SmileCommon):
     ) -> None:
         """Helper-function for _get_measurement_data()."""
         for item in ACTIVE_ACTUATORS:
-            # Skip max_dhw_temperature, not initially valid,
-            # skip thermostat for thermo_sensors
-            if item == "max_dhw_temperature" or (
-                item == "thermostat" and entity["dev_class"] == "thermo_sensor"
-            ):
-                continue
-
             temp_dict: ActuatorData = {}
             functionality = "thermostat_functionality"
 

--- a/plugwise/legacy/helper.py
+++ b/plugwise/legacy/helper.py
@@ -273,7 +273,7 @@ class SmileLegacyHelper(SmileCommon):
             self._get_lock_state(appliance, data, self._stretch_v2)
 
             if appliance.find("type").text in ACTUATOR_CLASSES:
-                self._get_actuator_functionalities(appliance, entity, data)
+                self._get_actuator_functionalities(appliance, data)
 
         # Anna: the Smile outdoor_temperature is present in the Home location
         # For some Anna's LOCATIONS is empty, falling back to domain_objects!
@@ -341,9 +341,7 @@ class SmileLegacyHelper(SmileCommon):
 
         self._count = count_data_items(self._count, data)
 
-    def _get_actuator_functionalities(
-        self, xml: etree.Element, entity: GwEntityData, data: GwEntityData
-    ) -> None:
+    def _get_actuator_functionalities(self, xml: etree.Element, data: GwEntityData) -> None:
         """Helper-function for _get_measurement_data()."""
         for item in ACTIVE_ACTUATORS:
             temp_dict: ActuatorData = {}

--- a/plugwise/smile.py
+++ b/plugwise/smile.py
@@ -175,6 +175,8 @@ class SmileAPI(SmileData):
             case "temperature_offset":
                 await self.set_offset(dev_id, temperature)
                 return
+            case "boiler_temperature":
+                key = "maximum_boiler_temperature"
             case "dhw_temperature":
                 key = "domestic_hot_water_setpoint"
 

--- a/plugwise/smile.py
+++ b/plugwise/smile.py
@@ -170,12 +170,12 @@ class SmileAPI(SmileData):
         key: str,
         temperature: float,
     ) -> None:
-        """Set the maximum boiler- or DHW-setpoint on the Central Heating boiler or the temperature-offset on a Thermostat."""
+        """Set the boiler- or DHW-setpoint on the Central Heating boiler or the temperature-offset on a Thermostat."""
         match key:
             case "temperature_offset":
                 await self.set_offset(dev_id, temperature)
                 return
-            case "max_dhw_temperature":
+            case "dhw_temperature":
                 key = "domestic_hot_water_setpoint"
 
         temp = str(temperature)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name            = "plugwise"
-version         = "1.12.0"
+version         = "1.13.0"
 license         = "MIT"
 description     = "Plugwise Smile (Adam/Anna/P1) and Stretch module for Python 3."
 readme          = "README.md"

--- a/scripts/manual_fixtures.py
+++ b/scripts/manual_fixtures.py
@@ -127,9 +127,7 @@ m_adam_cooling["056ee145a816487eaa69243c3280f8bf"]["binary_sensors"][
 m_adam_cooling["056ee145a816487eaa69243c3280f8bf"]["binary_sensors"]["flame_state"] = (
     False
 )
-m_adam_cooling["056ee145a816487eaa69243c3280f8bf"]["sensors"]["water_temperature"] = (
-    19.0
-)
+m_adam_cooling["056ee145a816487eaa69243c3280f8bf"]["boiler_temperature"]["current"] = 19.0
 m_adam_cooling["056ee145a816487eaa69243c3280f8bf"]["sensors"][
     "intended_boiler_temperature"
 ] = 17.5
@@ -184,13 +182,12 @@ m_adam_heating["056ee145a816487eaa69243c3280f8bf"]["binary_sensors"][
 m_adam_heating["056ee145a816487eaa69243c3280f8bf"]["binary_sensors"]["flame_state"] = (
     False
 )
-m_adam_heating["056ee145a816487eaa69243c3280f8bf"]["sensors"]["water_temperature"] = (
-    37.0
-)
+m_adam_heating["056ee145a816487eaa69243c3280f8bf"]["boiler_temperature"]["current"] = 37.0
 m_adam_heating["056ee145a816487eaa69243c3280f8bf"]["sensors"][
     "intended_boiler_temperature"
 ] = 38.1
-m_adam_heating["056ee145a816487eaa69243c3280f8bf"]["max_dhw_temperature"] = {
+m_adam_heating["056ee145a816487eaa69243c3280f8bf"]["dhw_temperature"] = {
+    "current": 37.0,
     "setpoint": 60.0,
     "lower_bound": 40.0,
     "upper_bound": 60.0,
@@ -247,12 +244,8 @@ m_anna_heatpump_cooling["1cbf783bb11e4a7c8a6843dee3a86927"]["binary_sensors"][
     "cooling_state"
 ] = True
 
-m_anna_heatpump_cooling["1cbf783bb11e4a7c8a6843dee3a86927"]["sensors"][
-    "water_temperature"
-] = 22.7
-m_anna_heatpump_cooling["1cbf783bb11e4a7c8a6843dee3a86927"]["sensors"][
-    "dhw_temperature"
-] = 41.5
+m_anna_heatpump_cooling["1cbf783bb11e4a7c8a6843dee3a86927"]["boiler_temperature"]["current"] = 22.7
+m_anna_heatpump_cooling["1cbf783bb11e4a7c8a6843dee3a86927"]["dhw_temperature"]["current"] = 41.5
 m_anna_heatpump_cooling["1cbf783bb11e4a7c8a6843dee3a86927"]["sensors"][
     "intended_boiler_temperature"
 ] = 0.0
@@ -304,12 +297,8 @@ m_anna_heatpump_idle["1cbf783bb11e4a7c8a6843dee3a86927"]["binary_sensors"][
     "cooling_state"
 ] = False
 
-m_anna_heatpump_idle["1cbf783bb11e4a7c8a6843dee3a86927"]["sensors"][
-    "water_temperature"
-] = 19.1
-m_anna_heatpump_idle["1cbf783bb11e4a7c8a6843dee3a86927"]["sensors"][
-    "dhw_temperature"
-] = 46.3
+m_anna_heatpump_idle["1cbf783bb11e4a7c8a6843dee3a86927"]["boiler_temperature"]["current"] = 19.1
+m_anna_heatpump_idle["1cbf783bb11e4a7c8a6843dee3a86927"]["dhw_temperature"]["current"] = 46.3
 m_anna_heatpump_idle["1cbf783bb11e4a7c8a6843dee3a86927"]["sensors"][
     "intended_boiler_temperature"
 ] = 18.0

--- a/tests/data/adam/adam_bad_thermostat.json
+++ b/tests/data/adam/adam_bad_thermostat.json
@@ -6,35 +6,35 @@
       "flame_state": false,
       "heating_state": false
     },
-    "dev_class": "heater_central",
-    "dhw_modes": [
-      "comfort",
-      "off"
-    ],
-    "location": "856285a783f24bf4b2573c8bc510eabf",
-    "max_dhw_temperature": {
-      "lower_bound": 0.0,
-      "resolution": 1.0,
-      "setpoint": 50.0,
-      "upper_bound": 100.0
-    },
-    "maximum_boiler_temperature": {
+    "boiler_temperature": {
+      "current": 20.9,
       "lower_bound": 25.0,
       "resolution": 0.01,
       "setpoint": 38.0,
       "upper_bound": 45.0
     },
+    "dev_class": "heater_central",
+    "dhw_modes": [
+      "comfort",
+      "off"
+    ],
+    "dhw_temperature": {
+      "current": 49.9,
+      "lower_bound": 0.0,
+      "resolution": 1.0,
+      "setpoint": 50.0,
+      "upper_bound": 100.0
+    },
+    "location": "856285a783f24bf4b2573c8bc510eabf",
     "model": "Generic heater",
     "model_id": "1.1",
     "name": "OpenTherm",
-    "dhw_mode": "off",
+    "select_dhw_mode": "off",
     "sensors": {
-      "dhw_temperature": 49.9,
       "intended_boiler_temperature": 0.0,
       "modulation_level": 0.0,
       "outdoor_air_temperature": 13.6,
-      "return_temperature": 33.0,
-      "water_temperature": 20.9
+      "return_temperature": 33.0
     },
     "vendor": "WeHeat"
   },

--- a/tests/data/adam/adam_bad_thermostat.json
+++ b/tests/data/adam/adam_bad_thermostat.json
@@ -14,7 +14,7 @@
       "upper_bound": 45.0
     },
     "dev_class": "heater_central",
-    "dhw_mode": "off",
+    "dhw_mode": "eco",
     "dhw_modes": [
       "comfort",
       "eco"

--- a/tests/data/adam/adam_bad_thermostat.json
+++ b/tests/data/adam/adam_bad_thermostat.json
@@ -17,7 +17,7 @@
     "dhw_mode": "off",
     "dhw_modes": [
       "comfort",
-      "off"
+      "eco"
     ],
     "dhw_temperature": {
       "current": 49.9,

--- a/tests/data/adam/adam_bad_thermostat.json
+++ b/tests/data/adam/adam_bad_thermostat.json
@@ -14,6 +14,7 @@
       "upper_bound": 45.0
     },
     "dev_class": "heater_central",
+    "dhw_mode": "off",
     "dhw_modes": [
       "comfort",
       "off"
@@ -29,7 +30,6 @@
     "model": "Generic heater",
     "model_id": "1.1",
     "name": "OpenTherm",
-    "select_dhw_mode": "off",
     "sensors": {
       "intended_boiler_temperature": 0.0,
       "modulation_level": 0.0,

--- a/tests/data/adam/adam_heatpump_cooling.json
+++ b/tests/data/adam/adam_heatpump_cooling.json
@@ -62,6 +62,7 @@
       "upper_bound": 50.0
     },
     "dev_class": "heater_central",
+    "dhw_mode": "comfort",
     "dhw_modes": [
       "comfort",
       "off"
@@ -77,7 +78,6 @@
     "model": "Generic heater/cooler",
     "model_id": "17.1",
     "name": "OpenTherm",
-    "select_dhw_mode": "comfort",
     "sensors": {
       "intended_boiler_temperature": 0.0,
       "modulation_level": 0.0,

--- a/tests/data/adam/adam_heatpump_cooling.json
+++ b/tests/data/adam/adam_heatpump_cooling.json
@@ -12,7 +12,13 @@
     "dev_class": "climate",
     "model": "ThermoZone",
     "name": "Slaapkamer SJ",
-    "preset_modes": ["no_frost", "vacation", "away", "home", "asleep"],
+    "preset_modes": [
+      "no_frost",
+      "vacation",
+      "away",
+      "home",
+      "asleep"
+    ],
     "select_schedule": "off",
     "select_zone_profile": "passive",
     "sensors": {
@@ -27,11 +33,17 @@
       "upper_bound": 99.9
     },
     "thermostats": {
-      "primary": ["d3a276aeb3114a509bab1e4bf8c40348"],
+      "primary": [
+        "d3a276aeb3114a509bab1e4bf8c40348"
+      ],
       "secondary": []
     },
     "vendor": "Plugwise",
-    "zone_profiles": ["active", "off", "passive"]
+    "zone_profiles": [
+      "active",
+      "off",
+      "passive"
+    ]
   },
   "0ca13e8176204ca7bf6f09de59f81c83": {
     "available": true,
@@ -42,36 +54,36 @@
       "flame_state": false,
       "heating_state": false
     },
-    "dev_class": "heater_central",
-    "location": "eedadcb297564f1483faa509179aebed",
-    "dhw_modes": [
-      "comfort",
-      "off"
-    ],
-    "max_dhw_temperature": {
-      "lower_bound": 40.0,
-      "resolution": 0.01,
-      "setpoint": 60.0,
-      "upper_bound": 65.0
-    },
-    "maximum_boiler_temperature": {
+    "boiler_temperature": {
+      "current": 24.5,
       "lower_bound": 7.0,
       "resolution": 0.01,
       "setpoint": 35.0,
       "upper_bound": 50.0
     },
+    "dev_class": "heater_central",
+    "dhw_modes": [
+      "comfort",
+      "off"
+    ],
+    "dhw_temperature": {
+      "current": 63.5,
+      "lower_bound": 40.0,
+      "resolution": 0.01,
+      "setpoint": 60.0,
+      "upper_bound": 65.0
+    },
+    "location": "eedadcb297564f1483faa509179aebed",
     "model": "Generic heater/cooler",
     "model_id": "17.1",
     "name": "OpenTherm",
-    "dhw_mode": "comfort",
+    "select_dhw_mode": "comfort",
     "sensors": {
-      "dhw_temperature": 63.5,
       "intended_boiler_temperature": 0.0,
       "modulation_level": 0.0,
       "outdoor_air_temperature": 13.5,
       "return_temperature": 24.9,
-      "water_pressure": 2.0,
-      "water_temperature": 24.5
+      "water_pressure": 2.0
     },
     "vendor": "Remeha B.V."
   },
@@ -134,7 +146,13 @@
     "dev_class": "climate",
     "model": "ThermoZone",
     "name": "Slaapkamer DB",
-    "preset_modes": ["no_frost", "vacation", "away", "home", "asleep"],
+    "preset_modes": [
+      "no_frost",
+      "vacation",
+      "away",
+      "home",
+      "asleep"
+    ],
     "select_schedule": "off",
     "select_zone_profile": "passive",
     "sensors": {
@@ -149,11 +167,17 @@
       "upper_bound": 99.9
     },
     "thermostats": {
-      "primary": ["47e2c550a33846b680725aa3fb229473"],
+      "primary": [
+        "47e2c550a33846b680725aa3fb229473"
+      ],
       "secondary": []
     },
     "vendor": "Plugwise",
-    "zone_profiles": ["active", "off", "passive"]
+    "zone_profiles": [
+      "active",
+      "off",
+      "passive"
+    ]
   },
   "2e0fc4db2a6d4cbeb7cf786143543961": {
     "available": true,
@@ -250,7 +274,13 @@
     "dev_class": "climate",
     "model": "ThermoZone",
     "name": "Badkamer 2",
-    "preset_modes": ["no_frost", "vacation", "away", "home", "asleep"],
+    "preset_modes": [
+      "no_frost",
+      "vacation",
+      "away",
+      "home",
+      "asleep"
+    ],
     "select_schedule": "Werkdag schema",
     "select_zone_profile": "passive",
     "sensors": {
@@ -264,11 +294,17 @@
       "upper_bound": 99.9
     },
     "thermostats": {
-      "primary": ["f04c985c11ad4848b8fcd710343f9dcf"],
+      "primary": [
+        "f04c985c11ad4848b8fcd710343f9dcf"
+      ],
       "secondary": []
     },
     "vendor": "Plugwise",
-    "zone_profiles": ["active", "off", "passive"]
+    "zone_profiles": [
+      "active",
+      "off",
+      "passive"
+    ]
   },
   "5ead63c65e5f44e7870ba2bd680ceb9e": {
     "available": true,
@@ -296,7 +332,11 @@
     },
     "dev_class": "gateway",
     "firmware": "3.2.8",
-    "gateway_modes": ["away", "full", "vacation"],
+    "gateway_modes": [
+      "away",
+      "full",
+      "vacation"
+    ],
     "hardware": "AME Smile 2.0 board",
     "location": "eedadcb297564f1483faa509179aebed",
     "mac_address": "012345670001",
@@ -394,7 +434,13 @@
     "dev_class": "climate",
     "model": "ThermoZone",
     "name": "Badkamer 1",
-    "preset_modes": ["no_frost", "vacation", "away", "home", "asleep"],
+    "preset_modes": [
+      "no_frost",
+      "vacation",
+      "away",
+      "home",
+      "asleep"
+    ],
     "select_schedule": "Werkdag schema",
     "select_zone_profile": "passive",
     "sensors": {
@@ -409,11 +455,17 @@
       "upper_bound": 99.9
     },
     "thermostats": {
-      "primary": ["eac5db95d97241f6b17790897847ccf5"],
+      "primary": [
+        "eac5db95d97241f6b17790897847ccf5"
+      ],
       "secondary": []
     },
     "vendor": "Plugwise",
-    "zone_profiles": ["active", "off", "passive"]
+    "zone_profiles": [
+      "active",
+      "off",
+      "passive"
+    ]
   },
   "93ac3f7bf25342f58cbb77c4a99ac0b3": {
     "active_preset": "away",
@@ -428,7 +480,13 @@
     "dev_class": "climate",
     "model": "ThermoZone",
     "name": "Slaapkamer RB",
-    "preset_modes": ["no_frost", "vacation", "away", "home", "asleep"],
+    "preset_modes": [
+      "no_frost",
+      "vacation",
+      "away",
+      "home",
+      "asleep"
+    ],
     "select_schedule": "off",
     "select_zone_profile": "passive",
     "sensors": {
@@ -442,11 +500,17 @@
       "upper_bound": 99.9
     },
     "thermostats": {
-      "primary": ["c4ed311d54e341f58b4cdd201d1fde7e"],
+      "primary": [
+        "c4ed311d54e341f58b4cdd201d1fde7e"
+      ],
       "secondary": []
     },
     "vendor": "Plugwise",
-    "zone_profiles": ["active", "off", "passive"]
+    "zone_profiles": [
+      "active",
+      "off",
+      "passive"
+    ]
   },
   "96714ad90fc948bcbcb5021c4b9f5ae9": {
     "available": true,
@@ -481,7 +545,13 @@
     "dev_class": "climate",
     "model": "ThermoZone",
     "name": "Slaapkamer SQ",
-    "preset_modes": ["no_frost", "vacation", "away", "home", "asleep"],
+    "preset_modes": [
+      "no_frost",
+      "vacation",
+      "away",
+      "home",
+      "asleep"
+    ],
     "select_schedule": "off",
     "select_zone_profile": "passive",
     "sensors": {
@@ -496,11 +566,17 @@
       "upper_bound": 99.9
     },
     "thermostats": {
-      "primary": ["beb32da072274e698146db8b022f3c36"],
+      "primary": [
+        "beb32da072274e698146db8b022f3c36"
+      ],
       "secondary": []
     },
     "vendor": "Plugwise",
-    "zone_profiles": ["active", "off", "passive"]
+    "zone_profiles": [
+      "active",
+      "off",
+      "passive"
+    ]
   },
   "a03b6e8e76dd4646af1a77c31dd9370c": {
     "available": true,
@@ -535,7 +611,13 @@
     "dev_class": "climate",
     "model": "ThermoZone",
     "name": "Keuken",
-    "preset_modes": ["no_frost", "vacation", "away", "home", "asleep"],
+    "preset_modes": [
+      "no_frost",
+      "vacation",
+      "away",
+      "home",
+      "asleep"
+    ],
     "select_schedule": "Werkdag schema",
     "select_zone_profile": "active",
     "sensors": {
@@ -550,11 +632,17 @@
       "upper_bound": 99.9
     },
     "thermostats": {
-      "primary": ["ea8372c0e3ad4622ad45a041d02425f5"],
+      "primary": [
+        "ea8372c0e3ad4622ad45a041d02425f5"
+      ],
       "secondary": []
     },
     "vendor": "Plugwise",
-    "zone_profiles": ["active", "off", "passive"]
+    "zone_profiles": [
+      "active",
+      "off",
+      "passive"
+    ]
   },
   "b52908550469425b812c87f766fe5303": {
     "active_preset": "away",
@@ -569,7 +657,13 @@
     "dev_class": "climate",
     "model": "ThermoZone",
     "name": "Bijkeuken",
-    "preset_modes": ["no_frost", "vacation", "away", "home", "asleep"],
+    "preset_modes": [
+      "no_frost",
+      "vacation",
+      "away",
+      "home",
+      "asleep"
+    ],
     "select_schedule": "off",
     "select_zone_profile": "active",
     "sensors": {
@@ -584,11 +678,17 @@
       "upper_bound": 99.9
     },
     "thermostats": {
-      "primary": ["1053c8bbf8be43c6921742b146a625f1"],
+      "primary": [
+        "1053c8bbf8be43c6921742b146a625f1"
+      ],
       "secondary": []
     },
     "vendor": "Plugwise",
-    "zone_profiles": ["active", "off", "passive"]
+    "zone_profiles": [
+      "active",
+      "off",
+      "passive"
+    ]
   },
   "bbcffa48019f4b09b8368bbaf9559e68": {
     "available": true,
@@ -701,7 +801,13 @@
     "dev_class": "climate",
     "model": "ThermoZone",
     "name": "Slaapkamer JM",
-    "preset_modes": ["no_frost", "vacation", "away", "home", "asleep"],
+    "preset_modes": [
+      "no_frost",
+      "vacation",
+      "away",
+      "home",
+      "asleep"
+    ],
     "select_schedule": "off",
     "select_zone_profile": "passive",
     "sensors": {
@@ -716,11 +822,17 @@
       "upper_bound": 99.9
     },
     "thermostats": {
-      "primary": ["7fda9f84f01342f8afe9ebbbbff30c0f"],
+      "primary": [
+        "7fda9f84f01342f8afe9ebbbbff30c0f"
+      ],
       "secondary": []
     },
     "vendor": "Plugwise",
-    "zone_profiles": ["active", "off", "passive"]
+    "zone_profiles": [
+      "active",
+      "off",
+      "passive"
+    ]
   },
   "ea8372c0e3ad4622ad45a041d02425f5": {
     "available": true,
@@ -805,7 +917,13 @@
     "dev_class": "climate",
     "model": "ThermoZone",
     "name": "Woonkamer",
-    "preset_modes": ["no_frost", "vacation", "away", "home", "asleep"],
+    "preset_modes": [
+      "no_frost",
+      "vacation",
+      "away",
+      "home",
+      "asleep"
+    ],
     "select_schedule": "Werkdag schema",
     "select_zone_profile": "active",
     "sensors": {
@@ -820,10 +938,16 @@
       "upper_bound": 35.0
     },
     "thermostats": {
-      "primary": ["ca79d23ae0094120b877558734cff85c"],
+      "primary": [
+        "ca79d23ae0094120b877558734cff85c"
+      ],
       "secondary": []
     },
     "vendor": "Plugwise",
-    "zone_profiles": ["active", "off", "passive"]
+    "zone_profiles": [
+      "active",
+      "off",
+      "passive"
+    ]
   }
 }

--- a/tests/data/adam/adam_heatpump_cooling.json
+++ b/tests/data/adam/adam_heatpump_cooling.json
@@ -65,7 +65,7 @@
     "dhw_mode": "comfort",
     "dhw_modes": [
       "comfort",
-      "off"
+      "eco"
     ],
     "dhw_temperature": {
       "current": 63.5,

--- a/tests/data/adam/adam_jip.json
+++ b/tests/data/adam/adam_jip.json
@@ -401,7 +401,7 @@
       "upper_bound": 90.0
     },
     "dev_class": "heater_central",
-    "dhw_mode": "off",
+    "dhw_mode": "eco",
     "dhw_modes": [
       "comfort",
       "eco"

--- a/tests/data/adam/adam_jip.json
+++ b/tests/data/adam/adam_jip.json
@@ -7,7 +7,13 @@
     "dev_class": "climate",
     "model": "ThermoZone",
     "name": "Slaapkamer",
-    "preset_modes": ["home", "asleep", "away", "vacation", "no_frost"],
+    "preset_modes": [
+      "home",
+      "asleep",
+      "away",
+      "vacation",
+      "no_frost"
+    ],
     "select_schedule": null,
     "select_zone_profile": "active",
     "sensors": {
@@ -20,11 +26,19 @@
       "upper_bound": 99.9
     },
     "thermostats": {
-      "primary": ["1346fbd8498d4dbcab7e18d51b771f3d"],
-      "secondary": ["356b65335e274d769c338223e7af9c33"]
+      "primary": [
+        "1346fbd8498d4dbcab7e18d51b771f3d"
+      ],
+      "secondary": [
+        "356b65335e274d769c338223e7af9c33"
+      ]
     },
     "vendor": "Plugwise",
-    "zone_profiles": ["active", "off", "passive"]
+    "zone_profiles": [
+      "active",
+      "off",
+      "passive"
+    ]
   },
   "13228dab8ce04617af318a2888b3c548": {
     "active_preset": "home",
@@ -34,7 +48,13 @@
     "dev_class": "climate",
     "model": "ThermoZone",
     "name": "Woonkamer",
-    "preset_modes": ["home", "asleep", "away", "vacation", "no_frost"],
+    "preset_modes": [
+      "home",
+      "asleep",
+      "away",
+      "vacation",
+      "no_frost"
+    ],
     "select_schedule": null,
     "select_zone_profile": "active",
     "sensors": {
@@ -47,11 +67,19 @@
       "upper_bound": 30.0
     },
     "thermostats": {
-      "primary": ["f61f1a2535f54f52ad006a3d18e459ca"],
-      "secondary": ["833de10f269c4deab58fb9df69901b4e"]
+      "primary": [
+        "f61f1a2535f54f52ad006a3d18e459ca"
+      ],
+      "secondary": [
+        "833de10f269c4deab58fb9df69901b4e"
+      ]
     },
     "vendor": "Plugwise",
-    "zone_profiles": ["active", "off", "passive"]
+    "zone_profiles": [
+      "active",
+      "off",
+      "passive"
+    ]
   },
   "1346fbd8498d4dbcab7e18d51b771f3d": {
     "available": true,
@@ -226,7 +254,11 @@
     },
     "dev_class": "gateway",
     "firmware": "3.2.8",
-    "gateway_modes": ["away", "full", "vacation"],
+    "gateway_modes": [
+      "away",
+      "full",
+      "vacation"
+    ],
     "hardware": "AME Smile 2.0 board",
     "location": "9e4433a9d69f40b3aefd15e74395eaec",
     "mac_address": "012345670001",
@@ -234,7 +266,12 @@
     "model_id": "smile_open_therm",
     "name": "Adam",
     "notifications": {},
-    "regulation_modes": ["heating", "off", "bleeding_cold", "bleeding_hot"],
+    "regulation_modes": [
+      "heating",
+      "off",
+      "bleeding_cold",
+      "bleeding_hot"
+    ],
     "select_gateway_mode": "full",
     "select_regulation_mode": "heating",
     "sensors": {
@@ -251,7 +288,13 @@
     "dev_class": "climate",
     "model": "ThermoZone",
     "name": "Kinderkamer",
-    "preset_modes": ["home", "asleep", "away", "vacation", "no_frost"],
+    "preset_modes": [
+      "home",
+      "asleep",
+      "away",
+      "vacation",
+      "no_frost"
+    ],
     "select_schedule": null,
     "select_zone_profile": "active",
     "sensors": {
@@ -264,11 +307,19 @@
       "upper_bound": 99.9
     },
     "thermostats": {
-      "primary": ["6f3e9d7084214c21b9dfa46f6eeb8700"],
-      "secondary": ["d4496250d0e942cfa7aea3476e9070d5"]
+      "primary": [
+        "6f3e9d7084214c21b9dfa46f6eeb8700"
+      ],
+      "secondary": [
+        "d4496250d0e942cfa7aea3476e9070d5"
+      ]
     },
     "vendor": "Plugwise",
-    "zone_profiles": ["active", "off", "passive"]
+    "zone_profiles": [
+      "active",
+      "off",
+      "passive"
+    ]
   },
   "d4496250d0e942cfa7aea3476e9070d5": {
     "available": true,
@@ -302,7 +353,13 @@
     "dev_class": "climate",
     "model": "ThermoZone",
     "name": "Logeerkamer",
-    "preset_modes": ["home", "asleep", "away", "vacation", "no_frost"],
+    "preset_modes": [
+      "home",
+      "asleep",
+      "away",
+      "vacation",
+      "no_frost"
+    ],
     "select_schedule": null,
     "select_zone_profile": "active",
     "sensors": {
@@ -315,11 +372,19 @@
       "upper_bound": 99.9
     },
     "thermostats": {
-      "primary": ["a6abc6a129ee499c88a4d420cc413b47"],
-      "secondary": ["1da4d325838e4ad8aac12177214505c9"]
+      "primary": [
+        "a6abc6a129ee499c88a4d420cc413b47"
+      ],
+      "secondary": [
+        "1da4d325838e4ad8aac12177214505c9"
+      ]
     },
     "vendor": "Plugwise",
-    "zone_profiles": ["active", "off", "passive"]
+    "zone_profiles": [
+      "active",
+      "off",
+      "passive"
+    ]
   },
   "e4684553153b44afbef2200885f379dc": {
     "available": true,
@@ -328,34 +393,35 @@
       "flame_state": false,
       "heating_state": false
     },
-    "dev_class": "heater_central",
-    "location": "9e4433a9d69f40b3aefd15e74395eaec",
-    "dhw_modes": [
-      "comfort",
-      "off"
-    ],
-    "max_dhw_temperature": {
-      "lower_bound": 40.0,
-      "resolution": 0.01,
-      "setpoint": 60.0,
-      "upper_bound": 60.0
-    },
-    "maximum_boiler_temperature": {
+    "boiler_temperature": {
+      "current": 37.3,
       "lower_bound": 20.0,
       "resolution": 0.01,
       "setpoint": 90.0,
       "upper_bound": 90.0
     },
+    "dev_class": "heater_central",
+    "dhw_mode": "off",
+    "dhw_modes": [
+      "comfort",
+      "off"
+    ],
+    "dhw_temperature": {
+      "current": 37.3,
+      "lower_bound": 40.0,
+      "resolution": 0.01,
+      "setpoint": 60.0,
+      "upper_bound": 60.0
+    },
+    "location": "9e4433a9d69f40b3aefd15e74395eaec",
     "model": "Generic heater",
     "model_id": "10.20",
     "name": "OpenTherm",
-    "dhw_mode": "off",
     "sensors": {
       "intended_boiler_temperature": 0.0,
       "modulation_level": 0.0,
       "return_temperature": 37.1,
-      "water_pressure": 1.4,
-      "water_temperature": 37.3
+      "water_pressure": 1.4
     },
     "vendor": "Remeha B.V."
   },

--- a/tests/data/adam/adam_jip.json
+++ b/tests/data/adam/adam_jip.json
@@ -404,7 +404,7 @@
     "dhw_mode": "off",
     "dhw_modes": [
       "comfort",
-      "off"
+      "eco"
     ],
     "dhw_temperature": {
       "current": 37.3,

--- a/tests/data/adam/adam_onoff_cooling_fake_firmware.json
+++ b/tests/data/adam/adam_onoff_cooling_fake_firmware.json
@@ -18,7 +18,7 @@
     "dhw_mode": "comfort",
     "dhw_modes": [
       "comfort",
-      "off"
+      "eco"
     ],
     "dhw_temperature": {
       "current": 63.5,

--- a/tests/data/adam/adam_onoff_cooling_fake_firmware.json
+++ b/tests/data/adam/adam_onoff_cooling_fake_firmware.json
@@ -7,35 +7,35 @@
       "flame_state": false,
       "heating_state": false
     },
-    "dev_class": "heater_central",
-    "location": "eedadcb297564f1483faa509179aebed",
-    "dhw_modes": [
-      "comfort",
-      "off"
-    ],
-    "max_dhw_temperature": {
-      "lower_bound": 40.0,
-      "resolution": 0.01,
-      "setpoint": 60.0,
-      "upper_bound": 65.0
-    },
-    "maximum_boiler_temperature": {
+    "boiler_temperature": {
+      "current": 24.5,
       "lower_bound": 7.0,
       "resolution": 0.01,
       "setpoint": 35.0,
       "upper_bound": 50.0
     },
+    "dev_class": "heater_central",
+    "dhw_mode": "comfort",
+    "dhw_modes": [
+      "comfort",
+      "off"
+    ],
+    "dhw_temperature": {
+      "current": 63.5,
+      "lower_bound": 40.0,
+      "resolution": 0.01,
+      "setpoint": 60.0,
+      "upper_bound": 65.0
+    },
+    "location": "eedadcb297564f1483faa509179aebed",
     "model": "Unknown",
     "name": "OnOff",
-    "dhw_mode": "comfort",
     "sensors": {
-      "dhw_temperature": 63.5,
       "intended_boiler_temperature": 0.0,
       "modulation_level": 0.0,
       "outdoor_air_temperature": 13.5,
       "return_temperature": 24.9,
-      "water_pressure": 2.0,
-      "water_temperature": 24.5
+      "water_pressure": 2.0
     }
   },
   "7d97fc3117784cfdafe347bcedcbbbcb": {
@@ -44,7 +44,11 @@
     },
     "dev_class": "gateway",
     "firmware": "3.2.8",
-    "gateway_modes": ["away", "full", "vacation"],
+    "gateway_modes": [
+      "away",
+      "full",
+      "vacation"
+    ],
     "hardware": "AME Smile 2.0 board",
     "location": "eedadcb297564f1483faa509179aebed",
     "mac_address": "012345670001",
@@ -92,7 +96,13 @@
     "dev_class": "climate",
     "model": "ThermoZone",
     "name": "Woonkamer",
-    "preset_modes": ["no_frost", "vacation", "away", "home", "asleep"],
+    "preset_modes": [
+      "no_frost",
+      "vacation",
+      "away",
+      "home",
+      "asleep"
+    ],
     "select_schedule": "Werkdag schema",
     "select_zone_profile": "active",
     "sensors": {
@@ -107,10 +117,16 @@
       "upper_bound": 35.0
     },
     "thermostats": {
-      "primary": ["ca79d23ae0094120b877558734cff85c"],
+      "primary": [
+        "ca79d23ae0094120b877558734cff85c"
+      ],
       "secondary": []
     },
     "vendor": "Plugwise",
-    "zone_profiles": ["active", "off", "passive"]
+    "zone_profiles": [
+      "active",
+      "off",
+      "passive"
+    ]
   }
 }

--- a/tests/data/adam/adam_plus_anna.json
+++ b/tests/data/adam/adam_plus_anna.json
@@ -54,7 +54,7 @@
     "dev_class": "heater_central",
     "dhw_modes": [
       "comfort",
-      "off"
+      "eco"
     ],
     "location": "07d618f0bb80412687f065b8698ce3e7",
     "model": "Generic heater",

--- a/tests/data/adam/adam_plus_anna.json
+++ b/tests/data/adam/adam_plus_anna.json
@@ -1,13 +1,22 @@
 {
   "009490cc2f674ce6b576863fbb64f867": {
     "active_preset": "home",
-    "available_schedules": ["Weekschema", "off"],
+    "available_schedules": [
+      "Weekschema",
+      "off"
+    ],
     "climate_mode": "auto",
     "control_state": "idle",
     "dev_class": "climate",
     "model": "ThermoZone",
     "name": "Living room",
-    "preset_modes": ["home", "asleep", "away", "vacation", "no_frost"],
+    "preset_modes": [
+      "home",
+      "asleep",
+      "away",
+      "vacation",
+      "no_frost"
+    ],
     "select_schedule": "Weekschema",
     "sensors": {
       "electricity_consumed": 74.2,
@@ -21,7 +30,9 @@
       "upper_bound": 35.0
     },
     "thermostats": {
-      "primary": ["ee62cad889f94e8ca3d09021f03a660b"],
+      "primary": [
+        "ee62cad889f94e8ca3d09021f03a660b"
+      ],
       "secondary": []
     },
     "vendor": "Plugwise"
@@ -33,24 +44,24 @@
       "flame_state": false,
       "heating_state": false
     },
-    "dev_class": "heater_central",
-    "location": "07d618f0bb80412687f065b8698ce3e7",
-    "dhw_modes": [
-      "comfort",
-      "off"
-    ],
-    "maximum_boiler_temperature": {
+    "boiler_temperature": {
+      "current": 48.0,
       "lower_bound": 0.0,
       "resolution": 1.0,
       "setpoint": 80.0,
       "upper_bound": 100.0
     },
+    "dev_class": "heater_central",
+    "dhw_modes": [
+      "comfort",
+      "off"
+    ],
+    "location": "07d618f0bb80412687f065b8698ce3e7",
     "model": "Generic heater",
     "name": "OpenTherm",
     "select_dhw_mode": "off",
     "sensors": {
-      "intended_boiler_temperature": 0.0,
-      "water_temperature": 48.0
+      "intended_boiler_temperature": 0.0
     }
   },
   "aa6b0002df0a46e1b1eb94beb61eddfe": {

--- a/tests/data/adam/adam_plus_anna.json
+++ b/tests/data/adam/adam_plus_anna.json
@@ -59,7 +59,7 @@
     "location": "07d618f0bb80412687f065b8698ce3e7",
     "model": "Generic heater",
     "name": "OpenTherm",
-    "select_dhw_mode": "off",
+    "select_dhw_mode": "eco",
     "sensors": {
       "intended_boiler_temperature": 0.0
     }

--- a/tests/data/adam/adam_plus_anna_new.json
+++ b/tests/data/adam/adam_plus_anna_new.json
@@ -16,7 +16,7 @@
     "dev_class": "heater_central",
     "dhw_modes": [
       "comfort",
-      "off"
+      "eco"
     ],
     "location": "bc93488efab249e5bc54fd7e175a6f91",
     "model": "Generic heater",

--- a/tests/data/adam/adam_plus_anna_new.json
+++ b/tests/data/adam/adam_plus_anna_new.json
@@ -21,7 +21,7 @@
     "location": "bc93488efab249e5bc54fd7e175a6f91",
     "model": "Generic heater",
     "name": "OpenTherm",
-    "select_dhw_mode": "off",
+    "select_dhw_mode": "eco",
     "sensors": {
       "intended_boiler_temperature": 22.5
     }

--- a/tests/data/adam/adam_plus_anna_new.json
+++ b/tests/data/adam/adam_plus_anna_new.json
@@ -6,24 +6,24 @@
       "flame_state": true,
       "heating_state": true
     },
-    "dev_class": "heater_central",
-    "location": "bc93488efab249e5bc54fd7e175a6f91",
-    "dhw_modes": [
-      "comfort",
-      "off"
-    ],
-    "maximum_boiler_temperature": {
+    "boiler_temperature": {
+      "current": 43.0,
       "lower_bound": 25.0,
       "resolution": 0.01,
       "setpoint": 50.0,
       "upper_bound": 95.0
     },
+    "dev_class": "heater_central",
+    "dhw_modes": [
+      "comfort",
+      "off"
+    ],
+    "location": "bc93488efab249e5bc54fd7e175a6f91",
     "model": "Generic heater",
     "name": "OpenTherm",
     "select_dhw_mode": "off",
     "sensors": {
-      "intended_boiler_temperature": 22.5,
-      "water_temperature": 43.0
+      "intended_boiler_temperature": 22.5
     }
   },
   "10016900610d4c7481df78c89606ef22": {

--- a/tests/data/adam/adam_plus_anna_new_regulation_off.json
+++ b/tests/data/adam/adam_plus_anna_new_regulation_off.json
@@ -16,7 +16,7 @@
     "dev_class": "heater_central",
     "dhw_modes": [
       "comfort",
-      "off"
+      "eco"
     ],
     "location": "bc93488efab249e5bc54fd7e175a6f91",
     "model": "Generic heater",

--- a/tests/data/adam/adam_plus_anna_new_regulation_off.json
+++ b/tests/data/adam/adam_plus_anna_new_regulation_off.json
@@ -6,24 +6,24 @@
       "flame_state": false,
       "heating_state": false
     },
-    "dev_class": "heater_central",
-    "location": "bc93488efab249e5bc54fd7e175a6f91",
-    "dhw_modes": [
-      "comfort",
-      "off"
-    ],
-    "maximum_boiler_temperature": {
+    "boiler_temperature": {
+      "current": 30.0,
       "lower_bound": 25.0,
       "resolution": 0.01,
       "setpoint": 50.0,
       "upper_bound": 95.0
     },
+    "dev_class": "heater_central",
+    "dhw_modes": [
+      "comfort",
+      "off"
+    ],
+    "location": "bc93488efab249e5bc54fd7e175a6f91",
     "model": "Generic heater",
     "name": "OpenTherm",
     "select_dhw_mode": "off",
     "sensors": {
-      "intended_boiler_temperature": 0.0,
-      "water_temperature": 30.0
+      "intended_boiler_temperature": 0.0
     }
   },
   "10016900610d4c7481df78c89606ef22": {
@@ -157,29 +157,6 @@
     },
     "vendor": "Plugwise"
   },
-  "da224107914542988a88561b4452b0f6": {
-    "binary_sensors": {
-      "plugwise_notification": false
-    },
-    "dev_class": "gateway",
-    "firmware": "3.7.8",
-    "gateway_modes": ["away", "full", "vacation"],
-    "hardware": "AME Smile 2.0 board",
-    "location": "bc93488efab249e5bc54fd7e175a6f91",
-    "mac_address": "012345679891",
-    "model": "Gateway",
-    "model_id": "smile_open_therm",
-    "name": "Adam",
-    "notifications": {},
-    "regulation_modes": ["bleeding_hot", "bleeding_cold", "off", "heating"],
-    "select_gateway_mode": "full",
-    "select_regulation_mode": "off",
-    "sensors": {
-      "outdoor_temperature": 9.19
-    },
-    "vendor": "Plugwise",
-    "zigbee_mac_address": "000D6F000D5A168D"
-  },
   "c9293d1d68ee48fc8843c6f0dee2b6be": {
     "dev_class": "pumping",
     "members": [
@@ -188,7 +165,44 @@
     ],
     "model": "Group",
     "name": "Vloerverwarming",
+    "sensors": {
+      "electricity_consumed": 43.8,
+      "electricity_produced": 0.0,
+      "temperature": 18.4
+    },
     "vendor": "Plugwise"
+  },
+  "da224107914542988a88561b4452b0f6": {
+    "binary_sensors": {
+      "plugwise_notification": false
+    },
+    "dev_class": "gateway",
+    "firmware": "3.7.8",
+    "gateway_modes": [
+      "away",
+      "full",
+      "vacation"
+    ],
+    "hardware": "AME Smile 2.0 board",
+    "location": "bc93488efab249e5bc54fd7e175a6f91",
+    "mac_address": "012345679891",
+    "model": "Gateway",
+    "model_id": "smile_open_therm",
+    "name": "Adam",
+    "notifications": {},
+    "regulation_modes": [
+      "bleeding_hot",
+      "bleeding_cold",
+      "off",
+      "heating"
+    ],
+    "select_gateway_mode": "full",
+    "select_regulation_mode": "off",
+    "sensors": {
+      "outdoor_temperature": 9.19
+    },
+    "vendor": "Plugwise",
+    "zigbee_mac_address": "000D6F000D5A168D"
   },
   "e2f4322d57924fa090fbbc48b3a140dc": {
     "available": true,
@@ -224,6 +238,10 @@
     ],
     "model": "Group",
     "name": "Test",
+    "sensors": {
+      "electricity_consumed": 14.8,
+      "electricity_produced": 0.0
+    },
     "switches": {
       "relay": true
     },
@@ -243,7 +261,13 @@
     "dev_class": "climate",
     "model": "ThermoZone",
     "name": "Living room",
-    "preset_modes": ["no_frost", "asleep", "vacation", "home", "away"],
+    "preset_modes": [
+      "no_frost",
+      "asleep",
+      "vacation",
+      "home",
+      "away"
+    ],
     "select_schedule": "off",
     "select_zone_profile": "active",
     "sensors": {
@@ -258,11 +282,17 @@
       "upper_bound": 35.0
     },
     "thermostats": {
-      "primary": ["ad4838d7d35c4d6ea796ee12ae5aedf8"],
+      "primary": [
+        "ad4838d7d35c4d6ea796ee12ae5aedf8"
+      ],
       "secondary": []
     },
     "vendor": "Plugwise",
-    "zone_profiles": ["active", "off", "passive"]
+    "zone_profiles": [
+      "active",
+      "off",
+      "passive"
+    ]
   },
   "f871b8c4d63549319221e294e4f88074": {
     "active_preset": "home",
@@ -278,7 +308,13 @@
     "dev_class": "climate",
     "model": "ThermoZone",
     "name": "Bathroom",
-    "preset_modes": ["no_frost", "asleep", "vacation", "home", "away"],
+    "preset_modes": [
+      "no_frost",
+      "asleep",
+      "vacation",
+      "home",
+      "away"
+    ],
     "select_schedule": "off",
     "select_zone_profile": "passive",
     "sensors": {
@@ -293,10 +329,18 @@
       "upper_bound": 99.9
     },
     "thermostats": {
-      "primary": ["e2f4322d57924fa090fbbc48b3a140dc"],
-      "secondary": ["1772a4ea304041adb83f357b751341ff"]
+      "primary": [
+        "e2f4322d57924fa090fbbc48b3a140dc"
+      ],
+      "secondary": [
+        "1772a4ea304041adb83f357b751341ff"
+      ]
     },
     "vendor": "Plugwise",
-    "zone_profiles": ["active", "off", "passive"]
+    "zone_profiles": [
+      "active",
+      "off",
+      "passive"
+    ]
   }
 }

--- a/tests/data/adam/adam_plus_anna_new_regulation_off.json
+++ b/tests/data/adam/adam_plus_anna_new_regulation_off.json
@@ -21,7 +21,7 @@
     "location": "bc93488efab249e5bc54fd7e175a6f91",
     "model": "Generic heater",
     "name": "OpenTherm",
-    "select_dhw_mode": "off",
+    "select_dhw_mode": "eco",
     "sensors": {
       "intended_boiler_temperature": 0.0
     }

--- a/tests/data/anna/anna_elga_2.json
+++ b/tests/data/anna/anna_elga_2.json
@@ -13,7 +13,7 @@
     "dev_class": "heater_central",
     "dhw_modes": [
       "comfort",
-      "off"
+      "eco"
     ],
     "location": "d34dfe6ab90b410c98068e75de3eb631",
     "model": "Generic heater/cooler",

--- a/tests/data/anna/anna_elga_2.json
+++ b/tests/data/anna/anna_elga_2.json
@@ -18,7 +18,7 @@
     "location": "d34dfe6ab90b410c98068e75de3eb631",
     "model": "Generic heater/cooler",
     "name": "OpenTherm",
-    "select_dhw_mode": "off",
+    "select_dhw_mode": "eco",
     "sensors": {
       "domestic_hot_water_setpoint": 60.0,
       "intended_boiler_temperature": 58.3,

--- a/tests/data/anna/anna_elga_2_cooling.json
+++ b/tests/data/anna/anna_elga_2_cooling.json
@@ -10,18 +10,19 @@
       "heating_state": false,
       "secondary_boiler_state": false
     },
+    "boiler_temperature": {
+      "current": 22.8,
+      "lower_bound": 0.0,
+      "resolution": 1.0,
+      "setpoint": 60.0,
+      "upper_bound": 100.0
+    },
     "dev_class": "heater_central",
     "dhw_modes": [
       "comfort",
       "off"
     ],
     "location": "d34dfe6ab90b410c98068e75de3eb631",
-    "maximum_boiler_temperature": {
-      "lower_bound": 0.0,
-      "resolution": 1.0,
-      "setpoint": 60.0,
-      "upper_bound": 100.0
-    },
     "model": "Generic heater/cooler",
     "name": "OpenTherm",
     "select_dhw_mode": "comfort",
@@ -31,14 +32,16 @@
       "modulation_level": 0.0,
       "outdoor_air_temperature": 30.0,
       "return_temperature": 23.4,
-      "water_pressure": 0.5,
-      "water_temperature": 22.8
+      "water_pressure": 0.5
     },
     "vendor": "Techneco"
   },
   "ebd90df1ab334565b5895f37590ccff4": {
     "active_preset": "home",
-    "available_schedules": ["Thermostat schedule", "off"],
+    "available_schedules": [
+      "Thermostat schedule",
+      "off"
+    ],
     "climate_mode": "auto",
     "control_state": "cooling",
     "dev_class": "thermostat",
@@ -47,7 +50,13 @@
     "location": "d3ce834534114348be628b61b26d9220",
     "model": "ThermoTouch",
     "name": "Anna",
-    "preset_modes": ["away", "no_frost", "vacation", "home", "asleep"],
+    "preset_modes": [
+      "away",
+      "no_frost",
+      "vacation",
+      "home",
+      "asleep"
+    ],
     "select_schedule": "Thermostat schedule",
     "sensors": {
       "cooling_activation_outdoor_temperature": 26.0,

--- a/tests/data/anna/anna_elga_2_cooling.json
+++ b/tests/data/anna/anna_elga_2_cooling.json
@@ -20,7 +20,7 @@
     "dev_class": "heater_central",
     "dhw_modes": [
       "comfort",
-      "off"
+      "eco"
     ],
     "location": "d34dfe6ab90b410c98068e75de3eb631",
     "model": "Generic heater/cooler",

--- a/tests/data/anna/anna_elga_2_cooling_UPDATED_DATA.json
+++ b/tests/data/anna/anna_elga_2_cooling_UPDATED_DATA.json
@@ -20,7 +20,7 @@
     "dev_class": "heater_central",
     "dhw_modes": [
       "comfort",
-      "off"
+      "eco"
     ],
     "location": "d34dfe6ab90b410c98068e75de3eb631",
 

--- a/tests/data/anna/anna_elga_2_cooling_UPDATED_DATA.json
+++ b/tests/data/anna/anna_elga_2_cooling_UPDATED_DATA.json
@@ -10,29 +10,29 @@
       "heating_state": true,
       "secondary_boiler_state": false
     },
+    "boiler_temperature": {
+      "current": 22.8,
+      "lower_bound": 0.0,
+      "resolution": 1.0,
+      "setpoint": 60.0,
+      "upper_bound": 100.0
+    },
     "dev_class": "heater_central",
     "dhw_modes": [
       "comfort",
       "off"
     ],
     "location": "d34dfe6ab90b410c98068e75de3eb631",
-    "maximum_boiler_temperature": {
-      "lower_bound": 0.0,
-      "resolution": 1.0,
-      "setpoint": 60.0,
-      "upper_bound": 100.0
-    },
+
     "model": "Generic heater/cooler",
     "name": "OpenTherm",
     "select_dhw_mode": "comfort",
     "sensors": {
-      "domestic_hot_water_setpoint": 60.0,
       "intended_boiler_temperature": 0.0,
       "modulation_level": 0.0,
       "outdoor_air_temperature": 3.0,
       "return_temperature": 23.4,
-      "water_pressure": 0.5,
-      "water_temperature": 22.8
+      "water_pressure": 0.5
     },
     "vendor": "Techneco"
   },

--- a/tests/data/anna/anna_elga_2_schedule_off.json
+++ b/tests/data/anna/anna_elga_2_schedule_off.json
@@ -20,7 +20,7 @@
     "dev_class": "heater_central",
     "dhw_modes": [
       "comfort",
-      "off"
+      "eco"
     ],
     "location": "d34dfe6ab90b410c98068e75de3eb631",
     "model": "Generic heater/cooler",

--- a/tests/data/anna/anna_elga_2_schedule_off.json
+++ b/tests/data/anna/anna_elga_2_schedule_off.json
@@ -10,18 +10,19 @@
       "heating_state": false,
       "secondary_boiler_state": false
     },
+    "boiler_temperature": {
+      "current": 22.8,
+      "lower_bound": 0.0,
+      "resolution": 1.0,
+      "setpoint": 60.0,
+      "upper_bound": 100.0
+    },
     "dev_class": "heater_central",
     "dhw_modes": [
       "comfort",
       "off"
     ],
     "location": "d34dfe6ab90b410c98068e75de3eb631",
-    "maximum_boiler_temperature": {
-      "lower_bound": 0.0,
-      "resolution": 1.0,
-      "setpoint": 60.0,
-      "upper_bound": 100.0
-    },
     "model": "Generic heater/cooler",
     "name": "OpenTherm",
     "select_dhw_mode": "comfort",
@@ -31,14 +32,16 @@
       "modulation_level": 0.0,
       "outdoor_air_temperature": 13.0,
       "return_temperature": 23.4,
-      "water_pressure": 0.5,
-      "water_temperature": 22.8
+      "water_pressure": 0.5
     },
     "vendor": "Techneco"
   },
   "ebd90df1ab334565b5895f37590ccff4": {
     "active_preset": "home",
-    "available_schedules": ["Thermostat schedule", "off"],
+    "available_schedules": [
+      "Thermostat schedule",
+      "off"
+    ],
     "climate_mode": "heat_cool",
     "control_state": "idle",
     "dev_class": "thermostat",
@@ -47,7 +50,13 @@
     "location": "d3ce834534114348be628b61b26d9220",
     "model": "ThermoTouch",
     "name": "Anna",
-    "preset_modes": ["away", "no_frost", "vacation", "home", "asleep"],
+    "preset_modes": [
+      "away",
+      "no_frost",
+      "vacation",
+      "home",
+      "asleep"
+    ],
     "select_schedule": "off",
     "sensors": {
       "cooling_activation_outdoor_temperature": 26.0,

--- a/tests/data/anna/anna_elga_no_cooling.json
+++ b/tests/data/anna/anna_elga_no_cooling.json
@@ -34,7 +34,7 @@
       "upper_bound": 100.0
     },
     "dev_class": "heater_central",
-    "dhw_mode": "off",
+    "dhw_mode": "eco",
     "dhw_modes": [
       "comfort",
       "eco"

--- a/tests/data/anna/anna_elga_no_cooling.json
+++ b/tests/data/anna/anna_elga_no_cooling.json
@@ -37,7 +37,7 @@
     "dhw_mode": "off",
     "dhw_modes": [
       "comfort",
-      "off"
+      "eco"
     ],
     "dhw_temperature": {
       "current": 46.3,

--- a/tests/data/anna/anna_elga_no_cooling.json
+++ b/tests/data/anna/anna_elga_no_cooling.json
@@ -26,41 +26,44 @@
       "heating_state": true,
       "secondary_boiler_state": false
     },
-    "dev_class": "heater_central",
-    "dhw_modes": [
-      "comfort",
-      "off"
-    ],
-    "location": "a57efe5f145f498c9be62a9b63626fbf",
-    "max_dhw_temperature": {
-      "lower_bound": 35.0,
-      "resolution": 0.01,
-      "setpoint": 53.0,
-      "upper_bound": 60.0
-    },
-    "maximum_boiler_temperature": {
+    "boiler_temperature": {
+      "current": 29.1,
       "lower_bound": 0.0,
       "resolution": 1.0,
       "setpoint": 60.0,
       "upper_bound": 100.0
     },
+    "dev_class": "heater_central",
+    "dhw_mode": "off",
+    "dhw_modes": [
+      "comfort",
+      "off"
+    ],
+    "dhw_temperature": {
+      "current": 46.3,
+      "lower_bound": 35.0,
+      "resolution": 0.01,
+      "setpoint": 53.0,
+      "upper_bound": 60.0
+    },
+    "location": "a57efe5f145f498c9be62a9b63626fbf",
     "model": "Generic heater",
     "name": "OpenTherm",
-    "dhw_mode": "off",
     "sensors": {
-      "dhw_temperature": 46.3,
       "intended_boiler_temperature": 35.0,
       "modulation_level": 52,
       "outdoor_air_temperature": 3.0,
       "return_temperature": 25.1,
-      "water_pressure": 1.57,
-      "water_temperature": 29.1
+      "water_pressure": 1.57
     },
     "vendor": "Techneco"
   },
   "3cb70739631c4d17a86b8b12e8a5161b": {
     "active_preset": "home",
-    "available_schedules": ["standaard", "off"],
+    "available_schedules": [
+      "standaard",
+      "off"
+    ],
     "climate_mode": "auto",
     "control_state": "heating",
     "dev_class": "thermostat",
@@ -69,7 +72,13 @@
     "location": "c784ee9fdab44e1395b8dee7d7a497d5",
     "model": "ThermoTouch",
     "name": "Anna",
-    "preset_modes": ["no_frost", "home", "away", "asleep", "vacation"],
+    "preset_modes": [
+      "no_frost",
+      "home",
+      "away",
+      "asleep",
+      "vacation"
+    ],
     "select_schedule": "standaard",
     "sensors": {
       "cooling_activation_outdoor_temperature": 21.0,

--- a/tests/data/anna/anna_heatpump_cooling.json
+++ b/tests/data/anna/anna_heatpump_cooling.json
@@ -28,18 +28,19 @@
       "heating_state": false,
       "secondary_boiler_state": false
     },
+    "boiler_temperature": {
+      "current": 24.7,
+      "lower_bound": 0.0,
+      "resolution": 1.0,
+      "setpoint": 60.0,
+      "upper_bound": 100.0
+    },
     "dev_class": "heater_central",
     "dhw_modes": [
       "comfort",
       "off"
     ],
     "location": "a57efe5f145f498c9be62a9b63626fbf",
-    "maximum_boiler_temperature": {
-      "lower_bound": 0.0,
-      "resolution": 1.0,
-      "setpoint": 60.0,
-      "upper_bound": 100.0
-    },
     "model": "Generic heater/cooler",
     "name": "OpenTherm",
     "select_dhw_mode": "off",
@@ -50,14 +51,16 @@
       "modulation_level": 40,
       "outdoor_air_temperature": 22.0,
       "return_temperature": 23.8,
-      "water_pressure": 1.61,
-      "water_temperature": 24.7
+      "water_pressure": 1.61
     },
     "vendor": "Techneco"
   },
   "3cb70739631c4d17a86b8b12e8a5161b": {
     "active_preset": "home",
-    "available_schedules": ["standaard", "off"],
+    "available_schedules": [
+      "standaard",
+      "off"
+    ],
     "climate_mode": "heat_cool",
     "control_state": "cooling",
     "dev_class": "thermostat",
@@ -66,7 +69,13 @@
     "location": "c784ee9fdab44e1395b8dee7d7a497d5",
     "model": "ThermoTouch",
     "name": "Anna",
-    "preset_modes": ["no_frost", "home", "away", "asleep", "vacation"],
+    "preset_modes": [
+      "no_frost",
+      "home",
+      "away",
+      "asleep",
+      "vacation"
+    ],
     "select_schedule": "off",
     "sensors": {
       "cooling_activation_outdoor_temperature": 21.0,

--- a/tests/data/anna/anna_heatpump_cooling.json
+++ b/tests/data/anna/anna_heatpump_cooling.json
@@ -43,7 +43,7 @@
     "location": "a57efe5f145f498c9be62a9b63626fbf",
     "model": "Generic heater/cooler",
     "name": "OpenTherm",
-    "select_dhw_mode": "off",
+    "select_dhw_mode": "eco",
     "sensors": {
       "dhw_temperature": 41.5,
       "domestic_hot_water_setpoint": 60.0,

--- a/tests/data/anna/anna_heatpump_cooling.json
+++ b/tests/data/anna/anna_heatpump_cooling.json
@@ -38,7 +38,7 @@
     "dev_class": "heater_central",
     "dhw_modes": [
       "comfort",
-      "off"
+      "eco"
     ],
     "location": "a57efe5f145f498c9be62a9b63626fbf",
     "model": "Generic heater/cooler",

--- a/tests/data/anna/anna_heatpump_cooling_fake_firmware.json
+++ b/tests/data/anna/anna_heatpump_cooling_fake_firmware.json
@@ -28,18 +28,19 @@
       "heating_state": false,
       "secondary_boiler_state": false
     },
+    "boiler_temperature": {
+      "current": 24.7,
+      "lower_bound": 0.0,
+      "resolution": 1.0,
+      "setpoint": 60.0,
+      "upper_bound": 100.0
+    },
     "dev_class": "heater_central",
     "dhw_modes": [
       "comfort",
       "off"
     ],
     "location": "a57efe5f145f498c9be62a9b63626fbf",
-    "maximum_boiler_temperature": {
-      "lower_bound": 0.0,
-      "resolution": 1.0,
-      "setpoint": 60.0,
-      "upper_bound": 100.0
-    },
     "model": "Generic heater/cooler",
     "name": "OpenTherm",
     "select_dhw_mode": "off",
@@ -50,14 +51,16 @@
       "modulation_level": 100,
       "outdoor_air_temperature": 22.0,
       "return_temperature": 23.8,
-      "water_pressure": 1.61,
-      "water_temperature": 24.7
+      "water_pressure": 1.61
     },
     "vendor": "Techneco"
   },
   "3cb70739631c4d17a86b8b12e8a5161b": {
     "active_preset": "home",
-    "available_schedules": ["standaard", "off"],
+    "available_schedules": [
+      "standaard",
+      "off"
+    ],
     "climate_mode": "heat_cool",
     "control_state": "cooling",
     "dev_class": "thermostat",
@@ -66,7 +69,13 @@
     "location": "c784ee9fdab44e1395b8dee7d7a497d5",
     "model": "ThermoTouch",
     "name": "Anna",
-    "preset_modes": ["no_frost", "home", "away", "asleep", "vacation"],
+    "preset_modes": [
+      "no_frost",
+      "home",
+      "away",
+      "asleep",
+      "vacation"
+    ],
     "select_schedule": "off",
     "sensors": {
       "cooling_activation_outdoor_temperature": 21.0,

--- a/tests/data/anna/anna_heatpump_cooling_fake_firmware.json
+++ b/tests/data/anna/anna_heatpump_cooling_fake_firmware.json
@@ -43,7 +43,7 @@
     "location": "a57efe5f145f498c9be62a9b63626fbf",
     "model": "Generic heater/cooler",
     "name": "OpenTherm",
-    "select_dhw_mode": "off",
+    "select_dhw_mode": "eco",
     "sensors": {
       "dhw_temperature": 41.5,
       "domestic_hot_water_setpoint": 60.0,

--- a/tests/data/anna/anna_heatpump_cooling_fake_firmware.json
+++ b/tests/data/anna/anna_heatpump_cooling_fake_firmware.json
@@ -38,7 +38,7 @@
     "dev_class": "heater_central",
     "dhw_modes": [
       "comfort",
-      "off"
+      "eco"
     ],
     "location": "a57efe5f145f498c9be62a9b63626fbf",
     "model": "Generic heater/cooler",

--- a/tests/data/anna/anna_heatpump_heating.json
+++ b/tests/data/anna/anna_heatpump_heating.json
@@ -36,10 +36,10 @@
       "upper_bound": 100.0
     },
     "dev_class": "heater_central",
-    "dhw_mode": "off",
+    "dhw_mode": "eco",
     "dhw_modes": [
       "comfort",
-      "off"
+      "eco"
     ],
     "dhw_temperature": {
       "current": 46.3,

--- a/tests/data/anna/anna_heatpump_heating.json
+++ b/tests/data/anna/anna_heatpump_heating.json
@@ -28,41 +28,44 @@
       "heating_state": true,
       "secondary_boiler_state": false
     },
-    "dev_class": "heater_central",
-    "dhw_modes": [
-      "comfort",
-      "off"
-    ],
-    "location": "a57efe5f145f498c9be62a9b63626fbf",
-    "max_dhw_temperature": {
-      "lower_bound": 35.0,
-      "resolution": 0.01,
-      "setpoint": 53.0,
-      "upper_bound": 60.0
-    },
-    "maximum_boiler_temperature": {
+    "boiler_temperature": {
+      "current": 29.1,
       "lower_bound": 0.0,
       "resolution": 1.0,
       "setpoint": 60.0,
       "upper_bound": 100.0
     },
+    "dev_class": "heater_central",
+    "dhw_mode": "off",
+    "dhw_modes": [
+      "comfort",
+      "off"
+    ],
+    "dhw_temperature": {
+      "current": 46.3,
+      "lower_bound": 35.0,
+      "resolution": 0.01,
+      "setpoint": 53.0,
+      "upper_bound": 60.0
+    },
+    "location": "a57efe5f145f498c9be62a9b63626fbf",
     "model": "Generic heater/cooler",
     "name": "OpenTherm",
-    "dhw_mode": "off",
     "sensors": {
-      "dhw_temperature": 46.3,
       "intended_boiler_temperature": 35.0,
       "modulation_level": 52,
       "outdoor_air_temperature": 3.0,
       "return_temperature": 25.1,
-      "water_pressure": 1.57,
-      "water_temperature": 29.1
+      "water_pressure": 1.57
     },
     "vendor": "Techneco"
   },
   "3cb70739631c4d17a86b8b12e8a5161b": {
     "active_preset": "home",
-    "available_schedules": ["standaard", "off"],
+    "available_schedules": [
+      "standaard",
+      "off"
+    ],
     "climate_mode": "auto",
     "control_state": "heating",
     "dev_class": "thermostat",
@@ -71,7 +74,13 @@
     "location": "c784ee9fdab44e1395b8dee7d7a497d5",
     "model": "ThermoTouch",
     "name": "Anna",
-    "preset_modes": ["no_frost", "home", "away", "asleep", "vacation"],
+    "preset_modes": [
+      "no_frost",
+      "home",
+      "away",
+      "asleep",
+      "vacation"
+    ],
     "select_schedule": "standaard",
     "sensors": {
       "cooling_activation_outdoor_temperature": 21.0,

--- a/tests/data/anna/anna_heatpump_heating_UPDATED_DATA.json
+++ b/tests/data/anna/anna_heatpump_heating_UPDATED_DATA.json
@@ -1,5 +1,12 @@
 {
   "1cbf783bb11e4a7c8a6843dee3a86927": {
+    "boiler_temperature": {
+      "current": 29.1,
+      "setpoint": 60.0,
+      "lower_bound": 0.0,
+      "upper_bound": 100.0,
+      "resolution": 1.0
+    },
     "dev_class": "heater_central",
     "dhw_modes": [
       "comfort",
@@ -9,12 +16,7 @@
     "model": "Generic heater/cooler",
     "name": "OpenTherm",
     "vendor": "Techneco",
-    "maximum_boiler_temperature": {
-      "setpoint": 60.0,
-      "lower_bound": 0.0,
-      "upper_bound": 100.0,
-      "resolution": 1.0
-    },
+
     "available": true,
     "binary_sensors": {
       "dhw_state": false,
@@ -27,9 +29,6 @@
     },
     "select_dhw_mode": "off",
     "sensors": {
-      "water_temperature": 29.1,
-      "domestic_hot_water_setpoint": 60.0,
-      "dhw_temperature": 46.3,
       "intended_boiler_temperature": 35.0,
       "modulation_level": 52,
       "return_temperature": 25.1,

--- a/tests/data/anna/anna_heatpump_heating_UPDATED_DATA.json
+++ b/tests/data/anna/anna_heatpump_heating_UPDATED_DATA.json
@@ -17,7 +17,6 @@
     "model": "Generic heater/cooler",
     "name": "OpenTherm",
     "vendor": "Techneco",
-
     "available": true,
     "binary_sensors": {
       "dhw_state": false,

--- a/tests/data/anna/anna_heatpump_heating_UPDATED_DATA.json
+++ b/tests/data/anna/anna_heatpump_heating_UPDATED_DATA.json
@@ -1,22 +1,5 @@
 {
   "1cbf783bb11e4a7c8a6843dee3a86927": {
-    "boiler_temperature": {
-      "current": 29.1,
-      "setpoint": 60.0,
-      "lower_bound": 0.0,
-      "upper_bound": 100.0,
-      "resolution": 1.0
-    },
-    "dev_class": "heater_central",
-    "dhw_mode": "eco",
-    "dhw_modes": [
-      "comfort",
-      "eco"
-    ],
-    "location": "a57efe5f145f498c9be62a9b63626fbf",
-    "model": "Generic heater/cooler",
-    "name": "OpenTherm",
-    "vendor": "Techneco",
     "available": true,
     "binary_sensors": {
       "dhw_state": false,
@@ -27,6 +10,22 @@
       "secondary_boiler_state": false,
       "flame_state": false
     },
+    "boiler_temperature": {
+      "current": 29.1,
+      "setpoint": 60.0,
+      "lower_bound": 0.0,
+      "upper_bound": 100.0,
+      "resolution": 1.0
+    },
+    "dev_class": "heater_central",
+    "dhw_modes": [
+      "comfort",
+      "eco"
+    ],
+    "location": "a57efe5f145f498c9be62a9b63626fbf",
+    "model": "Generic heater/cooler",
+    "name": "OpenTherm",
+    "select_dhw_mode": "eco",
     "sensors": {
       "intended_boiler_temperature": 35.0,
       "modulation_level": 52,
@@ -34,6 +33,7 @@
       "water_pressure": 1.57,
       "outdoor_air_temperature": 3.0
 
-    }
+    },
+    "vendor": "Techneco"
   }
 }

--- a/tests/data/anna/anna_heatpump_heating_UPDATED_DATA.json
+++ b/tests/data/anna/anna_heatpump_heating_UPDATED_DATA.json
@@ -8,9 +8,10 @@
       "resolution": 1.0
     },
     "dev_class": "heater_central",
+    "dhw_mode": "eco",
     "dhw_modes": [
       "comfort",
-      "off"
+      "eco"
     ],
     "location": "a57efe5f145f498c9be62a9b63626fbf",
     "model": "Generic heater/cooler",
@@ -27,7 +28,6 @@
       "secondary_boiler_state": false,
       "flame_state": false
     },
-    "select_dhw_mode": "off",
     "sensors": {
       "intended_boiler_temperature": 35.0,
       "modulation_level": 52,

--- a/tests/data/anna/anna_loria_cooling_active.json
+++ b/tests/data/anna/anna_loria_cooling_active.json
@@ -1,7 +1,11 @@
 {
   "582dfbdace4d4aeb832923ce7d1ddda0": {
     "active_preset": "home",
-    "available_schedules": ["Winter", "Test ", "off"],
+    "available_schedules": [
+      "Winter",
+      "Test ",
+      "off"
+    ],
     "climate_mode": "auto",
     "control_state": "cooling",
     "dev_class": "thermostat",
@@ -10,7 +14,13 @@
     "location": "15da035090b847e7a21f93e08c015ebc",
     "model": "ThermoTouch",
     "name": "Anna",
-    "preset_modes": ["away", "vacation", "no_frost", "home", "asleep"],
+    "preset_modes": [
+      "away",
+      "vacation",
+      "no_frost",
+      "home",
+      "asleep"
+    ],
     "select_schedule": "Winter",
     "sensors": {
       "illuminance": 45.0,
@@ -60,32 +70,38 @@
       "flame_state": false,
       "heating_state": false
     },
-    "dev_class": "heater_central",
-    "dhw_modes": ["off", "auto", "boost", "eco", "comfort"],
-    "location": "674b657c138a41a291d315d7471deb06",
-    "max_dhw_temperature": {
-      "lower_bound": 35.0,
-      "resolution": 0.01,
-      "setpoint": 53.0,
-      "upper_bound": 60.0
-    },
-    "maximum_boiler_temperature": {
+    "boiler_temperature": {
+      "current": 25.3,
       "lower_bound": 25.0,
       "resolution": 0.01,
       "setpoint": 40.0,
       "upper_bound": 45.0
     },
+    "dev_class": "heater_central",
+    "dhw_mode": "auto",
+    "dhw_modes": [
+      "off",
+      "auto",
+      "boost",
+      "eco",
+      "comfort"
+    ],
+    "dhw_temperature": {
+      "current": 52.9,
+      "lower_bound": 35.0,
+      "resolution": 0.01,
+      "setpoint": 53.0,
+      "upper_bound": 60.0
+    },
+    "location": "674b657c138a41a291d315d7471deb06",
     "model": "Generic heater/cooler",
     "model_id": "173",
     "name": "OpenTherm",
-    "dhw_mode": "auto",
     "sensors": {
-      "dhw_temperature": 52.9,
       "intended_boiler_temperature": 0.0,
       "modulation_level": 100,
       "outdoor_air_temperature": 17.2,
-      "return_temperature": 26.3,
-      "water_temperature": 25.3
+      "return_temperature": 26.3
     },
     "switches": {
       "cooling_ena_switch": true

--- a/tests/data/anna/anna_loria_driessens.json
+++ b/tests/data/anna/anna_loria_driessens.json
@@ -34,7 +34,13 @@
     "location": "fa70e08550c94de3a34feb27ecf31421",
     "model": "ThermoTouch",
     "name": "Anna",
-    "preset_modes": ["no_frost", "asleep", "vacation", "away", "home"],
+    "preset_modes": [
+      "no_frost",
+      "asleep",
+      "vacation",
+      "away",
+      "home"
+    ],
     "select_schedule": "Verwarmen@9-23u",
     "sensors": {
       "illuminance": 5.5,
@@ -66,32 +72,38 @@
       "flame_state": false,
       "heating_state": false
     },
-    "dev_class": "heater_central",
-    "dhw_modes": ["comfort", "eco", "off", "boost", "auto"],
-    "location": "82c15f65c9bf44c592d69e16139355e3",
-    "max_dhw_temperature": {
-      "lower_bound": 35.0,
-      "resolution": 0.01,
-      "setpoint": 53.0,
-      "upper_bound": 60.0
-    },
-    "maximum_boiler_temperature": {
+    "boiler_temperature": {
+      "current": 23.3,
       "lower_bound": 25.0,
       "resolution": 0.01,
       "setpoint": 45.0,
       "upper_bound": 45.0
     },
+    "dev_class": "heater_central",
+    "dhw_mode": "auto",
+    "dhw_modes": [
+      "comfort",
+      "eco",
+      "off",
+      "boost",
+      "auto"
+    ],
+    "dhw_temperature": {
+      "current": 49.5,
+      "lower_bound": 35.0,
+      "resolution": 0.01,
+      "setpoint": 53.0,
+      "upper_bound": 60.0
+    },
+    "location": "82c15f65c9bf44c592d69e16139355e3",
     "model": "Generic heater/cooler",
     "model_id": "173",
     "name": "OpenTherm",
-    "dhw_mode": "auto",
     "sensors": {
-      "dhw_temperature": 49.5,
       "intended_boiler_temperature": 0.0,
       "modulation_level": 0.0,
       "outdoor_air_temperature": 7.5,
-      "return_temperature": 23.0,
-      "water_temperature": 23.3
+      "return_temperature": 23.0
     },
     "switches": {
       "cooling_ena_switch": false

--- a/tests/data/anna/anna_loria_heating_idle.json
+++ b/tests/data/anna/anna_loria_heating_idle.json
@@ -1,7 +1,11 @@
 {
   "582dfbdace4d4aeb832923ce7d1ddda0": {
     "active_preset": "home",
-    "available_schedules": ["Winter", "Test ", "off"],
+    "available_schedules": [
+      "Winter",
+      "Test ",
+      "off"
+    ],
     "climate_mode": "auto",
     "control_state": "idle",
     "dev_class": "thermostat",
@@ -10,7 +14,13 @@
     "location": "15da035090b847e7a21f93e08c015ebc",
     "model": "ThermoTouch",
     "name": "Anna",
-    "preset_modes": ["away", "vacation", "no_frost", "home", "asleep"],
+    "preset_modes": [
+      "away",
+      "vacation",
+      "no_frost",
+      "home",
+      "asleep"
+    ],
     "select_schedule": "Winter",
     "sensors": {
       "illuminance": 45.0,
@@ -60,32 +70,38 @@
       "flame_state": false,
       "heating_state": false
     },
-    "dev_class": "heater_central",
-    "dhw_modes": ["off", "auto", "boost", "eco", "comfort"],
-    "location": "674b657c138a41a291d315d7471deb06",
-    "max_dhw_temperature": {
-      "lower_bound": 35.0,
-      "resolution": 0.01,
-      "setpoint": 53.0,
-      "upper_bound": 60.0
-    },
-    "maximum_boiler_temperature": {
+    "boiler_temperature": {
+      "current": 25.3,
       "lower_bound": 25.0,
       "resolution": 0.01,
       "setpoint": 40.0,
       "upper_bound": 45.0
     },
+    "dev_class": "heater_central",
+    "dhw_mode": "auto",
+    "dhw_modes": [
+      "off",
+      "auto",
+      "boost",
+      "eco",
+      "comfort"
+    ],
+    "dhw_temperature": {
+      "current": 52.9,
+      "lower_bound": 35.0,
+      "resolution": 0.01,
+      "setpoint": 53.0,
+      "upper_bound": 60.0
+    },
+    "location": "674b657c138a41a291d315d7471deb06",
     "model": "Generic heater/cooler",
     "model_id": "173",
     "name": "OpenTherm",
-    "dhw_mode": "auto",
     "sensors": {
-      "dhw_temperature": 52.9,
       "intended_boiler_temperature": 0.0,
       "modulation_level": 0.0,
       "outdoor_air_temperature": 17.2,
-      "return_temperature": 26.3,
-      "water_temperature": 25.3
+      "return_temperature": 26.3
     },
     "switches": {
       "cooling_ena_switch": false

--- a/tests/data/anna/anna_p1.json
+++ b/tests/data/anna/anna_p1.json
@@ -39,7 +39,7 @@
       "heating_state": false
     },
     "dev_class": "heater_central",
-    "dhw_modes": ["comfort", "off"],
+    "dhw_modes": ["comfort", "eco"],
     "location": "da7be222ab3b420c927f3e49fade0304",
     "model": "Generic heater",
     "model_id": "HR24",

--- a/tests/data/anna/anna_v4.json
+++ b/tests/data/anna/anna_v4.json
@@ -74,7 +74,7 @@
       "upper_bound": 100.0
     },
     "dev_class": "heater_central",
-    "dhw_mode": "off",
+    "dhw_mode": "eco",
     "dhw_modes": [
       "comfort",
       "eco"

--- a/tests/data/anna/anna_v4.json
+++ b/tests/data/anna/anna_v4.json
@@ -1,7 +1,11 @@
 {
   "01b85360fdd243d0aaad4d6ac2a5ba7e": {
     "active_preset": "home",
-    "available_schedules": ["Standaard", "Thuiswerken", "off"],
+    "available_schedules": [
+      "Standaard",
+      "Thuiswerken",
+      "off"
+    ],
     "climate_mode": "heat",
     "control_state": "heating",
     "dev_class": "thermostat",
@@ -10,7 +14,13 @@
     "location": "eb5309212bf5407bb143e5bfa3b18aee",
     "model": "ThermoTouch",
     "name": "Anna",
-    "preset_modes": ["vacation", "no_frost", "away", "asleep", "home"],
+    "preset_modes": [
+      "vacation",
+      "no_frost",
+      "away",
+      "asleep",
+      "home"
+    ],
     "select_schedule": "off",
     "sensors": {
       "illuminance": 60.0,
@@ -56,31 +66,35 @@
       "flame_state": false,
       "heating_state": true
     },
-    "dev_class": "heater_central",
-    "dhw_modes": ["comfort", "off"],
-    "location": "94c107dc6ac84ed98e9f68c0dd06bf71",
-    "max_dhw_temperature": {
-      "lower_bound": 30.0,
-      "resolution": 0.01,
-      "setpoint": 60.0,
-      "upper_bound": 60.0
-    },
-    "maximum_boiler_temperature": {
+    "boiler_temperature": {
+      "current": 45.0,
       "lower_bound": 0.0,
       "resolution": 1.0,
       "setpoint": 70.0,
       "upper_bound": 100.0
     },
+    "dev_class": "heater_central",
+    "dhw_mode": "off",
+    "dhw_modes": [
+      "comfort",
+      "off"
+    ],
+    "dhw_temperature": {
+      "current": 45.0,
+      "lower_bound": 30.0,
+      "resolution": 0.01,
+      "setpoint": 60.0,
+      "upper_bound": 60.0
+    },
+    "location": "94c107dc6ac84ed98e9f68c0dd06bf71",
     "model": "Generic heater",
     "model_id": "2.32",
     "name": "OpenTherm",
-    "dhw_mode": "off",
     "sensors": {
       "intended_boiler_temperature": 39.9,
       "modulation_level": 0.0,
       "return_temperature": 32.0,
-      "water_pressure": 2.2,
-      "water_temperature": 45.0
+      "water_pressure": 2.2
     },
     "vendor": "Bosch Thermotechniek B.V."
   }

--- a/tests/data/anna/anna_v4.json
+++ b/tests/data/anna/anna_v4.json
@@ -77,7 +77,7 @@
     "dhw_mode": "off",
     "dhw_modes": [
       "comfort",
-      "off"
+      "eco"
     ],
     "dhw_temperature": {
       "current": 45.0,

--- a/tests/data/anna/anna_v4_UPDATED_DATA.json
+++ b/tests/data/anna/anna_v4_UPDATED_DATA.json
@@ -1,13 +1,16 @@
 {
   "cd0e6156b1f04d5f952349ffbe397481": {
-    "dhw_modes": ["comfort", "off"],
-    "maximum_boiler_temperature": {
+    "boiler_temperature": {
+      "current": 51.0,
       "setpoint": 69.0,
       "lower_bound": 0.0,
       "upper_bound": 100.0,
       "resolution": 1.0
     },
-    "max_dhw_temperature": {
+    "dhw_mode": "comfort",
+    "dhw_modes": ["comfort", "off"],
+    "dhw_temperature": {
+      "current": 51.0,
       "setpoint": 59.0,
       "lower_bound": 30.0,
       "upper_bound": 60.0,
@@ -18,9 +21,7 @@
       "heating_state": false,
       "flame_state": false
     },
-    "dhw_mode": "comfort",
     "sensors": {
-      "water_temperature": 51.0,
       "intended_boiler_temperature": 0.0,
       "modulation_level": 0,
       "return_temperature": 41.0,

--- a/tests/data/anna/anna_v4_UPDATED_DATA.json
+++ b/tests/data/anna/anna_v4_UPDATED_DATA.json
@@ -8,7 +8,7 @@
       "resolution": 1.0
     },
     "dhw_mode": "comfort",
-    "dhw_modes": ["comfort", "off"],
+    "dhw_modes": ["comfort", "eco"],
     "dhw_temperature": {
       "current": 51.0,
       "setpoint": 59.0,

--- a/tests/data/anna/anna_v4_dhw.json
+++ b/tests/data/anna/anna_v4_dhw.json
@@ -74,7 +74,7 @@
       "upper_bound": 100.0
     },
     "dev_class": "heater_central",
-    "dhw_mode": "off",
+    "dhw_mode": "eco",
     "dhw_modes": [
       "comfort",
       "eco"

--- a/tests/data/anna/anna_v4_dhw.json
+++ b/tests/data/anna/anna_v4_dhw.json
@@ -77,7 +77,7 @@
     "dhw_mode": "off",
     "dhw_modes": [
       "comfort",
-      "off"
+      "eco"
     ],
     "dhw_temperature": {
       "current": 45.0,

--- a/tests/data/anna/anna_v4_dhw.json
+++ b/tests/data/anna/anna_v4_dhw.json
@@ -1,7 +1,11 @@
 {
   "01b85360fdd243d0aaad4d6ac2a5ba7e": {
     "active_preset": "home",
-    "available_schedules": ["Standaard", "Thuiswerken", "off"],
+    "available_schedules": [
+      "Standaard",
+      "Thuiswerken",
+      "off"
+    ],
     "climate_mode": "heat",
     "control_state": "idle",
     "dev_class": "thermostat",
@@ -10,7 +14,13 @@
     "location": "eb5309212bf5407bb143e5bfa3b18aee",
     "model": "ThermoTouch",
     "name": "Anna",
-    "preset_modes": ["vacation", "no_frost", "away", "asleep", "home"],
+    "preset_modes": [
+      "vacation",
+      "no_frost",
+      "away",
+      "asleep",
+      "home"
+    ],
     "select_schedule": "off",
     "sensors": {
       "illuminance": 60.0,
@@ -56,31 +66,35 @@
       "flame_state": true,
       "heating_state": false
     },
-    "dev_class": "heater_central",
-    "dhw_modes": ["comfort", "off"],
-    "location": "94c107dc6ac84ed98e9f68c0dd06bf71",
-    "max_dhw_temperature": {
-      "lower_bound": 30.0,
-      "resolution": 0.01,
-      "setpoint": 60.0,
-      "upper_bound": 60.0
-    },
-    "maximum_boiler_temperature": {
+    "boiler_temperature": {
+      "current": 45.0,
       "lower_bound": 0.0,
       "resolution": 1.0,
       "setpoint": 70.0,
       "upper_bound": 100.0
     },
+    "dev_class": "heater_central",
+    "dhw_mode": "off",
+    "dhw_modes": [
+      "comfort",
+      "off"
+    ],
+    "dhw_temperature": {
+      "current": 45.0,
+      "lower_bound": 30.0,
+      "resolution": 0.01,
+      "setpoint": 60.0,
+      "upper_bound": 60.0
+    },
+    "location": "94c107dc6ac84ed98e9f68c0dd06bf71",
     "model": "Generic heater",
     "model_id": "2.32",
     "name": "OpenTherm",
-    "dhw_mode": "off",
     "sensors": {
       "intended_boiler_temperature": 39.9,
       "modulation_level": 0.0,
       "return_temperature": 32.0,
-      "water_pressure": 2.2,
-      "water_temperature": 45.0
+      "water_pressure": 2.2
     },
     "vendor": "Bosch Thermotechniek B.V."
   }

--- a/tests/data/anna/anna_v4_no_tag.json
+++ b/tests/data/anna/anna_v4_no_tag.json
@@ -74,7 +74,7 @@
       "upper_bound": 100.0
     },
     "dev_class": "heater_central",
-    "dhw_mode": "off",
+    "dhw_mode": "eco",
     "dhw_modes": [
       "comfort",
       "eco"

--- a/tests/data/anna/anna_v4_no_tag.json
+++ b/tests/data/anna/anna_v4_no_tag.json
@@ -1,7 +1,11 @@
 {
   "01b85360fdd243d0aaad4d6ac2a5ba7e": {
     "active_preset": "home",
-    "available_schedules": ["Standaard", "Thuiswerken", "off"],
+    "available_schedules": [
+      "Standaard",
+      "Thuiswerken",
+      "off"
+    ],
     "climate_mode": "auto",
     "control_state": "heating",
     "dev_class": "thermostat",
@@ -10,7 +14,13 @@
     "location": "eb5309212bf5407bb143e5bfa3b18aee",
     "model": "ThermoTouch",
     "name": "Anna",
-    "preset_modes": ["vacation", "no_frost", "away", "asleep", "home"],
+    "preset_modes": [
+      "vacation",
+      "no_frost",
+      "away",
+      "asleep",
+      "home"
+    ],
     "select_schedule": "Thuiswerken",
     "sensors": {
       "illuminance": 60.0,
@@ -56,31 +66,35 @@
       "flame_state": false,
       "heating_state": true
     },
-    "dev_class": "heater_central",
-    "dhw_modes": ["comfort", "off"],
-    "location": "94c107dc6ac84ed98e9f68c0dd06bf71",
-    "max_dhw_temperature": {
-      "lower_bound": 30.0,
-      "resolution": 0.01,
-      "setpoint": 60.0,
-      "upper_bound": 60.0
-    },
-    "maximum_boiler_temperature": {
+    "boiler_temperature": {
+      "current": 45.0,
       "lower_bound": 0.0,
       "resolution": 1.0,
       "setpoint": 70.0,
       "upper_bound": 100.0
     },
+    "dev_class": "heater_central",
+    "dhw_mode": "off",
+    "dhw_modes": [
+      "comfort",
+      "off"
+    ],
+    "dhw_temperature": {
+      "current": 45.0,
+      "lower_bound": 30.0,
+      "resolution": 0.01,
+      "setpoint": 60.0,
+      "upper_bound": 60.0
+    },
+    "location": "94c107dc6ac84ed98e9f68c0dd06bf71",
     "model": "Generic heater",
     "model_id": "2.32",
     "name": "OpenTherm",
-    "dhw_mode": "off",
     "sensors": {
       "intended_boiler_temperature": 39.9,
       "modulation_level": 0.0,
       "return_temperature": 32.0,
-      "water_pressure": 2.2,
-      "water_temperature": 45.0
+      "water_pressure": 2.2
     },
     "vendor": "Bosch Thermotechniek B.V."
   }

--- a/tests/data/anna/anna_v4_no_tag.json
+++ b/tests/data/anna/anna_v4_no_tag.json
@@ -77,7 +77,7 @@
     "dhw_mode": "off",
     "dhw_modes": [
       "comfort",
-      "off"
+      "eco"
     ],
     "dhw_temperature": {
       "current": 45.0,

--- a/tests/test_adam.py
+++ b/tests/test_adam.py
@@ -466,5 +466,8 @@ class TestPlugwiseAdam(TestPlugwise):  # pylint: disable=attribute-defined-outsi
         )
         assert not tinkered
 
+        tinkered = await self.tinker_actuator_temp(api)
+        assert not tinkered
+
         await api.close_connection()
         await self.disconnect(server, client)

--- a/tests/test_adam.py
+++ b/tests/test_adam.py
@@ -441,7 +441,7 @@ class TestPlugwiseAdam(TestPlugwise):  # pylint: disable=attribute-defined-outsi
 
         test_items = await self.device_test(api, "2021-06-20 00:00:01", testdata)
         assert api.gateway_id == "b5c2386c6f6342669e50fe49dd05b188"
-        assert self.entity_items == 270
+        assert self.entity_items == 271
         assert test_items == self.entity_items
 
         # Negative test

--- a/tests/test_adam.py
+++ b/tests/test_adam.py
@@ -149,7 +149,7 @@ class TestPlugwiseAdam(TestPlugwise):  # pylint: disable=attribute-defined-outsi
         tinkered = await self.tinker_regulation_mode(api)
         assert not tinkered
 
-        tinkered = await self.tinker_max_boiler_temp(api)
+        tinkered = await self.tinker_actuator_temp(api)
         assert not tinkered
 
         assert not await self.tinker_zone_profile(
@@ -191,7 +191,7 @@ class TestPlugwiseAdam(TestPlugwise):  # pylint: disable=attribute-defined-outsi
         server, api, client = await self.connect_wrapper(raise_timeout=True)
         await self.device_test(api, "2023-12-17 00:00:01", testdata, skip_testing=True)
 
-        tinkered = await self.tinker_max_boiler_temp(api, unhappy=True)
+        tinkered = await self.tinker_actuator_temp(api, unhappy=True)
         assert tinkered
 
         tinkered = await self.tinker_gateway_mode(api, unhappy=True)
@@ -282,7 +282,7 @@ class TestPlugwiseAdam(TestPlugwise):  # pylint: disable=attribute-defined-outsi
         )
         assert result
 
-        tinkered = await self.tinker_max_boiler_temp(api, unhappy=True)
+        tinkered = await self.tinker_actuator_temp(api, unhappy=True)
         assert not tinkered
 
         try:

--- a/tests/test_anna.py
+++ b/tests/test_anna.py
@@ -29,7 +29,7 @@ class TestPlugwiseAnna(TestPlugwise):  # pylint: disable=attribute-defined-outsi
 
         await self.device_test(api, "2020-04-05 00:00:01", testdata)
         assert api.gateway_id == "0466eae8520144c78afb29628384edeb"
-        assert self.entity_items == 61
+        assert self.entity_items == 62
         assert not self.notifications
 
         assert not self.cooling_present

--- a/tests/test_anna.py
+++ b/tests/test_anna.py
@@ -101,7 +101,7 @@ class TestPlugwiseAnna(TestPlugwise):  # pylint: disable=attribute-defined-outsi
         )
 
         await self.device_test(api, "2020-04-05 00:00:01", testdata)
-        assert self.entity_items == 61
+        assert self.entity_items == 62
         assert not self.notifications
 
         result = await self.tinker_thermostat(

--- a/tests/test_anna.py
+++ b/tests/test_anna.py
@@ -130,7 +130,7 @@ class TestPlugwiseAnna(TestPlugwise):  # pylint: disable=attribute-defined-outsi
         )
 
         await self.device_test(api, "2020-04-05 00:00:01", testdata)
-        assert self.entity_items == 61
+        assert self.entity_items == 62
 
         result = await self.tinker_thermostat(
             api,

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -910,9 +910,9 @@ class TestPlugwise:  # pylint: disable=attribute-defined-outside-init
         return tinker_reg_mode_passed
 
     @staticmethod
-    async def tinker_max_boiler_temp(api, unhappy=False):
-        """Change max boiler temp setpoint to test functionality."""
-        tinker_max_boiler_temp_passed = False
+    async def tinker_actuator_temp(api, unhappy=False):
+        """Change actuator temperature setpoint to test functionality."""
+        tinker_actuator_passed = False
         new_temp = 60.0
         _LOGGER.info("- Adjusting temperature to %s", new_temp)
         for test in [
@@ -923,11 +923,11 @@ class TestPlugwise:  # pylint: disable=attribute-defined-outside-init
             _LOGGER.info("  + for %s", test)
             try:
                 await api.set_number("dummy", test, new_temp)
-                _LOGGER.info("  + tinker_max_boiler_temp worked as intended")
-                tinker_max_boiler_temp_passed = True
+                _LOGGER.info("  + tinker_actuator_temp worked as intended")
+                tinker_actuator_passed = True
             except pw_exceptions.PlugwiseError:
-                _LOGGER.info("  + tinker_max_boiler_temp failed as intended")
-                tinker_max_boiler_temp_passed = False
+                _LOGGER.info("  + tinker_actuator_temp failed as intended")
+                tinker_actuator_passed = False
             except (
                 pw_exceptions.ConnectionFailedError
             ):  # leave for-loop at connect-error
@@ -938,7 +938,7 @@ class TestPlugwise:  # pylint: disable=attribute-defined-outside-init
                     _LOGGER.info("  - succeeded unexpectedly for some reason")
                     return False
 
-        return tinker_max_boiler_temp_passed
+        return tinker_actuator_passed
 
     @staticmethod
     async def tinker_temp_offset(api, dev_id, unhappy=False):

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -916,8 +916,8 @@ class TestPlugwise:  # pylint: disable=attribute-defined-outside-init
         new_temp = 60.0
         _LOGGER.info("- Adjusting temperature to %s", new_temp)
         for test in [
-            "maximum_boiler_temperature",
-            "max_dhw_temperature",
+            "boiler_temperature",
+            "dhw_temperature",
             "bogus_temperature",
         ]:
             _LOGGER.info("  + for %s", test)


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Updated boiler and DHW temperature reporting to use unified structured temperature objects that include the live `current` value plus bounds/setpoint metadata.
  * Updated DHW temperature/mode handling so “eco” replaces the former “off” option where applicable.
  * Removed legacy DHW/boiler temperature sensor fields from generated payloads while keeping other water-related telemetry.
* **Tests**
  * Refreshed fixtures and expectations (including entity counts and formatting) to match the new temperature representation and DHW mode behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->