### PR TITLE
Implement boiler_temperature dict for legacy Anna

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## Ongoing
 
-- Implement dedicated boiler_temperature dict for legacy Anna
+- Implement dedicated boiler_temperature dict for legacy Anna via PR [#893](https://github.com/plugwise/python-plugwise/pull/893)
 
 ## v1.13.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## Ongoing
+
+- Implement dedicated boiler_temperature dict for legacy Anna
+
 ## v1.13.0
 
 - Improve on v1.12.0 update by outputting dedicated boiler_ and dhw_temperature dicts with current-key added. Rename dhw_mode off to eco for standard cv-heaters.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## Ongoing
+## v1.13.1
 
 - Implement dedicated boiler_temperature dict for legacy Anna via PR [#893](https://github.com/plugwise/python-plugwise/pull/893)
 

--- a/fixtures/legacy_anna/data.json
+++ b/fixtures/legacy_anna/data.json
@@ -13,14 +13,15 @@
       "flame_state": true,
       "heating_state": true
     },
-    "dev_class": "heater_central",
-    "location": "0000aaaa0000aaaa0000aaaa0000aa00",
-    "maximum_boiler_temperature": {
+    "boiler_temperature": {
+      "current": 23.6,
       "lower_bound": 50.0,
       "resolution": 1.0,
       "setpoint": 50.0,
       "upper_bound": 90.0
     },
+    "dev_class": "heater_central",
+    "location": "0000aaaa0000aaaa0000aaaa0000aa00",
     "model": "Generic heater",
     "name": "OpenTherm",
     "sensors": {
@@ -28,8 +29,7 @@
       "intended_boiler_temperature": 17.0,
       "modulation_level": 0.0,
       "return_temperature": 21.7,
-      "water_pressure": 1.2,
-      "water_temperature": 23.6
+      "water_pressure": 1.2
     },
     "vendor": "Bosch Thermotechniek B.V."
   },

--- a/fixtures/legacy_anna_2/data.json
+++ b/fixtures/legacy_anna_2/data.json
@@ -51,14 +51,15 @@
       "flame_state": false,
       "heating_state": false
     },
-    "dev_class": "heater_central",
-    "location": "be81e3f8275b4129852c4d8d550ae2eb",
-    "maximum_boiler_temperature": {
+    "boiler_temperature": {
+      "current": 54.0,
       "lower_bound": 50.0,
       "resolution": 1.0,
       "setpoint": 70.0,
       "upper_bound": 90.0
     },
+    "dev_class": "heater_central",
+    "location": "be81e3f8275b4129852c4d8d550ae2eb",
     "model": "Generic heater",
     "name": "OpenTherm",
     "sensors": {
@@ -66,8 +67,7 @@
       "intended_boiler_temperature": 0.0,
       "modulation_level": 0.0,
       "return_temperature": 0.0,
-      "water_pressure": 1.7,
-      "water_temperature": 54.0
+      "water_pressure": 1.7
     }
   }
 }

