### PR TITLE
Solve aiohttp BascicAuth depreciation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 - Add PEP 740 digital attestations (workaround until included in `uv publish`)
 - Pin GitHub acions including our own from gh-actions
-
+- Solve aiohttp BasicAuth deprecation via PR [#890](https://github.com/plugwise/python-plugwise/pull/890)
 ## v1.12.0
 
 - Replace the DHW-comfort-mode switch by a DHW mode selector to match the new HA select or water_heater platform updates, via PR [#883](https://github.com/plugwise/python-plugwise/pull/883)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,9 +2,9 @@
 
 ## Ongoing
 
-- Add PEP 740 digital attestations (workaround until included in `uv publish`)
-- Pin GitHub acions including our own from gh-actions
+- Add PEP 740 digital attestations (workaround until included in `uv publish`), pin GitHub acions including our own from gh-actions, via PR [#891](https://github.com/plugwise/python-plugwise/pull/891)
 - Solve aiohttp BasicAuth deprecation via PR [#890](https://github.com/plugwise/python-plugwise/pull/890)
+
 ## v1.12.0
 
 - Replace the DHW-comfort-mode switch by a DHW mode selector to match the new HA select or water_heater platform updates, via PR [#883](https://github.com/plugwise/python-plugwise/pull/883)

--- a/plugwise/smilecomm.py
+++ b/plugwise/smilecomm.py
@@ -15,7 +15,7 @@ from plugwise.exceptions import (
 from plugwise.util import escape_illegal_xml_characters
 
 # This way of importing aiohttp is because of patch/mocking in testing (aiohttp timeouts)
-from aiohttp import BasicAuth, ClientError, ClientResponse, ClientSession, ClientTimeout
+import aiohttp
 from defusedxml import ElementTree as etree
 
 
@@ -29,12 +29,12 @@ class SmileComm:
         port: int,
         timeout: int,
         username: str,
-        websession: ClientSession | None,
+        websession: aiohttp.ClientSession | None,
     ) -> None:
         """Set the constructor for this class."""
         if not websession:
-            aio_timeout = ClientTimeout(total=timeout)
-            self._websession = ClientSession(timeout=aio_timeout)
+            aio_timeout = aiohttp.ClientTimeout(total=timeout)
+            self._websession = aiohttp.ClientSession(timeout=aio_timeout)
         else:
             self._websession = websession
 
@@ -42,7 +42,7 @@ class SmileComm:
         if host.count(":") > 2:  # pragma: no cover
             host = f"[{host}]"
 
-        self._auth = BasicAuth(username, password=password)
+        self._base_header = {"Authorization": aiohttp.encode_basic_auth(username, password=password)}
         self._endpoint = f"http://{host}:{str(port)}"  # Sensitive
 
     async def _request(
@@ -53,36 +53,32 @@ class SmileComm:
         data: str | None = None,
     ) -> etree.Element:
         """Get/put/delete data from a give URL."""
-        resp: ClientResponse
+        resp: aiohttp.ClientResponse
         url = f"{self._endpoint}{command}"
         try:
             match method:
                 case "delete":
-                    resp = await self._websession.delete(url, auth=self._auth)
+                    resp = await self._websession.delete(url, headers=self._base_header)
                 case "get":
                     # Work-around for Stretchv2, should not hurt the other smiles
-                    headers = {"Accept-Encoding": "gzip"}
-                    resp = await self._websession.get(
-                        url, headers=headers, auth=self._auth
-                    )
+                    headers = {**self._base_header, "Accept-Encoding": "gzip"}
+                    resp = await self._websession.get(url, headers=headers)
                 case "post":
-                    headers = {"Content-type": "text/xml"}
+                    headers = {**self._base_header, "Content-type": "text/xml"}
                     resp = await self._websession.post(
                         url,
                         headers=headers,
                         data=data,
-                        auth=self._auth,
                     )
                 case "put":
-                    headers = {"Content-type": "text/xml"}
+                    headers = {**self._base_header, "Content-type": "text/xml"}
                     resp = await self._websession.put(
                         url,
                         headers=headers,
                         data=data,
-                        auth=self._auth,
                     )
         except (
-            ClientError
+            aiohttp.ClientError
         ) as exc:  # ClientError is an ancestor class of ServerTimeoutError
             if retry < 1:
                 LOGGER.warning(
@@ -108,7 +104,7 @@ class SmileComm:
         return await self._request_validate(resp, method)
 
     async def _request_validate(
-        self, resp: ClientResponse, method: str
+        self, resp: aiohttp.ClientResponse, method: str
     ) -> etree.Element:
         """Helper-function for _request(): validate the returned data."""
         match resp.status:

--- a/plugwise/smilecomm.py
+++ b/plugwise/smilecomm.py
@@ -15,7 +15,13 @@ from plugwise.exceptions import (
 from plugwise.util import escape_illegal_xml_characters
 
 # This way of importing aiohttp is because of patch/mocking in testing (aiohttp timeouts)
-import aiohttp
+from aiohttp import (
+    ClientError,
+    ClientResponse,
+    ClientSession,
+    ClientTimeout,
+    encode_basic_auth,
+)
 from defusedxml import ElementTree as etree
 
 
@@ -29,12 +35,12 @@ class SmileComm:
         port: int,
         timeout: int,
         username: str,
-        websession: aiohttp.ClientSession | None,
+        websession: ClientSession | None,
     ) -> None:
         """Set the constructor for this class."""
         if not websession:
-            aio_timeout = aiohttp.ClientTimeout(total=timeout)
-            self._websession = aiohttp.ClientSession(timeout=aio_timeout)
+            aio_timeout = ClientTimeout(total=timeout)
+            self._websession = ClientSession(timeout=aio_timeout)
         else:
             self._websession = websession
 
@@ -43,7 +49,7 @@ class SmileComm:
             host = f"[{host}]"
 
         self._base_header = {
-            "Authorization": aiohttp.encode_basic_auth(username, password=password)
+            "Authorization": encode_basic_auth(username, password=password)
         }
         self._endpoint = f"http://{host}:{str(port)}"  # Sensitive
 
@@ -55,7 +61,7 @@ class SmileComm:
         data: str | None = None,
     ) -> etree.Element:
         """Get/put/delete data from a give URL."""
-        resp: aiohttp.ClientResponse
+        resp: ClientResponse
         url = f"{self._endpoint}{command}"
         try:
             match method:
@@ -80,7 +86,7 @@ class SmileComm:
                         data=data,
                     )
         except (
-            aiohttp.ClientError
+            ClientError
         ) as exc:  # ClientError is an ancestor class of ServerTimeoutError
             if retry < 1:
                 LOGGER.warning(
@@ -106,7 +112,7 @@ class SmileComm:
         return await self._request_validate(resp, method)
 
     async def _request_validate(
-        self, resp: aiohttp.ClientResponse, method: str
+        self, resp: ClientResponse, method: str
     ) -> etree.Element:
         """Helper-function for _request(): validate the returned data."""
         match resp.status:

--- a/plugwise/smilecomm.py
+++ b/plugwise/smilecomm.py
@@ -42,7 +42,9 @@ class SmileComm:
         if host.count(":") > 2:  # pragma: no cover
             host = f"[{host}]"
 
-        self._base_header = {"Authorization": aiohttp.encode_basic_auth(username, password=password)}
+        self._base_header = {
+            "Authorization": aiohttp.encode_basic_auth(username, password=password)
+        }
         self._endpoint = f"http://{host}:{str(port)}"  # Sensitive
 
     async def _request(

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,7 +27,7 @@ maintainers = [
 requires-python = ">=3.13"
 dependencies    = [
         "aiofiles",
-        "aiohttp",
+        "aiohttp>=3.14",
         "defusedxml",
         "munch",
         "python-dateutil",

--- a/tests/test_generic.py
+++ b/tests/test_generic.py
@@ -48,7 +48,7 @@ class TestPlugwiseGeneric(TestPlugwise):  # pylint: disable=attribute-defined-ou
 
     # Test connect for timeout
     @patch(
-        "plugwise.smilecomm.ClientSession.get",
+        "plugwise.smilecomm.aiohttp.ClientSession.get",
         side_effect=aiohttp.ServerTimeoutError,
     )
     @pytest.mark.asyncio

--- a/tests/test_generic.py
+++ b/tests/test_generic.py
@@ -48,7 +48,7 @@ class TestPlugwiseGeneric(TestPlugwise):  # pylint: disable=attribute-defined-ou
 
     # Test connect for timeout
     @patch(
-        "plugwise.smilecomm.aiohttp.ClientSession.get",
+        "plugwise.smilecomm.ClientSession.get",
         side_effect=aiohttp.ServerTimeoutError,
     )
     @pytest.mark.asyncio


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved SmileComm HTTP compatibility by replacing deprecated BasicAuth usage with a reusable Authorization header.
  * Updated request handling for common HTTP methods, including adjusted Accept-Encoding and Content-Type headers.

* **Chores**
  * Tightened the aiohttp requirement to version 3.14+.
  * Refreshed the changelog to note the BasicAuth deprecation fix.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->