--- a/plugwise/common.py
+++ b/plugwise/common.py
@@ -9,11 +9,13 @@ from typing import cast
 
 from plugwise.constants import (
     ANNA,
+    DHW_SETPOINT,
     GROUP_TYPES,
     NONE,
     PRIORITY_DEVICE_CLASSES,
     SPECIAL_PLUG_TYPES,
     SWITCH_GROUP_TYPES,
+    ActuatorData,
     ApplianceType,
     GwEntityData,
     ModuleData,
@@ -289,3 +291,31 @@ class SmileCommon:
             break
 
         return module_data
+
+    def _create_special_dicts(
+        self, item: str, data: GwEntityData, temp_dict: ActuatorData
+    ) -> tuple[str, ActuatorData]:
+        """Create dhw_temperature and boiler_temperature dicts.
+
+        The initial item-names are updated and a current key is added.
+        Also, the copied sensor data is removed.
+        """
+        if item == DHW_SETPOINT:
+            item = "dhw_temperature"
+            if DHW_SETPOINT in data["sensors"]:
+                data["sensors"].pop(DHW_SETPOINT)
+                self._count -= 1
+            if "dhw_temperature" in data["sensors"]:
+                temp_dict["current"] = data["sensors"]["dhw_temperature"]
+                data["sensors"].pop("dhw_temperature")
+            elif "water_temperature" in data["sensors"]:
+                temp_dict["current"] = data["sensors"]["water_temperature"]
+                self._count += 1
+
+        if item == "maximum_boiler_temperature":
+            item = "boiler_temperature"
+            if "water_temperature" in data["sensors"]:
+                temp_dict["current"] = data["sensors"]["water_temperature"]
+                data["sensors"].pop("water_temperature")
+
+        return item, temp_dict

--- a/plugwise/helper.py
+++ b/plugwise/helper.py
@@ -18,7 +18,6 @@ from plugwise.constants import (
     ATTR_NAME,
     DATA,
     DEVICE_MEASUREMENTS,
-    DHW_SETPOINT,
     DOMAIN_OBJECTS,
     ENERGY_WATT_HOUR,
     GROUP_MEASUREMENTS,
@@ -586,34 +585,6 @@ class SmileHelper(SmileCommon):
                 item, temp_dict = self._create_special_dicts(item, data, temp_dict)
                 act_item = cast(ActuatorType, item)
                 data[act_item] = temp_dict
-
-    def _create_special_dicts(
-        self, item: str, data: GwEntityData, temp_dict: ActuatorData
-    ) -> tuple[str, ActuatorData]:
-        """Create dhw_temperature and boiler_temperature dicts.
-
-        The initial item-names are updated and a current key is added.
-        Also, the copied sensor data is removed.
-        """
-        if item == DHW_SETPOINT:
-            item = "dhw_temperature"
-            if DHW_SETPOINT in data["sensors"]:
-                data["sensors"].pop(DHW_SETPOINT)
-                self._count -= 1
-            if "dhw_temperature" in data["sensors"]:
-                temp_dict["current"] = data["sensors"]["dhw_temperature"]
-                data["sensors"].pop("dhw_temperature")
-            elif "water_temperature" in data["sensors"]:
-                temp_dict["current"] = data["sensors"]["water_temperature"]
-                self._count += 1
-
-        if item == "maximum_boiler_temperature":
-            item = "boiler_temperature"
-            if "water_temperature" in data["sensors"]:
-                temp_dict["current"] = data["sensors"]["water_temperature"]
-                data["sensors"].pop("water_temperature")
-
-        return item, temp_dict
 
     def _get_actuator_mode(
         self, appliance: etree.Element, entity_id: str, key: str

--- a/plugwise/legacy/helper.py
+++ b/plugwise/legacy/helper.py
@@ -366,12 +366,7 @@ class SmileLegacyHelper(SmileCommon):
                     self._count += 1
 
             if temp_dict:
-                if item == "maximum_boiler_temperature":
-                    item = "boiler_temperature"
-                if "water_temperature" in data["sensors"]:
-                    temp_dict["current"] = data["sensors"]["water_temperature"]
-                    data["sensors"].pop("water_temperature")
-
+                item, temp_dict = self._create_special_dicts(item, data, temp_dict)
                 act_item = cast(ActuatorType, item)
                 data[act_item] = temp_dict
 

--- a/plugwise/legacy/helper.py
+++ b/plugwise/legacy/helper.py
@@ -341,7 +341,9 @@ class SmileLegacyHelper(SmileCommon):
 
         self._count = count_data_items(self._count, data)
 
-    def _get_actuator_functionalities(self, xml: etree.Element, data: GwEntityData) -> None:
+    def _get_actuator_functionalities(
+        self, xml: etree.Element, data: GwEntityData
+    ) -> None:
         """Helper-function for _get_measurement_data()."""
         for item in ACTIVE_ACTUATORS:
             temp_dict: ActuatorData = {}

--- a/plugwise/legacy/helper.py
+++ b/plugwise/legacy/helper.py
@@ -364,6 +364,12 @@ class SmileLegacyHelper(SmileCommon):
                     self._count += 1
 
             if temp_dict:
+                if item == "maximum_boiler_temperature":
+                    item = "boiler_temperature"
+                if "water_temperature" in data["sensors"]:
+                    temp_dict["current"] = data["sensors"]["water_temperature"]
+                    data["sensors"].pop("water_temperature")
+
                 act_item = cast(ActuatorType, item)
                 data[act_item] = temp_dict
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name            = "plugwise"
-version         = "1.13.0"
+version         = "1.13.1"
 license         = "MIT"
 description     = "Plugwise Smile (Adam/Anna/P1) and Stretch module for Python 3."
 readme          = "README.md"

--- a/tests/data/anna/legacy_anna.json
+++ b/tests/data/anna/legacy_anna.json
@@ -13,14 +13,15 @@
       "flame_state": true,
       "heating_state": true
     },
-    "dev_class": "heater_central",
-    "location": "0000aaaa0000aaaa0000aaaa0000aa00",
-    "maximum_boiler_temperature": {
+    "boiler_temperature": {
+      "current": 23.6,
       "lower_bound": 50.0,
       "resolution": 1.0,
       "setpoint": 50.0,
       "upper_bound": 90.0
     },
+    "dev_class": "heater_central",
+    "location": "0000aaaa0000aaaa0000aaaa0000aa00",
     "model": "Generic heater",
     "name": "OpenTherm",
     "sensors": {
@@ -28,8 +29,7 @@
       "intended_boiler_temperature": 17.0,
       "modulation_level": 0.0,
       "return_temperature": 21.7,
-      "water_pressure": 1.2,
-      "water_temperature": 23.6
+      "water_pressure": 1.2
     },
     "vendor": "Bosch Thermotechniek B.V."
   },
@@ -44,7 +44,13 @@
     "location": "0000aaaa0000aaaa0000aaaa0000aa00",
     "model": "ThermoTouch",
     "name": "Anna",
-    "preset_modes": ["away", "vacation", "asleep", "home", "no_frost"],
+    "preset_modes": [
+      "away",
+      "vacation",
+      "asleep",
+      "home",
+      "no_frost"
+    ],
     "select_schedule": null,
     "sensors": {
       "illuminance": 150.8,

--- a/tests/data/anna/legacy_anna_2.json
+++ b/tests/data/anna/legacy_anna_2.json
@@ -1,7 +1,10 @@
 {
   "9e7377867dc24e51b8098a5ba02bd89d": {
     "active_preset": null,
-    "available_schedules": ["Thermostat schedule", "off"],
+    "available_schedules": [
+      "Thermostat schedule",
+      "off"
+    ],
     "climate_mode": "heat",
     "control_state": "idle",
     "dev_class": "thermostat",
@@ -10,7 +13,13 @@
     "location": "be81e3f8275b4129852c4d8d550ae2eb",
     "model": "ThermoTouch",
     "name": "Anna",
-    "preset_modes": ["vacation", "away", "no_frost", "home", "asleep"],
+    "preset_modes": [
+      "vacation",
+      "away",
+      "no_frost",
+      "home",
+      "asleep"
+    ],
     "select_schedule": "off",
     "sensors": {
       "illuminance": 19.5,
@@ -42,14 +51,15 @@
       "flame_state": false,
       "heating_state": false
     },
-    "dev_class": "heater_central",
-    "location": "be81e3f8275b4129852c4d8d550ae2eb",
-    "maximum_boiler_temperature": {
+    "boiler_temperature": {
+      "current": 54.0,
       "lower_bound": 50.0,
       "resolution": 1.0,
       "setpoint": 70.0,
       "upper_bound": 90.0
     },
+    "dev_class": "heater_central",
+    "location": "be81e3f8275b4129852c4d8d550ae2eb",
     "model": "Generic heater",
     "name": "OpenTherm",
     "sensors": {
@@ -57,8 +67,7 @@
       "intended_boiler_temperature": 0.0,
       "modulation_level": 0.0,
       "return_temperature": 0.0,
-      "water_pressure": 1.7,
-      "water_temperature": 54.0
+      "water_pressure": 1.7
     }
   }
 }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Enhanced legacy Anna heater telemetry parsing by consolidating water/boiler temperature into a single `boiler_temperature` structure that includes a live `current` value.
* **Bug Fixes**
  * Normalized legacy payloads so temperature readings no longer appear redundantly in the sensors map when represented in the consolidated structure.
* **Tests**
  * Updated legacy Anna test fixtures to match the revised temperature payload shape and formatting.
* **Chores**
  * Bumped the package version and updated the changelog entry for this release.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->