### PR TITLE
Include both old and new entities for a step-wise introduction of water_heaters in HA

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## v1.14.0
+
+- Include both old and new entities for a step-wise introduction of water_heaters in HA via PR [#895](https://github.com/plugwise/python-plugwise/pull/895):
+  - Keep the `dhw_cm_switch` and add the `dhw_modes list` and the `select_dhw_mode` string that will replace the `dhw_cm_switch` in the future
+  - `dhw_cm_switch` = `on` --> `select_dhw_mode` = `comfort`, `dhw_cm_switch` = `off` --> `select_dhw_mode` = `eco`
+  - Add a `current` (`temperature`) key to the `maximum_boiler_temperature` and `max_dhw_temperature` dicts
+
 ## v1.13.1
 
 - Implement dedicated boiler_temperature dict for legacy Anna via PR [#893](https://github.com/plugwise/python-plugwise/pull/893)

--- a/fixtures/adam_bad_thermostat/data.json
+++ b/fixtures/adam_bad_thermostat/data.json
@@ -6,27 +6,27 @@
       "flame_state": false,
       "heating_state": false
     },
-    "boiler_temperature": {
-      "current": 20.9,
-      "lower_bound": 25.0,
-      "resolution": 0.01,
-      "setpoint": 38.0,
-      "upper_bound": 45.0
-    },
     "dev_class": "heater_central",
     "dhw_mode": "eco",
     "dhw_modes": [
       "comfort",
       "eco"
     ],
-    "dhw_temperature": {
+    "location": "856285a783f24bf4b2573c8bc510eabf",
+    "max_dhw_temperature": {
       "current": 49.9,
       "lower_bound": 0.0,
       "resolution": 1.0,
       "setpoint": 50.0,
       "upper_bound": 100.0
     },
-    "location": "856285a783f24bf4b2573c8bc510eabf",
+    "maximum_boiler_temperature": {
+      "current": 20.9,
+      "lower_bound": 25.0,
+      "resolution": 0.01,
+      "setpoint": 38.0,
+      "upper_bound": 45.0
+    },
     "model": "Generic heater",
     "model_id": "1.1",
     "name": "OpenTherm",
@@ -34,7 +34,11 @@
       "intended_boiler_temperature": 0.0,
       "modulation_level": 0.0,
       "outdoor_air_temperature": 13.6,
-      "return_temperature": 33.0
+      "return_temperature": 33.0,
+      "water_temperature": 20.9
+    },
+    "switches": {
+      "dhw_cm_switch": false
     },
     "vendor": "WeHeat"
   },

--- a/fixtures/adam_bad_thermostat/data.json
+++ b/fixtures/adam_bad_thermostat/data.json
@@ -31,6 +31,7 @@
     "model_id": "1.1",
     "name": "OpenTherm",
     "sensors": {
+      "dhw_temperature": 49.9,
       "intended_boiler_temperature": 0.0,
       "modulation_level": 0.0,
       "outdoor_air_temperature": 13.6,

--- a/fixtures/adam_heatpump_cooling/data.json
+++ b/fixtures/adam_heatpump_cooling/data.json
@@ -54,27 +54,27 @@
       "flame_state": false,
       "heating_state": false
     },
-    "boiler_temperature": {
-      "current": 24.5,
-      "lower_bound": 7.0,
-      "resolution": 0.01,
-      "setpoint": 35.0,
-      "upper_bound": 50.0
-    },
     "dev_class": "heater_central",
     "dhw_mode": "comfort",
     "dhw_modes": [
       "comfort",
       "eco"
     ],
-    "dhw_temperature": {
+    "location": "eedadcb297564f1483faa509179aebed",
+    "max_dhw_temperature": {
       "current": 63.5,
       "lower_bound": 40.0,
       "resolution": 0.01,
       "setpoint": 60.0,
       "upper_bound": 65.0
     },
-    "location": "eedadcb297564f1483faa509179aebed",
+    "maximum_boiler_temperature": {
+      "current": 24.5,
+      "lower_bound": 7.0,
+      "resolution": 0.01,
+      "setpoint": 35.0,
+      "upper_bound": 50.0
+    },
     "model": "Generic heater/cooler",
     "model_id": "17.1",
     "name": "OpenTherm",
@@ -83,7 +83,11 @@
       "modulation_level": 0.0,
       "outdoor_air_temperature": 13.5,
       "return_temperature": 24.9,
-      "water_pressure": 2.0
+      "water_pressure": 2.0,
+      "water_temperature": 24.5
+    },
+    "switches": {
+      "dhw_cm_switch": true
     },
     "vendor": "Remeha B.V."
   },

--- a/fixtures/adam_heatpump_cooling/data.json
+++ b/fixtures/adam_heatpump_cooling/data.json
@@ -79,6 +79,7 @@
     "model_id": "17.1",
     "name": "OpenTherm",
     "sensors": {
+      "dhw_temperature": 63.5,
       "intended_boiler_temperature": 0.0,
       "modulation_level": 0.0,
       "outdoor_air_temperature": 13.5,

--- a/fixtures/adam_jip/data.json
+++ b/fixtures/adam_jip/data.json
@@ -393,27 +393,27 @@
       "flame_state": false,
       "heating_state": false
     },
-    "boiler_temperature": {
-      "current": 37.3,
-      "lower_bound": 20.0,
-      "resolution": 0.01,
-      "setpoint": 90.0,
-      "upper_bound": 90.0
-    },
     "dev_class": "heater_central",
     "dhw_mode": "eco",
     "dhw_modes": [
       "comfort",
       "eco"
     ],
-    "dhw_temperature": {
+    "location": "9e4433a9d69f40b3aefd15e74395eaec",
+    "max_dhw_temperature": {
       "current": 37.3,
       "lower_bound": 40.0,
       "resolution": 0.01,
       "setpoint": 60.0,
       "upper_bound": 60.0
     },
-    "location": "9e4433a9d69f40b3aefd15e74395eaec",
+    "maximum_boiler_temperature": {
+      "current": 37.3,
+      "lower_bound": 20.0,
+      "resolution": 0.01,
+      "setpoint": 90.0,
+      "upper_bound": 90.0
+    },
     "model": "Generic heater",
     "model_id": "10.20",
     "name": "OpenTherm",
@@ -421,7 +421,11 @@
       "intended_boiler_temperature": 0.0,
       "modulation_level": 0.0,
       "return_temperature": 37.1,
-      "water_pressure": 1.4
+      "water_pressure": 1.4,
+      "water_temperature": 37.3
+    },
+    "switches": {
+      "dhw_cm_switch": false
     },
     "vendor": "Remeha B.V."
   },

--- a/fixtures/adam_onoff_cooling_fake_firmware/data.json
+++ b/fixtures/adam_onoff_cooling_fake_firmware/data.json
@@ -31,6 +31,7 @@
     "model": "Unknown",
     "name": "OnOff",
     "sensors": {
+      "dhw_temperature": 63.5,
       "intended_boiler_temperature": 0.0,
       "modulation_level": 0.0,
       "outdoor_air_temperature": 13.5,

--- a/fixtures/adam_onoff_cooling_fake_firmware/data.json
+++ b/fixtures/adam_onoff_cooling_fake_firmware/data.json
@@ -7,27 +7,27 @@
       "flame_state": false,
       "heating_state": false
     },
-    "boiler_temperature": {
-      "current": 24.5,
-      "lower_bound": 7.0,
-      "resolution": 0.01,
-      "setpoint": 35.0,
-      "upper_bound": 50.0
-    },
     "dev_class": "heater_central",
     "dhw_mode": "comfort",
     "dhw_modes": [
       "comfort",
       "eco"
     ],
-    "dhw_temperature": {
+    "location": "eedadcb297564f1483faa509179aebed",
+    "max_dhw_temperature": {
       "current": 63.5,
       "lower_bound": 40.0,
       "resolution": 0.01,
       "setpoint": 60.0,
       "upper_bound": 65.0
     },
-    "location": "eedadcb297564f1483faa509179aebed",
+    "maximum_boiler_temperature": {
+      "current": 24.5,
+      "lower_bound": 7.0,
+      "resolution": 0.01,
+      "setpoint": 35.0,
+      "upper_bound": 50.0
+    },
     "model": "Unknown",
     "name": "OnOff",
     "sensors": {
@@ -35,7 +35,11 @@
       "modulation_level": 0.0,
       "outdoor_air_temperature": 13.5,
       "return_temperature": 24.9,
-      "water_pressure": 2.0
+      "water_pressure": 2.0,
+      "water_temperature": 24.5
+    },
+    "switches": {
+      "dhw_cm_switch": true
     }
   },
   "7d97fc3117784cfdafe347bcedcbbbcb": {

--- a/fixtures/adam_plus_anna/data.json
+++ b/fixtures/adam_plus_anna/data.json
@@ -44,24 +44,28 @@
       "flame_state": false,
       "heating_state": false
     },
-    "boiler_temperature": {
-      "current": 48.0,
-      "lower_bound": 0.0,
-      "resolution": 1.0,
-      "setpoint": 80.0,
-      "upper_bound": 100.0
-    },
     "dev_class": "heater_central",
     "dhw_modes": [
       "comfort",
       "eco"
     ],
     "location": "07d618f0bb80412687f065b8698ce3e7",
+    "maximum_boiler_temperature": {
+      "current": 48.0,
+      "lower_bound": 0.0,
+      "resolution": 1.0,
+      "setpoint": 80.0,
+      "upper_bound": 100.0
+    },
     "model": "Generic heater",
     "name": "OpenTherm",
     "select_dhw_mode": "eco",
     "sensors": {
-      "intended_boiler_temperature": 0.0
+      "intended_boiler_temperature": 0.0,
+      "water_temperature": 48.0
+    },
+    "switches": {
+      "dhw_cm_switch": false
     }
   },
   "aa6b0002df0a46e1b1eb94beb61eddfe": {

--- a/fixtures/adam_plus_anna_new/data.json
+++ b/fixtures/adam_plus_anna_new/data.json
@@ -6,24 +6,28 @@
       "flame_state": true,
       "heating_state": true
     },
-    "boiler_temperature": {
-      "current": 43.0,
-      "lower_bound": 25.0,
-      "resolution": 0.01,
-      "setpoint": 50.0,
-      "upper_bound": 95.0
-    },
     "dev_class": "heater_central",
     "dhw_modes": [
       "comfort",
       "eco"
     ],
     "location": "bc93488efab249e5bc54fd7e175a6f91",
+    "maximum_boiler_temperature": {
+      "current": 43.0,
+      "lower_bound": 25.0,
+      "resolution": 0.01,
+      "setpoint": 50.0,
+      "upper_bound": 95.0
+    },
     "model": "Generic heater",
     "name": "OpenTherm",
     "select_dhw_mode": "eco",
     "sensors": {
-      "intended_boiler_temperature": 22.5
+      "intended_boiler_temperature": 22.5,
+      "water_temperature": 43.0
+    },
+    "switches": {
+      "dhw_cm_switch": false
     }
   },
   "10016900610d4c7481df78c89606ef22": {

--- a/fixtures/adam_plus_anna_new_regulation_off/data.json
+++ b/fixtures/adam_plus_anna_new_regulation_off/data.json
@@ -6,24 +6,28 @@
       "flame_state": false,
       "heating_state": false
     },
-    "boiler_temperature": {
-      "current": 30.0,
-      "lower_bound": 25.0,
-      "resolution": 0.01,
-      "setpoint": 50.0,
-      "upper_bound": 95.0
-    },
     "dev_class": "heater_central",
     "dhw_modes": [
       "comfort",
       "eco"
     ],
     "location": "bc93488efab249e5bc54fd7e175a6f91",
+    "maximum_boiler_temperature": {
+      "current": 30.0,
+      "lower_bound": 25.0,
+      "resolution": 0.01,
+      "setpoint": 50.0,
+      "upper_bound": 95.0
+    },
     "model": "Generic heater",
     "name": "OpenTherm",
     "select_dhw_mode": "eco",
     "sensors": {
-      "intended_boiler_temperature": 0.0
+      "intended_boiler_temperature": 0.0,
+      "water_temperature": 30.0
+    },
+    "switches": {
+      "dhw_cm_switch": false
     }
   },
   "10016900610d4c7481df78c89606ef22": {

--- a/fixtures/anna_elga_2/data.json
+++ b/fixtures/anna_elga_2/data.json
@@ -28,6 +28,9 @@
       "water_pressure": 0.5,
       "water_temperature": 42.6
     },
+    "switches": {
+      "dhw_cm_switch": false
+    },
     "vendor": "Techneco"
   },
   "ebd90df1ab334565b5895f37590ccff4": {

--- a/fixtures/anna_elga_2_cooling/data.json
+++ b/fixtures/anna_elga_2_cooling/data.json
@@ -10,19 +10,19 @@
       "heating_state": false,
       "secondary_boiler_state": false
     },
-    "boiler_temperature": {
-      "current": 22.8,
-      "lower_bound": 0.0,
-      "resolution": 1.0,
-      "setpoint": 60.0,
-      "upper_bound": 100.0
-    },
     "dev_class": "heater_central",
     "dhw_modes": [
       "comfort",
       "eco"
     ],
     "location": "d34dfe6ab90b410c98068e75de3eb631",
+    "maximum_boiler_temperature": {
+      "current": 22.8,
+      "lower_bound": 0.0,
+      "resolution": 1.0,
+      "setpoint": 60.0,
+      "upper_bound": 100.0
+    },
     "model": "Generic heater/cooler",
     "name": "OpenTherm",
     "select_dhw_mode": "comfort",
@@ -32,7 +32,11 @@
       "modulation_level": 0.0,
       "outdoor_air_temperature": 30.0,
       "return_temperature": 23.4,
-      "water_pressure": 0.5
+      "water_pressure": 0.5,
+      "water_temperature": 22.8
+    },
+    "switches": {
+      "dhw_cm_switch": true
     },
     "vendor": "Techneco"
   },

--- a/fixtures/anna_elga_2_schedule_off/data.json
+++ b/fixtures/anna_elga_2_schedule_off/data.json
@@ -10,19 +10,19 @@
       "heating_state": false,
       "secondary_boiler_state": false
     },
-    "boiler_temperature": {
-      "current": 22.8,
-      "lower_bound": 0.0,
-      "resolution": 1.0,
-      "setpoint": 60.0,
-      "upper_bound": 100.0
-    },
     "dev_class": "heater_central",
     "dhw_modes": [
       "comfort",
       "eco"
     ],
     "location": "d34dfe6ab90b410c98068e75de3eb631",
+    "maximum_boiler_temperature": {
+      "current": 22.8,
+      "lower_bound": 0.0,
+      "resolution": 1.0,
+      "setpoint": 60.0,
+      "upper_bound": 100.0
+    },
     "model": "Generic heater/cooler",
     "name": "OpenTherm",
     "select_dhw_mode": "comfort",
@@ -32,7 +32,11 @@
       "modulation_level": 0.0,
       "outdoor_air_temperature": 13.0,
       "return_temperature": 23.4,
-      "water_pressure": 0.5
+      "water_pressure": 0.5,
+      "water_temperature": 22.8
+    },
+    "switches": {
+      "dhw_cm_switch": true
     },
     "vendor": "Techneco"
   },

--- a/fixtures/anna_elga_no_cooling/data.json
+++ b/fixtures/anna_elga_no_cooling/data.json
@@ -26,27 +26,27 @@
       "heating_state": true,
       "secondary_boiler_state": false
     },
-    "boiler_temperature": {
-      "current": 29.1,
-      "lower_bound": 0.0,
-      "resolution": 1.0,
-      "setpoint": 60.0,
-      "upper_bound": 100.0
-    },
     "dev_class": "heater_central",
     "dhw_mode": "eco",
     "dhw_modes": [
       "comfort",
       "eco"
     ],
-    "dhw_temperature": {
+    "location": "a57efe5f145f498c9be62a9b63626fbf",
+    "max_dhw_temperature": {
       "current": 46.3,
       "lower_bound": 35.0,
       "resolution": 0.01,
       "setpoint": 53.0,
       "upper_bound": 60.0
     },
-    "location": "a57efe5f145f498c9be62a9b63626fbf",
+    "maximum_boiler_temperature": {
+      "current": 29.1,
+      "lower_bound": 0.0,
+      "resolution": 1.0,
+      "setpoint": 60.0,
+      "upper_bound": 100.0
+    },
     "model": "Generic heater",
     "name": "OpenTherm",
     "sensors": {
@@ -54,7 +54,11 @@
       "modulation_level": 52,
       "outdoor_air_temperature": 3.0,
       "return_temperature": 25.1,
-      "water_pressure": 1.57
+      "water_pressure": 1.57,
+      "water_temperature": 29.1
+    },
+    "switches": {
+      "dhw_cm_switch": false
     },
     "vendor": "Techneco"
   },

--- a/fixtures/anna_elga_no_cooling/data.json
+++ b/fixtures/anna_elga_no_cooling/data.json
@@ -50,6 +50,7 @@
     "model": "Generic heater",
     "name": "OpenTherm",
     "sensors": {
+      "dhw_temperature": 46.3,
       "intended_boiler_temperature": 35.0,
       "modulation_level": 52,
       "outdoor_air_temperature": 3.0,

--- a/fixtures/anna_heatpump_cooling/data.json
+++ b/fixtures/anna_heatpump_cooling/data.json
@@ -28,19 +28,19 @@
       "heating_state": false,
       "secondary_boiler_state": false
     },
-    "boiler_temperature": {
-      "current": 24.7,
-      "lower_bound": 0.0,
-      "resolution": 1.0,
-      "setpoint": 60.0,
-      "upper_bound": 100.0
-    },
     "dev_class": "heater_central",
     "dhw_modes": [
       "comfort",
       "eco"
     ],
     "location": "a57efe5f145f498c9be62a9b63626fbf",
+    "maximum_boiler_temperature": {
+      "current": 24.7,
+      "lower_bound": 0.0,
+      "resolution": 1.0,
+      "setpoint": 60.0,
+      "upper_bound": 100.0
+    },
     "model": "Generic heater/cooler",
     "name": "OpenTherm",
     "select_dhw_mode": "eco",
@@ -51,7 +51,11 @@
       "modulation_level": 40,
       "outdoor_air_temperature": 22.0,
       "return_temperature": 23.8,
-      "water_pressure": 1.61
+      "water_pressure": 1.61,
+      "water_temperature": 24.7
+    },
+    "switches": {
+      "dhw_cm_switch": false
     },
     "vendor": "Techneco"
   },

--- a/fixtures/anna_heatpump_cooling_fake_firmware/data.json
+++ b/fixtures/anna_heatpump_cooling_fake_firmware/data.json
@@ -28,19 +28,19 @@
       "heating_state": false,
       "secondary_boiler_state": false
     },
-    "boiler_temperature": {
-      "current": 24.7,
-      "lower_bound": 0.0,
-      "resolution": 1.0,
-      "setpoint": 60.0,
-      "upper_bound": 100.0
-    },
     "dev_class": "heater_central",
     "dhw_modes": [
       "comfort",
       "eco"
     ],
     "location": "a57efe5f145f498c9be62a9b63626fbf",
+    "maximum_boiler_temperature": {
+      "current": 24.7,
+      "lower_bound": 0.0,
+      "resolution": 1.0,
+      "setpoint": 60.0,
+      "upper_bound": 100.0
+    },
     "model": "Generic heater/cooler",
     "name": "OpenTherm",
     "select_dhw_mode": "eco",
@@ -51,7 +51,11 @@
       "modulation_level": 100,
       "outdoor_air_temperature": 22.0,
       "return_temperature": 23.8,
-      "water_pressure": 1.61
+      "water_pressure": 1.61,
+      "water_temperature": 24.7
+    },
+    "switches": {
+      "dhw_cm_switch": false
     },
     "vendor": "Techneco"
   },

--- a/fixtures/anna_heatpump_heating/data.json
+++ b/fixtures/anna_heatpump_heating/data.json
@@ -52,6 +52,7 @@
     "model": "Generic heater/cooler",
     "name": "OpenTherm",
     "sensors": {
+      "dhw_temperature": 46.3,
       "intended_boiler_temperature": 35.0,
       "modulation_level": 52,
       "outdoor_air_temperature": 3.0,

--- a/fixtures/anna_heatpump_heating/data.json
+++ b/fixtures/anna_heatpump_heating/data.json
@@ -28,27 +28,27 @@
       "heating_state": true,
       "secondary_boiler_state": false
     },
-    "boiler_temperature": {
-      "current": 29.1,
-      "lower_bound": 0.0,
-      "resolution": 1.0,
-      "setpoint": 60.0,
-      "upper_bound": 100.0
-    },
     "dev_class": "heater_central",
     "dhw_mode": "eco",
     "dhw_modes": [
       "comfort",
       "eco"
     ],
-    "dhw_temperature": {
+    "location": "a57efe5f145f498c9be62a9b63626fbf",
+    "max_dhw_temperature": {
       "current": 46.3,
       "lower_bound": 35.0,
       "resolution": 0.01,
       "setpoint": 53.0,
       "upper_bound": 60.0
     },
-    "location": "a57efe5f145f498c9be62a9b63626fbf",
+    "maximum_boiler_temperature": {
+      "current": 29.1,
+      "lower_bound": 0.0,
+      "resolution": 1.0,
+      "setpoint": 60.0,
+      "upper_bound": 100.0
+    },
     "model": "Generic heater/cooler",
     "name": "OpenTherm",
     "sensors": {
@@ -56,7 +56,11 @@
       "modulation_level": 52,
       "outdoor_air_temperature": 3.0,
       "return_temperature": 25.1,
-      "water_pressure": 1.57
+      "water_pressure": 1.57,
+      "water_temperature": 29.1
+    },
+    "switches": {
+      "dhw_cm_switch": false
     },
     "vendor": "Techneco"
   },

--- a/fixtures/anna_loria_cooling_active/data.json
+++ b/fixtures/anna_loria_cooling_active/data.json
@@ -70,13 +70,6 @@
       "flame_state": false,
       "heating_state": false
     },
-    "boiler_temperature": {
-      "current": 25.3,
-      "lower_bound": 25.0,
-      "resolution": 0.01,
-      "setpoint": 40.0,
-      "upper_bound": 45.0
-    },
     "dev_class": "heater_central",
     "dhw_mode": "auto",
     "dhw_modes": [
@@ -86,14 +79,21 @@
       "eco",
       "comfort"
     ],
-    "dhw_temperature": {
+    "location": "674b657c138a41a291d315d7471deb06",
+    "max_dhw_temperature": {
       "current": 52.9,
       "lower_bound": 35.0,
       "resolution": 0.01,
       "setpoint": 53.0,
       "upper_bound": 60.0
     },
-    "location": "674b657c138a41a291d315d7471deb06",
+    "maximum_boiler_temperature": {
+      "current": 25.3,
+      "lower_bound": 25.0,
+      "resolution": 0.01,
+      "setpoint": 40.0,
+      "upper_bound": 45.0
+    },
     "model": "Generic heater/cooler",
     "model_id": "173",
     "name": "OpenTherm",
@@ -101,10 +101,12 @@
       "intended_boiler_temperature": 0.0,
       "modulation_level": 100,
       "outdoor_air_temperature": 17.2,
-      "return_temperature": 26.3
+      "return_temperature": 26.3,
+      "water_temperature": 25.3
     },
     "switches": {
-      "cooling_ena_switch": true
+      "cooling_ena_switch": true,
+      "dhw_cm_switch": true
     },
     "vendor": "Atlantic"
   }

--- a/fixtures/anna_loria_cooling_active/data.json
+++ b/fixtures/anna_loria_cooling_active/data.json
@@ -98,6 +98,7 @@
     "model_id": "173",
     "name": "OpenTherm",
     "sensors": {
+      "dhw_temperature": 52.9,
       "intended_boiler_temperature": 0.0,
       "modulation_level": 100,
       "outdoor_air_temperature": 17.2,

--- a/fixtures/anna_loria_driessens/data.json
+++ b/fixtures/anna_loria_driessens/data.json
@@ -100,6 +100,7 @@
     "model_id": "173",
     "name": "OpenTherm",
     "sensors": {
+      "dhw_temperature": 49.5,
       "intended_boiler_temperature": 0.0,
       "modulation_level": 0.0,
       "outdoor_air_temperature": 7.5,

--- a/fixtures/anna_loria_driessens/data.json
+++ b/fixtures/anna_loria_driessens/data.json
@@ -72,13 +72,6 @@
       "flame_state": false,
       "heating_state": false
     },
-    "boiler_temperature": {
-      "current": 23.3,
-      "lower_bound": 25.0,
-      "resolution": 0.01,
-      "setpoint": 45.0,
-      "upper_bound": 45.0
-    },
     "dev_class": "heater_central",
     "dhw_mode": "auto",
     "dhw_modes": [
@@ -88,14 +81,21 @@
       "boost",
       "auto"
     ],
-    "dhw_temperature": {
+    "location": "82c15f65c9bf44c592d69e16139355e3",
+    "max_dhw_temperature": {
       "current": 49.5,
       "lower_bound": 35.0,
       "resolution": 0.01,
       "setpoint": 53.0,
       "upper_bound": 60.0
     },
-    "location": "82c15f65c9bf44c592d69e16139355e3",
+    "maximum_boiler_temperature": {
+      "current": 23.3,
+      "lower_bound": 25.0,
+      "resolution": 0.01,
+      "setpoint": 45.0,
+      "upper_bound": 45.0
+    },
     "model": "Generic heater/cooler",
     "model_id": "173",
     "name": "OpenTherm",
@@ -103,10 +103,12 @@
       "intended_boiler_temperature": 0.0,
       "modulation_level": 0.0,
       "outdoor_air_temperature": 7.5,
-      "return_temperature": 23.0
+      "return_temperature": 23.0,
+      "water_temperature": 23.3
     },
     "switches": {
-      "cooling_ena_switch": false
+      "cooling_ena_switch": false,
+      "dhw_cm_switch": true
     },
     "vendor": "Atlantic"
   }

--- a/fixtures/anna_loria_heating_idle/data.json
+++ b/fixtures/anna_loria_heating_idle/data.json
@@ -98,6 +98,7 @@
     "model_id": "173",
     "name": "OpenTherm",
     "sensors": {
+      "dhw_temperature": 52.9,
       "intended_boiler_temperature": 0.0,
       "modulation_level": 0.0,
       "outdoor_air_temperature": 17.2,

--- a/fixtures/anna_loria_heating_idle/data.json
+++ b/fixtures/anna_loria_heating_idle/data.json
@@ -70,13 +70,6 @@
       "flame_state": false,
       "heating_state": false
     },
-    "boiler_temperature": {
-      "current": 25.3,
-      "lower_bound": 25.0,
-      "resolution": 0.01,
-      "setpoint": 40.0,
-      "upper_bound": 45.0
-    },
     "dev_class": "heater_central",
     "dhw_mode": "auto",
     "dhw_modes": [
@@ -86,14 +79,21 @@
       "eco",
       "comfort"
     ],
-    "dhw_temperature": {
+    "location": "674b657c138a41a291d315d7471deb06",
+    "max_dhw_temperature": {
       "current": 52.9,
       "lower_bound": 35.0,
       "resolution": 0.01,
       "setpoint": 53.0,
       "upper_bound": 60.0
     },
-    "location": "674b657c138a41a291d315d7471deb06",
+    "maximum_boiler_temperature": {
+      "current": 25.3,
+      "lower_bound": 25.0,
+      "resolution": 0.01,
+      "setpoint": 40.0,
+      "upper_bound": 45.0
+    },
     "model": "Generic heater/cooler",
     "model_id": "173",
     "name": "OpenTherm",
@@ -101,10 +101,12 @@
       "intended_boiler_temperature": 0.0,
       "modulation_level": 0.0,
       "outdoor_air_temperature": 17.2,
-      "return_temperature": 26.3
+      "return_temperature": 26.3,
+      "water_temperature": 25.3
     },
     "switches": {
-      "cooling_ena_switch": false
+      "cooling_ena_switch": false,
+      "dhw_cm_switch": true
     },
     "vendor": "Atlantic"
   }

--- a/fixtures/anna_p1/data.json
+++ b/fixtures/anna_p1/data.json
@@ -63,6 +63,9 @@
       "water_pressure": 6.0,
       "water_temperature": 35.0
     },
+    "switches": {
+      "dhw_cm_switch": true
+    },
     "vendor": "Intergas"
   },
   "53130847be2f436cb946b78dedb9053a": {

--- a/fixtures/anna_v4/data.json
+++ b/fixtures/anna_v4/data.json
@@ -66,27 +66,27 @@
       "flame_state": false,
       "heating_state": true
     },
-    "boiler_temperature": {
-      "current": 45.0,
-      "lower_bound": 0.0,
-      "resolution": 1.0,
-      "setpoint": 70.0,
-      "upper_bound": 100.0
-    },
     "dev_class": "heater_central",
     "dhw_mode": "eco",
     "dhw_modes": [
       "comfort",
       "eco"
     ],
-    "dhw_temperature": {
+    "location": "94c107dc6ac84ed98e9f68c0dd06bf71",
+    "max_dhw_temperature": {
       "current": 45.0,
       "lower_bound": 30.0,
       "resolution": 0.01,
       "setpoint": 60.0,
       "upper_bound": 60.0
     },
-    "location": "94c107dc6ac84ed98e9f68c0dd06bf71",
+    "maximum_boiler_temperature": {
+      "current": 45.0,
+      "lower_bound": 0.0,
+      "resolution": 1.0,
+      "setpoint": 70.0,
+      "upper_bound": 100.0
+    },
     "model": "Generic heater",
     "model_id": "2.32",
     "name": "OpenTherm",
@@ -94,7 +94,11 @@
       "intended_boiler_temperature": 39.9,
       "modulation_level": 0.0,
       "return_temperature": 32.0,
-      "water_pressure": 2.2
+      "water_pressure": 2.2,
+      "water_temperature": 45.0
+    },
+    "switches": {
+      "dhw_cm_switch": false
     },
     "vendor": "Bosch Thermotechniek B.V."
   }

--- a/fixtures/anna_v4_dhw/data.json
+++ b/fixtures/anna_v4_dhw/data.json
@@ -66,27 +66,27 @@
       "flame_state": true,
       "heating_state": false
     },
-    "boiler_temperature": {
-      "current": 45.0,
-      "lower_bound": 0.0,
-      "resolution": 1.0,
-      "setpoint": 70.0,
-      "upper_bound": 100.0
-    },
     "dev_class": "heater_central",
     "dhw_mode": "eco",
     "dhw_modes": [
       "comfort",
       "eco"
     ],
-    "dhw_temperature": {
+    "location": "94c107dc6ac84ed98e9f68c0dd06bf71",
+    "max_dhw_temperature": {
       "current": 45.0,
       "lower_bound": 30.0,
       "resolution": 0.01,
       "setpoint": 60.0,
       "upper_bound": 60.0
     },
-    "location": "94c107dc6ac84ed98e9f68c0dd06bf71",
+    "maximum_boiler_temperature": {
+      "current": 45.0,
+      "lower_bound": 0.0,
+      "resolution": 1.0,
+      "setpoint": 70.0,
+      "upper_bound": 100.0
+    },
     "model": "Generic heater",
     "model_id": "2.32",
     "name": "OpenTherm",
@@ -94,7 +94,11 @@
       "intended_boiler_temperature": 39.9,
       "modulation_level": 0.0,
       "return_temperature": 32.0,
-      "water_pressure": 2.2
+      "water_pressure": 2.2,
+      "water_temperature": 45.0
+    },
+    "switches": {
+      "dhw_cm_switch": false
     },
     "vendor": "Bosch Thermotechniek B.V."
   }

--- a/fixtures/anna_v4_no_tag/data.json
+++ b/fixtures/anna_v4_no_tag/data.json
@@ -66,27 +66,27 @@
       "flame_state": false,
       "heating_state": true
     },
-    "boiler_temperature": {
-      "current": 45.0,
-      "lower_bound": 0.0,
-      "resolution": 1.0,
-      "setpoint": 70.0,
-      "upper_bound": 100.0
-    },
     "dev_class": "heater_central",
     "dhw_mode": "eco",
     "dhw_modes": [
       "comfort",
       "eco"
     ],
-    "dhw_temperature": {
+    "location": "94c107dc6ac84ed98e9f68c0dd06bf71",
+    "max_dhw_temperature": {
       "current": 45.0,
       "lower_bound": 30.0,
       "resolution": 0.01,
       "setpoint": 60.0,
       "upper_bound": 60.0
     },
-    "location": "94c107dc6ac84ed98e9f68c0dd06bf71",
+    "maximum_boiler_temperature": {
+      "current": 45.0,
+      "lower_bound": 0.0,
+      "resolution": 1.0,
+      "setpoint": 70.0,
+      "upper_bound": 100.0
+    },
     "model": "Generic heater",
     "model_id": "2.32",
     "name": "OpenTherm",
@@ -94,7 +94,11 @@
       "intended_boiler_temperature": 39.9,
       "modulation_level": 0.0,
       "return_temperature": 32.0,
-      "water_pressure": 2.2
+      "water_pressure": 2.2,
+      "water_temperature": 45.0
+    },
+    "switches": {
+      "dhw_cm_switch": false
     },
     "vendor": "Bosch Thermotechniek B.V."
   }

--- a/fixtures/legacy_anna/data.json
+++ b/fixtures/legacy_anna/data.json
@@ -13,15 +13,15 @@
       "flame_state": true,
       "heating_state": true
     },
-    "boiler_temperature": {
+    "dev_class": "heater_central",
+    "location": "0000aaaa0000aaaa0000aaaa0000aa00",
+    "maximum_boiler_temperature": {
       "current": 23.6,
       "lower_bound": 50.0,
       "resolution": 1.0,
       "setpoint": 50.0,
       "upper_bound": 90.0
     },
-    "dev_class": "heater_central",
-    "location": "0000aaaa0000aaaa0000aaaa0000aa00",
     "model": "Generic heater",
     "name": "OpenTherm",
     "sensors": {
@@ -29,7 +29,8 @@
       "intended_boiler_temperature": 17.0,
       "modulation_level": 0.0,
       "return_temperature": 21.7,
-      "water_pressure": 1.2
+      "water_pressure": 1.2,
+      "water_temperature": 23.6
     },
     "vendor": "Bosch Thermotechniek B.V."
   },

--- a/fixtures/legacy_anna_2/data.json
+++ b/fixtures/legacy_anna_2/data.json
@@ -51,15 +51,15 @@
       "flame_state": false,
       "heating_state": false
     },
-    "boiler_temperature": {
+    "dev_class": "heater_central",
+    "location": "be81e3f8275b4129852c4d8d550ae2eb",
+    "maximum_boiler_temperature": {
       "current": 54.0,
       "lower_bound": 50.0,
       "resolution": 1.0,
       "setpoint": 70.0,
       "upper_bound": 90.0
     },
-    "dev_class": "heater_central",
-    "location": "be81e3f8275b4129852c4d8d550ae2eb",
     "model": "Generic heater",
     "name": "OpenTherm",
     "sensors": {
@@ -67,7 +67,8 @@
       "intended_boiler_temperature": 0.0,
       "modulation_level": 0.0,
       "return_temperature": 0.0,
-      "water_pressure": 1.7
+      "water_pressure": 1.7,
+      "water_temperature": 54.0
     }
   }
 }

--- a/fixtures/m_adam_cooling/data.json
+++ b/fixtures/m_adam_cooling/data.json
@@ -7,24 +7,28 @@
       "flame_state": false,
       "heating_state": false
     },
-    "boiler_temperature": {
-      "current": 19.0,
-      "lower_bound": 25.0,
-      "resolution": 0.01,
-      "setpoint": 50.0,
-      "upper_bound": 95.0
-    },
     "dev_class": "heater_central",
     "dhw_modes": [
       "comfort",
       "eco"
     ],
     "location": "bc93488efab249e5bc54fd7e175a6f91",
+    "maximum_boiler_temperature": {
+      "current": 19.0,
+      "lower_bound": 25.0,
+      "resolution": 0.01,
+      "setpoint": 50.0,
+      "upper_bound": 95.0
+    },
     "model": "Generic heater",
     "name": "OpenTherm",
     "select_dhw_mode": "eco",
     "sensors": {
-      "intended_boiler_temperature": 17.5
+      "intended_boiler_temperature": 17.5,
+      "water_temperature": 43.0
+    },
+    "switches": {
+      "dhw_cm_switch": false
     }
   },
   "14df5c4dc8cb4ba69f9d1ac0eaf7c5c6": {

--- a/fixtures/m_adam_heating/data.json
+++ b/fixtures/m_adam_heating/data.json
@@ -31,7 +31,7 @@
     "name": "OpenTherm",
     "sensors": {
       "intended_boiler_temperature": 38.1,
-      "water_temperature": 43.0
+      "water_temperature": 37.0
     },
     "switches": {
       "dhw_cm_switch": false

--- a/fixtures/m_adam_heating/data.json
+++ b/fixtures/m_adam_heating/data.json
@@ -6,31 +6,35 @@
       "flame_state": false,
       "heating_state": true
     },
-    "boiler_temperature": {
-      "current": 37.0,
-      "lower_bound": 25.0,
-      "resolution": 0.01,
-      "setpoint": 50.0,
-      "upper_bound": 95.0
-    },
     "dev_class": "heater_central",
+    "dhw_mode": "eco",
     "dhw_modes": [
       "comfort",
       "eco"
     ],
-    "dhw_temperature": {
+    "location": "bc93488efab249e5bc54fd7e175a6f91",
+    "max_dhw_temperature": {
       "current": 37.0,
       "lower_bound": 40.0,
       "resolution": 0.01,
       "setpoint": 60.0,
       "upper_bound": 60.0
     },
-    "location": "bc93488efab249e5bc54fd7e175a6f91",
+    "maximum_boiler_temperature": {
+      "current": 37.0,
+      "lower_bound": 25.0,
+      "resolution": 0.01,
+      "setpoint": 50.0,
+      "upper_bound": 95.0
+    },
     "model": "Generic heater",
     "name": "OpenTherm",
-    "select_dhw_mode": "eco",
     "sensors": {
-      "intended_boiler_temperature": 38.1
+      "intended_boiler_temperature": 38.1,
+      "water_temperature": 43.0
+    },
+    "switches": {
+      "dhw_cm_switch": false
     }
   },
   "14df5c4dc8cb4ba69f9d1ac0eaf7c5c6": {

--- a/fixtures/m_adam_heating_off_schedule/data.json
+++ b/fixtures/m_adam_heating_off_schedule/data.json
@@ -31,7 +31,7 @@
     "name": "OpenTherm",
     "sensors": {
       "intended_boiler_temperature": 0.0,
-      "water_temperature": 43.0
+      "water_temperature": 37.0
     },
     "switches": {
       "dhw_cm_switch": false

--- a/fixtures/m_adam_heating_off_schedule/data.json
+++ b/fixtures/m_adam_heating_off_schedule/data.json
@@ -6,31 +6,35 @@
       "flame_state": false,
       "heating_state": false
     },
-    "boiler_temperature": {
-      "current": 37.0,
-      "lower_bound": 25.0,
-      "resolution": 0.01,
-      "setpoint": 50.0,
-      "upper_bound": 95.0
-    },
     "dev_class": "heater_central",
+    "dhw_mode": "eco",
     "dhw_modes": [
       "comfort",
       "eco"
     ],
-    "dhw_temperature": {
+    "location": "bc93488efab249e5bc54fd7e175a6f91",
+    "max_dhw_temperature": {
       "current": 37.0,
       "lower_bound": 40.0,
       "resolution": 0.01,
       "setpoint": 60.0,
       "upper_bound": 60.0
     },
-    "location": "bc93488efab249e5bc54fd7e175a6f91",
+    "maximum_boiler_temperature": {
+      "current": 37.0,
+      "lower_bound": 25.0,
+      "resolution": 0.01,
+      "setpoint": 50.0,
+      "upper_bound": 95.0
+    },
     "model": "Generic heater",
     "name": "OpenTherm",
-    "select_dhw_mode": "eco",
     "sensors": {
-      "intended_boiler_temperature": 0.0
+      "intended_boiler_temperature": 0.0,
+      "water_temperature": 43.0
+    },
+    "switches": {
+      "dhw_cm_switch": false
     }
   },
   "14df5c4dc8cb4ba69f9d1ac0eaf7c5c6": {

--- a/fixtures/m_adam_jip/data.json
+++ b/fixtures/m_adam_jip/data.json
@@ -392,27 +392,27 @@
       "flame_state": false,
       "heating_state": false
     },
-    "boiler_temperature": {
-      "current": 37.3,
-      "lower_bound": 20.0,
-      "resolution": 0.01,
-      "setpoint": 90.0,
-      "upper_bound": 90.0
-    },
     "dev_class": "heater_central",
     "dhw_mode": "eco",
     "dhw_modes": [
       "comfort",
       "eco"
     ],
-    "dhw_temperature": {
+    "location": "9e4433a9d69f40b3aefd15e74395eaec",
+    "max_dhw_temperature": {
       "current": 37.3,
       "lower_bound": 40.0,
       "resolution": 0.01,
       "setpoint": 60.0,
       "upper_bound": 60.0
     },
-    "location": "9e4433a9d69f40b3aefd15e74395eaec",
+    "maximum_boiler_temperature": {
+      "current": 37.3,
+      "lower_bound": 20.0,
+      "resolution": 0.01,
+      "setpoint": 90.0,
+      "upper_bound": 90.0
+    },
     "model": "Generic heater",
     "model_id": "10.20",
     "name": "OpenTherm",
@@ -420,7 +420,11 @@
       "intended_boiler_temperature": 0.0,
       "modulation_level": 0.0,
       "return_temperature": 37.1,
-      "water_pressure": 1.4
+      "water_pressure": 1.4,
+      "water_temperature": 37.3
+    },
+    "switches": {
+      "dhw_cm_switch": false
     },
     "vendor": "Remeha B.V."
   },

--- a/fixtures/m_anna_heatpump_cooling/data.json
+++ b/fixtures/m_anna_heatpump_cooling/data.json
@@ -52,6 +52,7 @@
     "model": "Generic heater/cooler",
     "name": "OpenTherm",
     "sensors": {
+      "dhw_temperature": 46.3,
       "intended_boiler_temperature": 0.0,
       "modulation_level": 40,
       "outdoor_air_temperature": 28.0,

--- a/fixtures/m_anna_heatpump_cooling/data.json
+++ b/fixtures/m_anna_heatpump_cooling/data.json
@@ -28,27 +28,27 @@
       "heating_state": false,
       "secondary_boiler_state": false
     },
-    "boiler_temperature": {
-      "current": 22.7,
-      "lower_bound": 0.0,
-      "resolution": 1.0,
-      "setpoint": 60.0,
-      "upper_bound": 100.0
-    },
     "dev_class": "heater_central",
     "dhw_mode": "eco",
     "dhw_modes": [
       "comfort",
       "eco"
     ],
-    "dhw_temperature": {
+    "location": "a57efe5f145f498c9be62a9b63626fbf",
+    "max_dhw_temperature": {
       "current": 41.5,
       "lower_bound": 35.0,
       "resolution": 0.01,
       "setpoint": 53.0,
       "upper_bound": 60.0
     },
-    "location": "a57efe5f145f498c9be62a9b63626fbf",
+    "maximum_boiler_temperature": {
+      "current": 22.7,
+      "lower_bound": 0.0,
+      "resolution": 1.0,
+      "setpoint": 60.0,
+      "upper_bound": 100.0
+    },
     "model": "Generic heater/cooler",
     "name": "OpenTherm",
     "sensors": {
@@ -56,7 +56,11 @@
       "modulation_level": 40,
       "outdoor_air_temperature": 28.0,
       "return_temperature": 23.8,
-      "water_pressure": 1.57
+      "water_pressure": 1.57,
+      "water_temperature": 29.1
+    },
+    "switches": {
+      "dhw_cm_switch": false
     },
     "vendor": "Techneco"
   },

--- a/fixtures/m_anna_heatpump_idle/data.json
+++ b/fixtures/m_anna_heatpump_idle/data.json
@@ -52,6 +52,7 @@
     "model": "Generic heater/cooler",
     "name": "OpenTherm",
     "sensors": {
+      "dhw_temperature": 46.3,
       "intended_boiler_temperature": 18.0,
       "modulation_level": 0,
       "outdoor_air_temperature": 28.2,

--- a/fixtures/m_anna_heatpump_idle/data.json
+++ b/fixtures/m_anna_heatpump_idle/data.json
@@ -28,27 +28,27 @@
       "heating_state": false,
       "secondary_boiler_state": false
     },
-    "boiler_temperature": {
-      "current": 19.1,
-      "lower_bound": 0.0,
-      "resolution": 1.0,
-      "setpoint": 60.0,
-      "upper_bound": 100.0
-    },
     "dev_class": "heater_central",
     "dhw_mode": "eco",
     "dhw_modes": [
       "comfort",
       "eco"
     ],
-    "dhw_temperature": {
+    "location": "a57efe5f145f498c9be62a9b63626fbf",
+    "max_dhw_temperature": {
       "current": 46.3,
       "lower_bound": 35.0,
       "resolution": 0.01,
       "setpoint": 53.0,
       "upper_bound": 60.0
     },
-    "location": "a57efe5f145f498c9be62a9b63626fbf",
+    "maximum_boiler_temperature": {
+      "current": 19.1,
+      "lower_bound": 0.0,
+      "resolution": 1.0,
+      "setpoint": 60.0,
+      "upper_bound": 100.0
+    },
     "model": "Generic heater/cooler",
     "name": "OpenTherm",
     "sensors": {
@@ -56,7 +56,11 @@
       "modulation_level": 0,
       "outdoor_air_temperature": 28.2,
       "return_temperature": 22.0,
-      "water_pressure": 1.57
+      "water_pressure": 1.57,
+      "water_temperature": 29.1
+    },
+    "switches": {
+      "dhw_cm_switch": false
     },
     "vendor": "Techneco"
   },

--- a/plugwise/common.py
+++ b/plugwise/common.py
@@ -295,19 +295,16 @@ class SmileCommon:
     def _create_special_dicts(
         self, item: str, data: GwEntityData, temp_dict: ActuatorData
     ) -> tuple[str, ActuatorData]:
-        """Create dhw_temperature and boiler_temperature dicts.
-
-        The initial item-names are updated and a current key is added.
-        Also, the copied sensor data is removed.
-        """
+        """Update the max_dhw_temperature and maximum_boiler_temperature dicts with a current key."""
         if item == DHW_SETPOINT:
             item = "max_dhw_temperature"
             if DHW_SETPOINT in data["sensors"]:
                 data["sensors"].pop(DHW_SETPOINT)
                 self._count -= 1
+            # Use dhw_temperature when available, otherwise use water_temperature
             if "dhw_temperature" in data["sensors"]:
                 temp_dict["current"] = data["sensors"]["dhw_temperature"]
-                data["sensors"].pop("dhw_temperature")
+                self._count += 1
             elif "water_temperature" in data["sensors"]:
                 temp_dict["current"] = data["sensors"]["water_temperature"]
                 self._count += 1

--- a/plugwise/common.py
+++ b/plugwise/common.py
@@ -315,5 +315,6 @@ class SmileCommon:
         if item == "maximum_boiler_temperature":
             if "water_temperature" in data["sensors"]:
                 temp_dict["current"] = data["sensors"]["water_temperature"]
+                self._count += 1
 
         return item, temp_dict

--- a/plugwise/common.py
+++ b/plugwise/common.py
@@ -301,7 +301,7 @@ class SmileCommon:
         Also, the copied sensor data is removed.
         """
         if item == DHW_SETPOINT:
-            item = "dhw_temperature"
+            item = "max_dhw_temperature"
             if DHW_SETPOINT in data["sensors"]:
                 data["sensors"].pop(DHW_SETPOINT)
                 self._count -= 1
@@ -313,9 +313,7 @@ class SmileCommon:
                 self._count += 1
 
         if item == "maximum_boiler_temperature":
-            item = "boiler_temperature"
             if "water_temperature" in data["sensors"]:
                 temp_dict["current"] = data["sensors"]["water_temperature"]
-                data["sensors"].pop("water_temperature")
 
         return item, temp_dict

--- a/plugwise/constants.py
+++ b/plugwise/constants.py
@@ -592,7 +592,7 @@ class GwEntityData(TypedDict, total=False):
 
     # Dict-types
     binary_sensors: SmileBinarySensors
-    max_dhw_temperatureL ActuatorData
+    max_dhw_temperature: ActuatorData
     maximum_boiler_temperature: ActuatorData
     sensors: SmileSensors
     switches: SmileSwitches

--- a/plugwise/constants.py
+++ b/plugwise/constants.py
@@ -257,10 +257,9 @@ ACTUATOR_CLASSES: Final[tuple[str, ...]] = (
     "zone_thermostat",
 )
 ActuatorType = Literal[
-    "boiler_temperature",
-    "dhw_temperature",
     "domestic_hot_water_setpoint",
     "maximum_boiler_temperature",
+    "max_dhw_temperature",
     "temperature_offset",
     "thermostat",
 ]
@@ -382,13 +381,13 @@ SpecialType = Literal[
     "c_heating_state",
     "thermostat_supports_cooling",
 ]
-
 SPECIALS: Final[tuple[str, ...]] = get_args(SpecialType)
 
 SPECIAL_FORMAT: Final[tuple[str, ...]] = (ENERGY_KILO_WATT_HOUR, VOLUME_CUBIC_METERS)
 
 SwitchType = Literal[
     "cooling_ena_switch",
+    "dhw_cm_switch",
     "lock",
     "relay",
 ]
@@ -408,6 +407,11 @@ ToggleNameType = Literal[
     "cooling_ena_switch",
     "dhw_cm_switch",
 ]
+TOGGLES: Final[dict[str, ToggleNameType]] = {
+    "cooling_enabled": "cooling_ena_switch",
+    "domestic_hot_water_comfort_mode": "dhw_cm_switch",
+}
+
 ZONE_THERMOSTATS: Final[tuple[str, ...]] = (
     "thermostat",
     "thermostatic_radiator_valve",
@@ -588,8 +592,7 @@ class GwEntityData(TypedDict, total=False):
 
     # Dict-types
     binary_sensors: SmileBinarySensors
-    boiler_temperature: ActuatorData
-    dhw_temperature: ActuatorData
+    max_dhw_temperatureL ActuatorData
     maximum_boiler_temperature: ActuatorData
     sensors: SmileSensors
     switches: SmileSwitches

--- a/plugwise/data.py
+++ b/plugwise/data.py
@@ -80,7 +80,7 @@ class SmileData(SmileHelper):
 
             # Replace select_dhw_mode with dhw_mode when applicable
             if (
-                "dhw_temperature" in entity
+                "max_dhw_temperature" in entity
                 and (mode := entity.get("select_dhw_mode")) is not None
             ):
                 entity.pop("select_dhw_mode")

--- a/plugwise/helper.py
+++ b/plugwise/helper.py
@@ -505,6 +505,9 @@ class SmileHelper(SmileCommon):
         if xml.find("type").text == "heater_central":
             locator = f"./actuator_functionalities/toggle_functionality[type='{toggle}']/state"
             if (state := xml.find(locator)) is not None:
+                if "switches" not in data:
+                    return
+
                 data["switches"][name] = state.text == "on"
                 self._count += 1
                 match toggle:

--- a/plugwise/helper.py
+++ b/plugwise/helper.py
@@ -86,6 +86,7 @@ class SmileHelper(SmileCommon):
         super().__init__()
         self._endpoint: str
         self._elga: bool
+        self._dhw_allowed_modes: list[str] | None = None
         self._is_thermostat: bool
         self._loc_data: dict[str, ThermoLoc]
         self._schedule_old_states: dict[str, dict[str, str]]

--- a/plugwise/helper.py
+++ b/plugwise/helper.py
@@ -242,6 +242,7 @@ class SmileHelper(SmileCommon):
                     appl := self._appl_heater_central_info(appl, appliance, False)
                 ):  # False means non-legacy entity
                     return Munch()
+                self._collect_dhw_modes(appliance)
 
                 return appl
             case _ as s if s.endswith("_plug"):
@@ -262,6 +263,18 @@ class SmileHelper(SmileCommon):
                 return appl
             case _:  # pragma: no cover
                 return Munch()
+
+    def _collect_dhw_modes(self, appliance: etree.Element) -> None:
+        """Collect the DHW modes."""
+        # Collect the Loria dhw modes
+        self._dhw_allowed_modes = self._get_appl_actuator_modes(
+            appliance, "domestic_hot_water_mode_control_functionality"
+        )
+        # Determine the dhw modes from the domestic_hot_water_comfort_mode toggle
+        if not self._dhw_allowed_modes:
+            self._get_toggle_state(
+                appliance, "domestic_hot_water_comfort_mode", "dhw_cm_switch", {}
+            )
 
     def _appl_gateway_info(self, appl: Munch, appliance: etree.Element) -> Munch:
         """Helper-function for _appliance_info_finder()."""

--- a/plugwise/helper.py
+++ b/plugwise/helper.py
@@ -31,6 +31,7 @@ from plugwise.constants import (
     TEMP_CELSIUS,
     THERMO_MATCHING,
     THERMOSTAT_CLASSES,
+    TOGGLES,
     UOM,
     ZONE_MEASUREMENTS,
     ActuatorData,
@@ -240,7 +241,6 @@ class SmileHelper(SmileCommon):
                     appl := self._appl_heater_central_info(appl, appliance, False)
                 ):  # False means non-legacy entity
                     return Munch()
-                self._collect_dhw_modes(appliance)
 
                 return appl
             case _ as s if s.endswith("_plug"):
@@ -261,18 +261,6 @@ class SmileHelper(SmileCommon):
                 return appl
             case _:  # pragma: no cover
                 return Munch()
-
-    def _collect_dhw_modes(self, appliance: etree.Element) -> None:
-        """Collect the DHW modes."""
-        # Collect the Loria dhw modes
-        self._dhw_allowed_modes = self._get_appl_actuator_modes(
-            appliance, "domestic_hot_water_mode_control_functionality"
-        )
-        # Determine the dhw modes from the domestic_hot_water_comfort_mode toggle
-        if not self._dhw_allowed_modes:
-            self._get_toggle_state(
-                appliance, "domestic_hot_water_comfort_mode", "dhw_cm_switch", {}
-            )
 
     def _appl_gateway_info(self, appl: Munch, appliance: etree.Element) -> Munch:
         """Helper-function for _appliance_info_finder()."""
@@ -417,12 +405,11 @@ class SmileHelper(SmileCommon):
             appliance := self._domain_objects.find(f'./appliance[@id="{entity_id}"]')
         ) is not None:
             # Collect the cooling enabled toggle state
-            self._get_toggle_state(
-                appliance, "cooling_enabled", "cooling_ena_switch", data
-            )
-
             self._appliance_measurements(appliance, data, measurements)
             self._get_lock_state(appliance, data)
+
+            for toggle, name in TOGGLES.items():
+                self._get_toggle_state(appliance, toggle, name, data)
 
             if appliance.find("type").text in ACTUATOR_CLASSES:
                 self._get_actuator_functionalities(appliance, entity, data)

--- a/plugwise/helper.py
+++ b/plugwise/helper.py
@@ -505,16 +505,11 @@ class SmileHelper(SmileCommon):
         if xml.find("type").text == "heater_central":
             locator = f"./actuator_functionalities/toggle_functionality[type='{toggle}']/state"
             if (state := xml.find(locator)) is not None:
-                if "switches" not in data:
-                    return
-
-                data["switches"][name] = state.text == "on"
-                self._count += 1
-                match toggle:
-                    case "cooling_enabled":
-                        data["switches"][name] = state.text == "on"
-                    case "domestic_hot_water_comfort_mode":
-                        self._dhw_allowed_modes = ["comfort", "eco"]
+                if "switches" in data:
+                    data["switches"][name] = state.text == "on"
+                    self._count += 1
+                if toggle == "domestic_hot_water_comfort_mode":
+                    self._dhw_allowed_modes = ["comfort", "eco"]
 
     def _get_plugwise_notifications(self) -> None:
         """Collect the Plugwise notifications."""

--- a/plugwise/helper.py
+++ b/plugwise/helper.py
@@ -504,6 +504,8 @@ class SmileHelper(SmileCommon):
         if xml.find("type").text == "heater_central":
             locator = f"./actuator_functionalities/toggle_functionality[type='{toggle}']/state"
             if (state := xml.find(locator)) is not None:
+                data["switches"][name] = state.text == "on"
+                self._count += 1
                 match toggle:
                     case "cooling_enabled":
                         data["switches"][name] = state.text == "on"
@@ -534,9 +536,9 @@ class SmileHelper(SmileCommon):
         Add the resulting dict(s) to the entity's data.
         """
         for item in ACTIVE_ACTUATORS:
-            # Skip boiler_ and dhw_temperature, not initially valid,
+            # Skip max_dhw_temperature, not initially valid,
             # skip thermostat for all but zones with thermostats
-            if item in ("boiler_temperature", "dhw_temperature") or (
+            if item == "max_dhw_temperature" or (
                 item == "thermostat"
                 and (
                     entity["dev_class"] != "climate"

--- a/plugwise/legacy/helper.py
+++ b/plugwise/legacy/helper.py
@@ -273,7 +273,7 @@ class SmileLegacyHelper(SmileCommon):
             self._get_lock_state(appliance, data, self._stretch_v2)
 
             if appliance.find("type").text in ACTUATOR_CLASSES:
-                self._get_actuator_functionalities(appliance, data)
+                self._get_actuator_functionalities(appliance, data, entity)
 
         # Anna: the Smile outdoor_temperature is present in the Home location
         # For some Anna's LOCATIONS is empty, falling back to domain_objects!

--- a/plugwise/legacy/helper.py
+++ b/plugwise/legacy/helper.py
@@ -342,10 +342,20 @@ class SmileLegacyHelper(SmileCommon):
         self._count = count_data_items(self._count, data)
 
     def _get_actuator_functionalities(
-        self, xml: etree.Element, data: GwEntityData
+        self,
+        xml: etree.Element,
+        data: GwEntityData,
+        entity: GwEntityData,
     ) -> None:
         """Helper-function for _get_measurement_data()."""
         for item in ACTIVE_ACTUATORS:
+            # Skip max_dhw_temperature, not initially valid,
+            # skip thermostat for thermo_sensors
+            if item == "max_dhw_temperature" or (
+                item == "thermostat" and entity["dev_class"] == "thermo_sensor"
+            ):
+                continue
+
             temp_dict: ActuatorData = {}
             functionality = "thermostat_functionality"
 

--- a/plugwise/smile.py
+++ b/plugwise/smile.py
@@ -261,7 +261,7 @@ class SmileAPI(SmileData):
         - 2 modes, comfort and off, representing the dhw comfort mode on and off switch states,
         - and the 5 modes available on the Loria.
         """
-        if mode not in self._dhw_allowed_modes:
+        if self._dhw_allowed_modes is not None and mode not in self._dhw_allowed_modes:
             raise PlugwiseError("Plugwise: invalid dhw mode.")
 
         match length:

--- a/plugwise/smile.py
+++ b/plugwise/smile.py
@@ -261,7 +261,7 @@ class SmileAPI(SmileData):
         - 2 modes, comfort and off, representing the dhw comfort mode on and off switch states,
         - and the 5 modes available on the Loria.
         """
-        if self._dhw_allowed_modes is not None and mode not in self._dhw_allowed_modes:
+        if self._dhw_allowed_modes and mode not in self._dhw_allowed_modes:
             raise PlugwiseError("Plugwise: invalid dhw mode.")
 
         match length:

--- a/plugwise/smile.py
+++ b/plugwise/smile.py
@@ -175,9 +175,7 @@ class SmileAPI(SmileData):
             case "temperature_offset":
                 await self.set_offset(dev_id, temperature)
                 return
-            case "boiler_temperature":
-                key = "maximum_boiler_temperature"
-            case "dhw_temperature":
+            case "max_dhw_temperature":
                 key = "domestic_hot_water_setpoint"
 
         temp = str(temperature)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name            = "plugwise"
-version         = "1.14.0a0"
+version         = "1.14.0"
 license         = "MIT"
 description     = "Plugwise Smile (Adam/Anna/P1) and Stretch module for Python 3."
 readme          = "README.md"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name            = "plugwise"
-version         = "1.13.1"
+version         = "1.14.0a0"
 license         = "MIT"
 description     = "Plugwise Smile (Adam/Anna/P1) and Stretch module for Python 3."
 readme          = "README.md"

--- a/scripts/manual_fixtures.py
+++ b/scripts/manual_fixtures.py
@@ -193,6 +193,9 @@ m_adam_heating["056ee145a816487eaa69243c3280f8bf"]["max_dhw_temperature"] = {
     "upper_bound": 60.0,
     "resolution": 0.01,
 }
+dhw_mode = m_adam_heating["056ee145a816487eaa69243c3280f8bf"]["select_dhw_mode"]
+m_adam_heating["056ee145a816487eaa69243c3280f8bf"]["dhw_mode"] = dhw_mode
+m_adam_heating["056ee145a816487eaa69243c3280f8bf"].pop("select_dhw_mode")
 
 json_writer("m_adam_heating", m_adam_heating)
 

--- a/scripts/manual_fixtures.py
+++ b/scripts/manual_fixtures.py
@@ -186,6 +186,9 @@ m_adam_heating["056ee145a816487eaa69243c3280f8bf"]["maximum_boiler_temperature"]
 m_adam_heating["056ee145a816487eaa69243c3280f8bf"]["sensors"][
     "intended_boiler_temperature"
 ] = 38.1
+m_adam_heating["056ee145a816487eaa69243c3280f8bf"]["sensors"][
+    "water_temperature"
+] = 37.0
 m_adam_heating["056ee145a816487eaa69243c3280f8bf"]["max_dhw_temperature"] = {
     "current": 37.0,
     "setpoint": 60.0,

--- a/scripts/manual_fixtures.py
+++ b/scripts/manual_fixtures.py
@@ -127,7 +127,7 @@ m_adam_cooling["056ee145a816487eaa69243c3280f8bf"]["binary_sensors"][
 m_adam_cooling["056ee145a816487eaa69243c3280f8bf"]["binary_sensors"]["flame_state"] = (
     False
 )
-m_adam_cooling["056ee145a816487eaa69243c3280f8bf"]["boiler_temperature"]["current"] = 19.0
+m_adam_cooling["056ee145a816487eaa69243c3280f8bf"]["maximum_boiler_temperature"]["current"] = 19.0
 m_adam_cooling["056ee145a816487eaa69243c3280f8bf"]["sensors"][
     "intended_boiler_temperature"
 ] = 17.5
@@ -182,11 +182,11 @@ m_adam_heating["056ee145a816487eaa69243c3280f8bf"]["binary_sensors"][
 m_adam_heating["056ee145a816487eaa69243c3280f8bf"]["binary_sensors"]["flame_state"] = (
     False
 )
-m_adam_heating["056ee145a816487eaa69243c3280f8bf"]["boiler_temperature"]["current"] = 37.0
+m_adam_heating["056ee145a816487eaa69243c3280f8bf"]["maximum_boiler_temperature"]["current"] = 37.0
 m_adam_heating["056ee145a816487eaa69243c3280f8bf"]["sensors"][
     "intended_boiler_temperature"
 ] = 38.1
-m_adam_heating["056ee145a816487eaa69243c3280f8bf"]["dhw_temperature"] = {
+m_adam_heating["056ee145a816487eaa69243c3280f8bf"]["max_dhw_temperature"] = {
     "current": 37.0,
     "setpoint": 60.0,
     "lower_bound": 40.0,
@@ -244,8 +244,8 @@ m_anna_heatpump_cooling["1cbf783bb11e4a7c8a6843dee3a86927"]["binary_sensors"][
     "cooling_state"
 ] = True
 
-m_anna_heatpump_cooling["1cbf783bb11e4a7c8a6843dee3a86927"]["boiler_temperature"]["current"] = 22.7
-m_anna_heatpump_cooling["1cbf783bb11e4a7c8a6843dee3a86927"]["dhw_temperature"]["current"] = 41.5
+m_anna_heatpump_cooling["1cbf783bb11e4a7c8a6843dee3a86927"]["maximum_boiler_temperature"]["current"] = 22.7
+m_anna_heatpump_cooling["1cbf783bb11e4a7c8a6843dee3a86927"]["max_dhw_temperature"]["current"] = 41.5
 m_anna_heatpump_cooling["1cbf783bb11e4a7c8a6843dee3a86927"]["sensors"][
     "intended_boiler_temperature"
 ] = 0.0
@@ -297,8 +297,8 @@ m_anna_heatpump_idle["1cbf783bb11e4a7c8a6843dee3a86927"]["binary_sensors"][
     "cooling_state"
 ] = False
 
-m_anna_heatpump_idle["1cbf783bb11e4a7c8a6843dee3a86927"]["boiler_temperature"]["current"] = 19.1
-m_anna_heatpump_idle["1cbf783bb11e4a7c8a6843dee3a86927"]["dhw_temperature"]["current"] = 46.3
+m_anna_heatpump_idle["1cbf783bb11e4a7c8a6843dee3a86927"]["maximum_boiler_temperature"]["current"] = 19.1
+m_anna_heatpump_idle["1cbf783bb11e4a7c8a6843dee3a86927"]["max_dhw_temperature"]["current"] = 46.3
 m_anna_heatpump_idle["1cbf783bb11e4a7c8a6843dee3a86927"]["sensors"][
     "intended_boiler_temperature"
 ] = 18.0

--- a/tests/data/adam/adam_bad_thermostat.json
+++ b/tests/data/adam/adam_bad_thermostat.json
@@ -6,27 +6,22 @@
       "flame_state": false,
       "heating_state": false
     },
-    "boiler_temperature": {
-      "current": 20.9,
-      "lower_bound": 25.0,
-      "resolution": 0.01,
-      "setpoint": 38.0,
-      "upper_bound": 45.0
-    },
     "dev_class": "heater_central",
-    "dhw_mode": "eco",
-    "dhw_modes": [
-      "comfort",
-      "eco"
-    ],
-    "dhw_temperature": {
+    "location": "856285a783f24bf4b2573c8bc510eabf",
+    "max_dhw_temperature": {
       "current": 49.9,
       "lower_bound": 0.0,
       "resolution": 1.0,
       "setpoint": 50.0,
       "upper_bound": 100.0
     },
-    "location": "856285a783f24bf4b2573c8bc510eabf",
+    "maximum_boiler_temperature": {
+      "current": 20.9,
+      "lower_bound": 25.0,
+      "resolution": 0.01,
+      "setpoint": 38.0,
+      "upper_bound": 45.0
+    },
     "model": "Generic heater",
     "model_id": "1.1",
     "name": "OpenTherm",
@@ -34,7 +29,11 @@
       "intended_boiler_temperature": 0.0,
       "modulation_level": 0.0,
       "outdoor_air_temperature": 13.6,
-      "return_temperature": 33.0
+      "return_temperature": 33.0,
+      "water_temperature": 20.9
+    },
+    "switches": {
+      "dhw_cm_switch": false
     },
     "vendor": "WeHeat"
   },

--- a/tests/data/adam/adam_bad_thermostat.json
+++ b/tests/data/adam/adam_bad_thermostat.json
@@ -31,7 +31,6 @@
     "model_id": "1.1",
     "name": "OpenTherm",
     "sensors": {
-      "dhw_temperature": 49.9,
       "intended_boiler_temperature": 0.0,
       "modulation_level": 0.0,
       "outdoor_air_temperature": 13.6,

--- a/tests/data/adam/adam_bad_thermostat.json
+++ b/tests/data/adam/adam_bad_thermostat.json
@@ -7,6 +7,11 @@
       "heating_state": false
     },
     "dev_class": "heater_central",
+    "dhw_mode": "eco",
+    "dhw_modes": [
+      "comfort",
+      "eco"
+    ],
     "location": "856285a783f24bf4b2573c8bc510eabf",
     "max_dhw_temperature": {
       "current": 49.9,

--- a/tests/data/adam/adam_bad_thermostat.json
+++ b/tests/data/adam/adam_bad_thermostat.json
@@ -31,6 +31,7 @@
     "model_id": "1.1",
     "name": "OpenTherm",
     "sensors": {
+      "dhw_temperature": 49.9,
       "intended_boiler_temperature": 0.0,
       "modulation_level": 0.0,
       "outdoor_air_temperature": 13.6,

--- a/tests/data/adam/adam_heatpump_cooling.json
+++ b/tests/data/adam/adam_heatpump_cooling.json
@@ -79,7 +79,6 @@
     "model_id": "17.1",
     "name": "OpenTherm",
     "sensors": {
-      "dhw_temperature": 63.5,
       "intended_boiler_temperature": 0.0,
       "modulation_level": 0.0,
       "outdoor_air_temperature": 13.5,

--- a/tests/data/adam/adam_heatpump_cooling.json
+++ b/tests/data/adam/adam_heatpump_cooling.json
@@ -54,27 +54,27 @@
       "flame_state": false,
       "heating_state": false
     },
-    "boiler_temperature": {
-      "current": 24.5,
-      "lower_bound": 7.0,
-      "resolution": 0.01,
-      "setpoint": 35.0,
-      "upper_bound": 50.0
-    },
     "dev_class": "heater_central",
     "dhw_mode": "comfort",
     "dhw_modes": [
       "comfort",
       "eco"
     ],
-    "dhw_temperature": {
+    "location": "eedadcb297564f1483faa509179aebed",
+    "max_dhw_temperature": {
       "current": 63.5,
       "lower_bound": 40.0,
       "resolution": 0.01,
       "setpoint": 60.0,
       "upper_bound": 65.0
     },
-    "location": "eedadcb297564f1483faa509179aebed",
+    "maximum_boiler_temperature": {
+      "current": 24.5,
+      "lower_bound": 7.0,
+      "resolution": 0.01,
+      "setpoint": 35.0,
+      "upper_bound": 50.0
+    },
     "model": "Generic heater/cooler",
     "model_id": "17.1",
     "name": "OpenTherm",
@@ -83,7 +83,11 @@
       "modulation_level": 0.0,
       "outdoor_air_temperature": 13.5,
       "return_temperature": 24.9,
-      "water_pressure": 2.0
+      "water_pressure": 2.0,
+      "water_temperature": 24.5
+    },
+    "switches": {
+      "dhw_cm_switch": true
     },
     "vendor": "Remeha B.V."
   },

--- a/tests/data/adam/adam_heatpump_cooling.json
+++ b/tests/data/adam/adam_heatpump_cooling.json
@@ -79,6 +79,7 @@
     "model_id": "17.1",
     "name": "OpenTherm",
     "sensors": {
+      "dhw_temperature": 63.5,
       "intended_boiler_temperature": 0.0,
       "modulation_level": 0.0,
       "outdoor_air_temperature": 13.5,

--- a/tests/data/adam/adam_jip.json
+++ b/tests/data/adam/adam_jip.json
@@ -393,27 +393,27 @@
       "flame_state": false,
       "heating_state": false
     },
-    "boiler_temperature": {
-      "current": 37.3,
-      "lower_bound": 20.0,
-      "resolution": 0.01,
-      "setpoint": 90.0,
-      "upper_bound": 90.0
-    },
     "dev_class": "heater_central",
     "dhw_mode": "eco",
     "dhw_modes": [
       "comfort",
       "eco"
     ],
-    "dhw_temperature": {
+    "location": "9e4433a9d69f40b3aefd15e74395eaec",
+    "max_dhw_temperature": {
       "current": 37.3,
       "lower_bound": 40.0,
       "resolution": 0.01,
       "setpoint": 60.0,
       "upper_bound": 60.0
     },
-    "location": "9e4433a9d69f40b3aefd15e74395eaec",
+    "maximum_boiler_temperature": {
+      "current": 37.3,
+      "lower_bound": 20.0,
+      "resolution": 0.01,
+      "setpoint": 90.0,
+      "upper_bound": 90.0
+    },
     "model": "Generic heater",
     "model_id": "10.20",
     "name": "OpenTherm",
@@ -421,7 +421,11 @@
       "intended_boiler_temperature": 0.0,
       "modulation_level": 0.0,
       "return_temperature": 37.1,
-      "water_pressure": 1.4
+      "water_pressure": 1.4,
+      "water_temperature": 37.3
+    },
+    "switches": {
+      "dhw_cm_switch": false
     },
     "vendor": "Remeha B.V."
   },

--- a/tests/data/adam/adam_onoff_cooling_fake_firmware.json
+++ b/tests/data/adam/adam_onoff_cooling_fake_firmware.json
@@ -31,7 +31,6 @@
     "model": "Unknown",
     "name": "OnOff",
     "sensors": {
-      "dhw_temperature": 63.5,
       "intended_boiler_temperature": 0.0,
       "modulation_level": 0.0,
       "outdoor_air_temperature": 13.5,

--- a/tests/data/adam/adam_onoff_cooling_fake_firmware.json
+++ b/tests/data/adam/adam_onoff_cooling_fake_firmware.json
@@ -31,6 +31,7 @@
     "model": "Unknown",
     "name": "OnOff",
     "sensors": {
+      "dhw_temperature": 63.5,
       "intended_boiler_temperature": 0.0,
       "modulation_level": 0.0,
       "outdoor_air_temperature": 13.5,

--- a/tests/data/adam/adam_onoff_cooling_fake_firmware.json
+++ b/tests/data/adam/adam_onoff_cooling_fake_firmware.json
@@ -7,27 +7,27 @@
       "flame_state": false,
       "heating_state": false
     },
-    "boiler_temperature": {
-      "current": 24.5,
-      "lower_bound": 7.0,
-      "resolution": 0.01,
-      "setpoint": 35.0,
-      "upper_bound": 50.0
-    },
     "dev_class": "heater_central",
     "dhw_mode": "comfort",
     "dhw_modes": [
       "comfort",
       "eco"
     ],
-    "dhw_temperature": {
+    "location": "eedadcb297564f1483faa509179aebed",
+    "max_dhw_temperature": {
       "current": 63.5,
       "lower_bound": 40.0,
       "resolution": 0.01,
       "setpoint": 60.0,
       "upper_bound": 65.0
     },
-    "location": "eedadcb297564f1483faa509179aebed",
+    "maximum_boiler_temperature": {
+      "current": 24.5,
+      "lower_bound": 7.0,
+      "resolution": 0.01,
+      "setpoint": 35.0,
+      "upper_bound": 50.0
+    },
     "model": "Unknown",
     "name": "OnOff",
     "sensors": {
@@ -35,7 +35,11 @@
       "modulation_level": 0.0,
       "outdoor_air_temperature": 13.5,
       "return_temperature": 24.9,
-      "water_pressure": 2.0
+      "water_pressure": 2.0,
+      "water_temperature": 24.5
+    },
+    "switches": {
+      "dhw_cm_switch": true
     }
   },
   "7d97fc3117784cfdafe347bcedcbbbcb": {

--- a/tests/data/adam/adam_plus_anna.json
+++ b/tests/data/adam/adam_plus_anna.json
@@ -44,24 +44,28 @@
       "flame_state": false,
       "heating_state": false
     },
-    "boiler_temperature": {
-      "current": 48.0,
-      "lower_bound": 0.0,
-      "resolution": 1.0,
-      "setpoint": 80.0,
-      "upper_bound": 100.0
-    },
     "dev_class": "heater_central",
     "dhw_modes": [
       "comfort",
       "eco"
     ],
     "location": "07d618f0bb80412687f065b8698ce3e7",
+    "maximum_boiler_temperature": {
+      "current": 48.0,
+      "lower_bound": 0.0,
+      "resolution": 1.0,
+      "setpoint": 80.0,
+      "upper_bound": 100.0
+    },
     "model": "Generic heater",
     "name": "OpenTherm",
     "select_dhw_mode": "eco",
     "sensors": {
-      "intended_boiler_temperature": 0.0
+      "intended_boiler_temperature": 0.0,
+      "water_temperature": 48.0
+    },
+    "switches": {
+      "dhw_cm_switch": false
     }
   },
   "aa6b0002df0a46e1b1eb94beb61eddfe": {

--- a/tests/data/adam/adam_plus_anna_new.json
+++ b/tests/data/adam/adam_plus_anna_new.json
@@ -6,24 +6,23 @@
       "flame_state": true,
       "heating_state": true
     },
-    "boiler_temperature": {
+    "dev_class": "heater_central",
+    "location": "bc93488efab249e5bc54fd7e175a6f91",
+    "maximum_boiler_temperature": {
       "current": 43.0,
       "lower_bound": 25.0,
       "resolution": 0.01,
       "setpoint": 50.0,
       "upper_bound": 95.0
     },
-    "dev_class": "heater_central",
-    "dhw_modes": [
-      "comfort",
-      "eco"
-    ],
-    "location": "bc93488efab249e5bc54fd7e175a6f91",
     "model": "Generic heater",
     "name": "OpenTherm",
-    "select_dhw_mode": "eco",
     "sensors": {
-      "intended_boiler_temperature": 22.5
+      "intended_boiler_temperature": 22.5,
+      "water_temperature": 43.0
+    },
+    "switches": {
+      "dhw_cm_switch": false
     }
   },
   "10016900610d4c7481df78c89606ef22": {

--- a/tests/data/adam/adam_plus_anna_new.json
+++ b/tests/data/adam/adam_plus_anna_new.json
@@ -7,6 +7,10 @@
       "heating_state": true
     },
     "dev_class": "heater_central",
+    "dhw_modes": [
+      "comfort",
+      "eco"
+    ],
     "location": "bc93488efab249e5bc54fd7e175a6f91",
     "maximum_boiler_temperature": {
       "current": 43.0,
@@ -17,6 +21,7 @@
     },
     "model": "Generic heater",
     "name": "OpenTherm",
+    "select_dhw_mode": "eco",
     "sensors": {
       "intended_boiler_temperature": 22.5,
       "water_temperature": 43.0

--- a/tests/data/adam/adam_plus_anna_new_regulation_off.json
+++ b/tests/data/adam/adam_plus_anna_new_regulation_off.json
@@ -6,24 +6,28 @@
       "flame_state": false,
       "heating_state": false
     },
-    "boiler_temperature": {
-      "current": 30.0,
-      "lower_bound": 25.0,
-      "resolution": 0.01,
-      "setpoint": 50.0,
-      "upper_bound": 95.0
-    },
     "dev_class": "heater_central",
     "dhw_modes": [
       "comfort",
       "eco"
     ],
     "location": "bc93488efab249e5bc54fd7e175a6f91",
+    "maximum_boiler_temperature": {
+      "current": 30.0,
+      "lower_bound": 25.0,
+      "resolution": 0.01,
+      "setpoint": 50.0,
+      "upper_bound": 95.0
+    },
     "model": "Generic heater",
     "name": "OpenTherm",
     "select_dhw_mode": "eco",
     "sensors": {
-      "intended_boiler_temperature": 0.0
+      "intended_boiler_temperature": 0.0,
+      "water_temperature": 30.0
+    },
+    "switches": {
+      "dhw_cm_switch": false
     }
   },
   "10016900610d4c7481df78c89606ef22": {

--- a/tests/data/anna/anna_elga_2.json
+++ b/tests/data/anna/anna_elga_2.json
@@ -28,11 +28,17 @@
       "water_pressure": 0.5,
       "water_temperature": 42.6
     },
+    "switches": {
+      "dhw_cm_switch": false
+    },
     "vendor": "Techneco"
   },
   "ebd90df1ab334565b5895f37590ccff4": {
     "active_preset": "home",
-    "available_schedules": ["Thermostat schedule", "off"],
+    "available_schedules": [
+      "Thermostat schedule",
+      "off"
+    ],
     "climate_mode": "auto",
     "control_state": "heating",
     "dev_class": "thermostat",
@@ -41,7 +47,13 @@
     "location": "d3ce834534114348be628b61b26d9220",
     "model": "ThermoTouch",
     "name": "Anna",
-    "preset_modes": ["away", "no_frost", "vacation", "home", "asleep"],
+    "preset_modes": [
+      "away",
+      "no_frost",
+      "vacation",
+      "home",
+      "asleep"
+    ],
     "select_schedule": "Thermostat schedule",
     "sensors": {
       "cooling_activation_outdoor_temperature": 24.0,

--- a/tests/data/anna/anna_elga_2_cooling.json
+++ b/tests/data/anna/anna_elga_2_cooling.json
@@ -10,19 +10,19 @@
       "heating_state": false,
       "secondary_boiler_state": false
     },
-    "boiler_temperature": {
-      "current": 22.8,
-      "lower_bound": 0.0,
-      "resolution": 1.0,
-      "setpoint": 60.0,
-      "upper_bound": 100.0
-    },
     "dev_class": "heater_central",
     "dhw_modes": [
       "comfort",
       "eco"
     ],
     "location": "d34dfe6ab90b410c98068e75de3eb631",
+    "maximum_boiler_temperature": {
+      "current": 22.8,
+      "lower_bound": 0.0,
+      "resolution": 1.0,
+      "setpoint": 60.0,
+      "upper_bound": 100.0
+    },
     "model": "Generic heater/cooler",
     "name": "OpenTherm",
     "select_dhw_mode": "comfort",
@@ -32,7 +32,11 @@
       "modulation_level": 0.0,
       "outdoor_air_temperature": 30.0,
       "return_temperature": 23.4,
-      "water_pressure": 0.5
+      "water_pressure": 0.5,
+      "water_temperature": 22.8
+    },
+    "switches": {
+      "dhw_cm_switch": true
     },
     "vendor": "Techneco"
   },

--- a/tests/data/anna/anna_elga_2_cooling_UPDATED_DATA.json
+++ b/tests/data/anna/anna_elga_2_cooling_UPDATED_DATA.json
@@ -10,29 +10,33 @@
       "heating_state": true,
       "secondary_boiler_state": false
     },
-    "boiler_temperature": {
-      "current": 22.8,
-      "lower_bound": 0.0,
-      "resolution": 1.0,
-      "setpoint": 60.0,
-      "upper_bound": 100.0
-    },
     "dev_class": "heater_central",
     "dhw_modes": [
       "comfort",
       "eco"
     ],
     "location": "d34dfe6ab90b410c98068e75de3eb631",
-
+    "maximum_boiler_temperature": {
+      "current": 22.8,
+      "lower_bound": 0.0,
+      "resolution": 1.0,
+      "setpoint": 60.0,
+      "upper_bound": 100.0
+    },
     "model": "Generic heater/cooler",
     "name": "OpenTherm",
     "select_dhw_mode": "comfort",
     "sensors": {
+      "domestic_hot_water_setpoint": 60.0,
       "intended_boiler_temperature": 0.0,
       "modulation_level": 0.0,
       "outdoor_air_temperature": 3.0,
       "return_temperature": 23.4,
-      "water_pressure": 0.5
+      "water_pressure": 0.5,
+      "water_temperature": 22.8
+    },
+    "switches": {
+      "dhw_cm_switch": true
     },
     "vendor": "Techneco"
   },

--- a/tests/data/anna/anna_elga_2_schedule_off.json
+++ b/tests/data/anna/anna_elga_2_schedule_off.json
@@ -10,19 +10,19 @@
       "heating_state": false,
       "secondary_boiler_state": false
     },
-    "boiler_temperature": {
-      "current": 22.8,
-      "lower_bound": 0.0,
-      "resolution": 1.0,
-      "setpoint": 60.0,
-      "upper_bound": 100.0
-    },
     "dev_class": "heater_central",
     "dhw_modes": [
       "comfort",
       "eco"
     ],
     "location": "d34dfe6ab90b410c98068e75de3eb631",
+    "maximum_boiler_temperature": {
+      "current": 22.8,
+      "lower_bound": 0.0,
+      "resolution": 1.0,
+      "setpoint": 60.0,
+      "upper_bound": 100.0
+    },
     "model": "Generic heater/cooler",
     "name": "OpenTherm",
     "select_dhw_mode": "comfort",
@@ -32,7 +32,11 @@
       "modulation_level": 0.0,
       "outdoor_air_temperature": 13.0,
       "return_temperature": 23.4,
-      "water_pressure": 0.5
+      "water_pressure": 0.5,
+      "water_temperature": 22.8
+    },
+    "switches": {
+      "dhw_cm_switch": true
     },
     "vendor": "Techneco"
   },

--- a/tests/data/anna/anna_elga_no_cooling.json
+++ b/tests/data/anna/anna_elga_no_cooling.json
@@ -50,7 +50,6 @@
     "model": "Generic heater",
     "name": "OpenTherm",
     "sensors": {
-      "dhw_temperature": 46.3,
       "intended_boiler_temperature": 35.0,
       "modulation_level": 52,
       "outdoor_air_temperature": 3.0,

--- a/tests/data/anna/anna_elga_no_cooling.json
+++ b/tests/data/anna/anna_elga_no_cooling.json
@@ -26,27 +26,27 @@
       "heating_state": true,
       "secondary_boiler_state": false
     },
-    "boiler_temperature": {
-      "current": 29.1,
-      "lower_bound": 0.0,
-      "resolution": 1.0,
-      "setpoint": 60.0,
-      "upper_bound": 100.0
-    },
     "dev_class": "heater_central",
     "dhw_mode": "eco",
     "dhw_modes": [
       "comfort",
       "eco"
     ],
-    "dhw_temperature": {
+    "location": "a57efe5f145f498c9be62a9b63626fbf",
+    "max_dhw_temperature": {
       "current": 46.3,
       "lower_bound": 35.0,
       "resolution": 0.01,
       "setpoint": 53.0,
       "upper_bound": 60.0
     },
-    "location": "a57efe5f145f498c9be62a9b63626fbf",
+    "maximum_boiler_temperature": {
+      "current": 29.1,
+      "lower_bound": 0.0,
+      "resolution": 1.0,
+      "setpoint": 60.0,
+      "upper_bound": 100.0
+    },
     "model": "Generic heater",
     "name": "OpenTherm",
     "sensors": {
@@ -54,7 +54,11 @@
       "modulation_level": 52,
       "outdoor_air_temperature": 3.0,
       "return_temperature": 25.1,
-      "water_pressure": 1.57
+      "water_pressure": 1.57,
+      "water_temperature": 29.1
+    },
+    "switches": {
+      "dhw_cm_switch": false
     },
     "vendor": "Techneco"
   },

--- a/tests/data/anna/anna_elga_no_cooling.json
+++ b/tests/data/anna/anna_elga_no_cooling.json
@@ -50,6 +50,7 @@
     "model": "Generic heater",
     "name": "OpenTherm",
     "sensors": {
+      "dhw_temperature": 46.3,
       "intended_boiler_temperature": 35.0,
       "modulation_level": 52,
       "outdoor_air_temperature": 3.0,

--- a/tests/data/anna/anna_heatpump_cooling.json
+++ b/tests/data/anna/anna_heatpump_cooling.json
@@ -28,19 +28,19 @@
       "heating_state": false,
       "secondary_boiler_state": false
     },
-    "boiler_temperature": {
-      "current": 24.7,
-      "lower_bound": 0.0,
-      "resolution": 1.0,
-      "setpoint": 60.0,
-      "upper_bound": 100.0
-    },
     "dev_class": "heater_central",
     "dhw_modes": [
       "comfort",
       "eco"
     ],
     "location": "a57efe5f145f498c9be62a9b63626fbf",
+    "maximum_boiler_temperature": {
+      "current": 24.7,
+      "lower_bound": 0.0,
+      "resolution": 1.0,
+      "setpoint": 60.0,
+      "upper_bound": 100.0
+    },
     "model": "Generic heater/cooler",
     "name": "OpenTherm",
     "select_dhw_mode": "eco",
@@ -51,7 +51,11 @@
       "modulation_level": 40,
       "outdoor_air_temperature": 22.0,
       "return_temperature": 23.8,
-      "water_pressure": 1.61
+      "water_pressure": 1.61,
+      "water_temperature": 24.7
+    },
+    "switches": {
+      "dhw_cm_switch": false
     },
     "vendor": "Techneco"
   },

--- a/tests/data/anna/anna_heatpump_cooling_fake_firmware.json
+++ b/tests/data/anna/anna_heatpump_cooling_fake_firmware.json
@@ -28,19 +28,19 @@
       "heating_state": false,
       "secondary_boiler_state": false
     },
-    "boiler_temperature": {
-      "current": 24.7,
-      "lower_bound": 0.0,
-      "resolution": 1.0,
-      "setpoint": 60.0,
-      "upper_bound": 100.0
-    },
     "dev_class": "heater_central",
     "dhw_modes": [
       "comfort",
       "eco"
     ],
     "location": "a57efe5f145f498c9be62a9b63626fbf",
+    "maximum_boiler_temperature": {
+      "current": 24.7,
+      "lower_bound": 0.0,
+      "resolution": 1.0,
+      "setpoint": 60.0,
+      "upper_bound": 100.0
+    },
     "model": "Generic heater/cooler",
     "name": "OpenTherm",
     "select_dhw_mode": "eco",
@@ -51,7 +51,11 @@
       "modulation_level": 100,
       "outdoor_air_temperature": 22.0,
       "return_temperature": 23.8,
-      "water_pressure": 1.61
+      "water_pressure": 1.61,
+      "water_temperature": 24.7
+    },
+    "switches": {
+      "dhw_cm_switch": false
     },
     "vendor": "Techneco"
   },

--- a/tests/data/anna/anna_heatpump_heating.json
+++ b/tests/data/anna/anna_heatpump_heating.json
@@ -52,7 +52,6 @@
     "model": "Generic heater/cooler",
     "name": "OpenTherm",
     "sensors": {
-      "dhw_temperature": 46.3,
       "intended_boiler_temperature": 35.0,
       "modulation_level": 52,
       "outdoor_air_temperature": 3.0,

--- a/tests/data/anna/anna_heatpump_heating.json
+++ b/tests/data/anna/anna_heatpump_heating.json
@@ -52,6 +52,7 @@
     "model": "Generic heater/cooler",
     "name": "OpenTherm",
     "sensors": {
+      "dhw_temperature": 46.3,
       "intended_boiler_temperature": 35.0,
       "modulation_level": 52,
       "outdoor_air_temperature": 3.0,

--- a/tests/data/anna/anna_heatpump_heating.json
+++ b/tests/data/anna/anna_heatpump_heating.json
@@ -28,27 +28,27 @@
       "heating_state": true,
       "secondary_boiler_state": false
     },
-    "boiler_temperature": {
-      "current": 29.1,
-      "lower_bound": 0.0,
-      "resolution": 1.0,
-      "setpoint": 60.0,
-      "upper_bound": 100.0
-    },
     "dev_class": "heater_central",
     "dhw_mode": "eco",
     "dhw_modes": [
       "comfort",
       "eco"
     ],
-    "dhw_temperature": {
+    "location": "a57efe5f145f498c9be62a9b63626fbf",
+    "max_dhw_temperature": {
       "current": 46.3,
       "lower_bound": 35.0,
       "resolution": 0.01,
       "setpoint": 53.0,
       "upper_bound": 60.0
     },
-    "location": "a57efe5f145f498c9be62a9b63626fbf",
+    "maximum_boiler_temperature": {
+      "current": 29.1,
+      "lower_bound": 0.0,
+      "resolution": 1.0,
+      "setpoint": 60.0,
+      "upper_bound": 100.0
+    },
     "model": "Generic heater/cooler",
     "name": "OpenTherm",
     "sensors": {
@@ -56,7 +56,11 @@
       "modulation_level": 52,
       "outdoor_air_temperature": 3.0,
       "return_temperature": 25.1,
-      "water_pressure": 1.57
+      "water_pressure": 1.57,
+      "water_temperature": 29.1
+    },
+    "switches": {
+      "dhw_cm_switch": false
     },
     "vendor": "Techneco"
   },

--- a/tests/data/anna/anna_heatpump_heating_UPDATED_DATA.json
+++ b/tests/data/anna/anna_heatpump_heating_UPDATED_DATA.json
@@ -10,19 +10,19 @@
       "secondary_boiler_state": false,
       "flame_state": false
     },
-    "boiler_temperature": {
-      "current": 29.1,
-      "setpoint": 60.0,
-      "lower_bound": 0.0,
-      "upper_bound": 100.0,
-      "resolution": 1.0
-    },
     "dev_class": "heater_central",
     "dhw_modes": [
       "comfort",
       "eco"
     ],
     "location": "a57efe5f145f498c9be62a9b63626fbf",
+    "maximum_boiler_temperature": {
+      "current": 29.1,
+      "setpoint": 60.0,
+      "lower_bound": 0.0,
+      "upper_bound": 100.0,
+      "resolution": 1.0
+    },
     "model": "Generic heater/cooler",
     "name": "OpenTherm",
     "select_dhw_mode": "eco",
@@ -33,6 +33,9 @@
       "water_pressure": 1.57,
       "outdoor_air_temperature": 3.0
 
+    },
+    "switches": {
+      "dhw_cm_switch": false
     },
     "vendor": "Techneco"
   }

--- a/tests/data/anna/anna_loria_cooling_active.json
+++ b/tests/data/anna/anna_loria_cooling_active.json
@@ -98,7 +98,6 @@
     "model_id": "173",
     "name": "OpenTherm",
     "sensors": {
-      "dhw_temperature": 52.9,
       "intended_boiler_temperature": 0.0,
       "modulation_level": 100,
       "outdoor_air_temperature": 17.2,

--- a/tests/data/anna/anna_loria_cooling_active.json
+++ b/tests/data/anna/anna_loria_cooling_active.json
@@ -70,13 +70,6 @@
       "flame_state": false,
       "heating_state": false
     },
-    "boiler_temperature": {
-      "current": 25.3,
-      "lower_bound": 25.0,
-      "resolution": 0.01,
-      "setpoint": 40.0,
-      "upper_bound": 45.0
-    },
     "dev_class": "heater_central",
     "dhw_mode": "auto",
     "dhw_modes": [
@@ -86,14 +79,21 @@
       "eco",
       "comfort"
     ],
-    "dhw_temperature": {
+    "location": "674b657c138a41a291d315d7471deb06",
+    "max_dhw_temperature": {
       "current": 52.9,
       "lower_bound": 35.0,
       "resolution": 0.01,
       "setpoint": 53.0,
       "upper_bound": 60.0
     },
-    "location": "674b657c138a41a291d315d7471deb06",
+    "maximum_boiler_temperature": {
+      "current": 25.3,
+      "lower_bound": 25.0,
+      "resolution": 0.01,
+      "setpoint": 40.0,
+      "upper_bound": 45.0
+    },
     "model": "Generic heater/cooler",
     "model_id": "173",
     "name": "OpenTherm",
@@ -101,10 +101,12 @@
       "intended_boiler_temperature": 0.0,
       "modulation_level": 100,
       "outdoor_air_temperature": 17.2,
-      "return_temperature": 26.3
+      "return_temperature": 26.3,
+      "water_temperature": 25.3
     },
     "switches": {
-      "cooling_ena_switch": true
+      "cooling_ena_switch": true,
+      "dhw_cm_switch": true
     },
     "vendor": "Atlantic"
   }

--- a/tests/data/anna/anna_loria_cooling_active.json
+++ b/tests/data/anna/anna_loria_cooling_active.json
@@ -98,6 +98,7 @@
     "model_id": "173",
     "name": "OpenTherm",
     "sensors": {
+      "dhw_temperature": 52.9,
       "intended_boiler_temperature": 0.0,
       "modulation_level": 100,
       "outdoor_air_temperature": 17.2,

--- a/tests/data/anna/anna_loria_driessens.json
+++ b/tests/data/anna/anna_loria_driessens.json
@@ -100,6 +100,7 @@
     "model_id": "173",
     "name": "OpenTherm",
     "sensors": {
+      "dhw_temperature": 49.5,
       "intended_boiler_temperature": 0.0,
       "modulation_level": 0.0,
       "outdoor_air_temperature": 7.5,

--- a/tests/data/anna/anna_loria_driessens.json
+++ b/tests/data/anna/anna_loria_driessens.json
@@ -100,7 +100,6 @@
     "model_id": "173",
     "name": "OpenTherm",
     "sensors": {
-      "dhw_temperature": 49.5,
       "intended_boiler_temperature": 0.0,
       "modulation_level": 0.0,
       "outdoor_air_temperature": 7.5,

--- a/tests/data/anna/anna_loria_driessens.json
+++ b/tests/data/anna/anna_loria_driessens.json
@@ -72,13 +72,6 @@
       "flame_state": false,
       "heating_state": false
     },
-    "boiler_temperature": {
-      "current": 23.3,
-      "lower_bound": 25.0,
-      "resolution": 0.01,
-      "setpoint": 45.0,
-      "upper_bound": 45.0
-    },
     "dev_class": "heater_central",
     "dhw_mode": "auto",
     "dhw_modes": [
@@ -88,14 +81,21 @@
       "boost",
       "auto"
     ],
-    "dhw_temperature": {
+    "location": "82c15f65c9bf44c592d69e16139355e3",
+    "max_dhw_temperature": {
       "current": 49.5,
       "lower_bound": 35.0,
       "resolution": 0.01,
       "setpoint": 53.0,
       "upper_bound": 60.0
     },
-    "location": "82c15f65c9bf44c592d69e16139355e3",
+    "maximum_boiler_temperature": {
+      "current": 23.3,
+      "lower_bound": 25.0,
+      "resolution": 0.01,
+      "setpoint": 45.0,
+      "upper_bound": 45.0
+    },
     "model": "Generic heater/cooler",
     "model_id": "173",
     "name": "OpenTherm",
@@ -103,10 +103,12 @@
       "intended_boiler_temperature": 0.0,
       "modulation_level": 0.0,
       "outdoor_air_temperature": 7.5,
-      "return_temperature": 23.0
+      "return_temperature": 23.0,
+      "water_temperature": 23.3
     },
     "switches": {
-      "cooling_ena_switch": false
+      "cooling_ena_switch": false,
+      "dhw_cm_switch": true
     },
     "vendor": "Atlantic"
   }

--- a/tests/data/anna/anna_loria_heating_idle.json
+++ b/tests/data/anna/anna_loria_heating_idle.json
@@ -98,6 +98,7 @@
     "model_id": "173",
     "name": "OpenTherm",
     "sensors": {
+      "dhw_temperature": 52.9,
       "intended_boiler_temperature": 0.0,
       "modulation_level": 0.0,
       "outdoor_air_temperature": 17.2,

--- a/tests/data/anna/anna_loria_heating_idle.json
+++ b/tests/data/anna/anna_loria_heating_idle.json
@@ -98,7 +98,6 @@
     "model_id": "173",
     "name": "OpenTherm",
     "sensors": {
-      "dhw_temperature": 52.9,
       "intended_boiler_temperature": 0.0,
       "modulation_level": 0.0,
       "outdoor_air_temperature": 17.2,

--- a/tests/data/anna/anna_loria_heating_idle.json
+++ b/tests/data/anna/anna_loria_heating_idle.json
@@ -70,13 +70,6 @@
       "flame_state": false,
       "heating_state": false
     },
-    "boiler_temperature": {
-      "current": 25.3,
-      "lower_bound": 25.0,
-      "resolution": 0.01,
-      "setpoint": 40.0,
-      "upper_bound": 45.0
-    },
     "dev_class": "heater_central",
     "dhw_mode": "auto",
     "dhw_modes": [
@@ -86,14 +79,21 @@
       "eco",
       "comfort"
     ],
-    "dhw_temperature": {
+    "location": "674b657c138a41a291d315d7471deb06",
+    "max_dhw_temperature": {
       "current": 52.9,
       "lower_bound": 35.0,
       "resolution": 0.01,
       "setpoint": 53.0,
       "upper_bound": 60.0
     },
-    "location": "674b657c138a41a291d315d7471deb06",
+    "maximum_boiler_temperature": {
+      "current": 25.3,
+      "lower_bound": 25.0,
+      "resolution": 0.01,
+      "setpoint": 40.0,
+      "upper_bound": 45.0
+    },
     "model": "Generic heater/cooler",
     "model_id": "173",
     "name": "OpenTherm",
@@ -101,10 +101,12 @@
       "intended_boiler_temperature": 0.0,
       "modulation_level": 0.0,
       "outdoor_air_temperature": 17.2,
-      "return_temperature": 26.3
+      "return_temperature": 26.3,
+      "water_temperature": 25.3
     },
     "switches": {
-      "cooling_ena_switch": false
+      "cooling_ena_switch": false,
+      "dhw_cm_switch": true
     },
     "vendor": "Atlantic"
   }

--- a/tests/data/anna/anna_p1.json
+++ b/tests/data/anna/anna_p1.json
@@ -1,7 +1,10 @@
 {
   "1e5e55b958ac445583602f767cb45942": {
     "active_preset": "home",
-    "available_schedules": ["Thermostat schedule", "off"],
+    "available_schedules": [
+      "Thermostat schedule",
+      "off"
+    ],
     "climate_mode": "heat",
     "control_state": "idle",
     "dev_class": "thermostat",
@@ -10,7 +13,13 @@
     "location": "5b13651d79c4454684fd268850b1bff8",
     "model": "ThermoTouch",
     "name": "Anna",
-    "preset_modes": ["home", "asleep", "away", "vacation", "no_frost"],
+    "preset_modes": [
+      "home",
+      "asleep",
+      "away",
+      "vacation",
+      "no_frost"
+    ],
     "select_schedule": "off",
     "sensors": {
       "illuminance": 2.0,
@@ -39,7 +48,10 @@
       "heating_state": false
     },
     "dev_class": "heater_central",
-    "dhw_modes": ["comfort", "eco"],
+    "dhw_modes": [
+      "comfort",
+      "eco"
+    ],
     "location": "da7be222ab3b420c927f3e49fade0304",
     "model": "Generic heater",
     "model_id": "HR24",
@@ -51,7 +63,28 @@
       "water_pressure": 6.0,
       "water_temperature": 35.0
     },
+    "switches": {
+      "dhw_cm_switch": true
+    },
     "vendor": "Intergas"
+  },
+  "53130847be2f436cb946b78dedb9053a": {
+    "binary_sensors": {
+      "plugwise_notification": false
+    },
+    "dev_class": "gateway",
+    "firmware": "4.4.4",
+    "hardware": "AME Smile 2.0 board",
+    "location": "da7be222ab3b420c927f3e49fade0304",
+    "mac_address": "C493000ABCD",
+    "model": "Gateway",
+    "model_id": "smile_thermo",
+    "name": "Smile Anna P1",
+    "notifications": {},
+    "sensors": {
+      "outdoor_temperature": 11.8
+    },
+    "vendor": "Plugwise"
   },
   "da7be222ab3b420c927f3e49fade0304": {
     "available": true,
@@ -81,23 +114,5 @@
       "voltage_phase_one": 234.6
     },
     "vendor": "SAGEM"
-  },
-  "53130847be2f436cb946b78dedb9053a": {
-    "binary_sensors": {
-      "plugwise_notification": false
-    },
-    "dev_class": "gateway",
-    "firmware": "4.4.4",
-    "hardware": "AME Smile 2.0 board",
-    "location": "da7be222ab3b420c927f3e49fade0304",
-    "mac_address": "C493000ABCD",
-    "model": "Gateway",
-    "model_id": "smile_thermo",
-    "name": "Smile Anna P1",
-    "notifications": {},
-    "sensors": {
-      "outdoor_temperature": 11.8
-    },
-    "vendor": "Plugwise"
   }
 }

--- a/tests/data/anna/anna_v4.json
+++ b/tests/data/anna/anna_v4.json
@@ -66,27 +66,27 @@
       "flame_state": false,
       "heating_state": true
     },
-    "boiler_temperature": {
-      "current": 45.0,
-      "lower_bound": 0.0,
-      "resolution": 1.0,
-      "setpoint": 70.0,
-      "upper_bound": 100.0
-    },
     "dev_class": "heater_central",
     "dhw_mode": "eco",
     "dhw_modes": [
       "comfort",
       "eco"
     ],
-    "dhw_temperature": {
+    "location": "94c107dc6ac84ed98e9f68c0dd06bf71",
+    "max_dhw_temperature": {
       "current": 45.0,
       "lower_bound": 30.0,
       "resolution": 0.01,
       "setpoint": 60.0,
       "upper_bound": 60.0
     },
-    "location": "94c107dc6ac84ed98e9f68c0dd06bf71",
+    "maximum_boiler_temperature": {
+      "current": 45.0,
+      "lower_bound": 0.0,
+      "resolution": 1.0,
+      "setpoint": 70.0,
+      "upper_bound": 100.0
+    },
     "model": "Generic heater",
     "model_id": "2.32",
     "name": "OpenTherm",
@@ -94,7 +94,11 @@
       "intended_boiler_temperature": 39.9,
       "modulation_level": 0.0,
       "return_temperature": 32.0,
-      "water_pressure": 2.2
+      "water_pressure": 2.2,
+      "water_temperature": 45.0
+    },
+    "switches": {
+      "dhw_cm_switch": false
     },
     "vendor": "Bosch Thermotechniek B.V."
   }

--- a/tests/data/anna/anna_v4_UPDATED_DATA.json
+++ b/tests/data/anna/anna_v4_UPDATED_DATA.json
@@ -1,31 +1,32 @@
 {
   "cd0e6156b1f04d5f952349ffbe397481": {
-    "boiler_temperature": {
+    "dhw_mode": "comfort",
+    "dhw_modes": ["comfort", "eco"],
+    "binary_sensors": {
+      "dhw_state": false,
+      "heating_state": false,
+      "flame_state": false
+    },
+    "maximum_boiler_temperature": {
       "current": 51.0,
       "setpoint": 69.0,
       "lower_bound": 0.0,
       "upper_bound": 100.0,
       "resolution": 1.0
     },
-    "dhw_mode": "comfort",
-    "dhw_modes": ["comfort", "eco"],
-    "dhw_temperature": {
+    "max_dhw_temperature": {
       "current": 51.0,
       "setpoint": 59.0,
       "lower_bound": 30.0,
       "upper_bound": 60.0,
       "resolution": 0.01
     },
-    "binary_sensors": {
-      "dhw_state": false,
-      "heating_state": false,
-      "flame_state": false
-    },
     "sensors": {
       "intended_boiler_temperature": 0.0,
       "modulation_level": 0,
       "return_temperature": 41.0,
-      "water_pressure": 2.1
+      "water_pressure": 2.1,
+      "water_temperature": 51.0
     }
   },
   "01b85360fdd243d0aaad4d6ac2a5ba7e": {

--- a/tests/data/anna/anna_v4_dhw.json
+++ b/tests/data/anna/anna_v4_dhw.json
@@ -66,27 +66,27 @@
       "flame_state": true,
       "heating_state": false
     },
-    "boiler_temperature": {
-      "current": 45.0,
-      "lower_bound": 0.0,
-      "resolution": 1.0,
-      "setpoint": 70.0,
-      "upper_bound": 100.0
-    },
     "dev_class": "heater_central",
     "dhw_mode": "eco",
     "dhw_modes": [
       "comfort",
       "eco"
     ],
-    "dhw_temperature": {
+    "location": "94c107dc6ac84ed98e9f68c0dd06bf71",
+    "max_dhw_temperature": {
       "current": 45.0,
       "lower_bound": 30.0,
       "resolution": 0.01,
       "setpoint": 60.0,
       "upper_bound": 60.0
     },
-    "location": "94c107dc6ac84ed98e9f68c0dd06bf71",
+    "maximum_boiler_temperature": {
+      "current": 45.0,
+      "lower_bound": 0.0,
+      "resolution": 1.0,
+      "setpoint": 70.0,
+      "upper_bound": 100.0
+    },
     "model": "Generic heater",
     "model_id": "2.32",
     "name": "OpenTherm",
@@ -94,7 +94,11 @@
       "intended_boiler_temperature": 39.9,
       "modulation_level": 0.0,
       "return_temperature": 32.0,
-      "water_pressure": 2.2
+      "water_pressure": 2.2,
+      "water_temperature": 45.0
+    },
+    "switches": {
+      "dhw_cm_switch": false
     },
     "vendor": "Bosch Thermotechniek B.V."
   }

--- a/tests/data/anna/anna_v4_no_tag.json
+++ b/tests/data/anna/anna_v4_no_tag.json
@@ -66,27 +66,27 @@
       "flame_state": false,
       "heating_state": true
     },
-    "boiler_temperature": {
-      "current": 45.0,
-      "lower_bound": 0.0,
-      "resolution": 1.0,
-      "setpoint": 70.0,
-      "upper_bound": 100.0
-    },
     "dev_class": "heater_central",
     "dhw_mode": "eco",
     "dhw_modes": [
       "comfort",
       "eco"
     ],
-    "dhw_temperature": {
+    "location": "94c107dc6ac84ed98e9f68c0dd06bf71",
+    "max_dhw_temperature": {
       "current": 45.0,
       "lower_bound": 30.0,
       "resolution": 0.01,
       "setpoint": 60.0,
       "upper_bound": 60.0
     },
-    "location": "94c107dc6ac84ed98e9f68c0dd06bf71",
+    "maximum_boiler_temperature": {
+      "current": 45.0,
+      "lower_bound": 0.0,
+      "resolution": 1.0,
+      "setpoint": 70.0,
+      "upper_bound": 100.0
+    },
     "model": "Generic heater",
     "model_id": "2.32",
     "name": "OpenTherm",
@@ -94,7 +94,11 @@
       "intended_boiler_temperature": 39.9,
       "modulation_level": 0.0,
       "return_temperature": 32.0,
-      "water_pressure": 2.2
+      "water_pressure": 2.2,
+      "water_temperature": 45.0
+    },
+    "switches": {
+      "dhw_cm_switch": false
     },
     "vendor": "Bosch Thermotechniek B.V."
   }

--- a/tests/data/anna/anna_without_boiler_fw441.json
+++ b/tests/data/anna/anna_without_boiler_fw441.json
@@ -1,7 +1,11 @@
 {
   "7ffbb3ab4b6c4ab2915d7510f7bf8fe9": {
     "active_preset": "home",
-    "available_schedules": ["Test", "Normaal", "off"],
+    "available_schedules": [
+      "Test",
+      "Normaal",
+      "off"
+    ],
     "climate_mode": "auto",
     "control_state": "idle",
     "dev_class": "thermostat",
@@ -10,7 +14,13 @@
     "location": "c34c6864216446528e95d88985e714cc",
     "model": "ThermoTouch",
     "name": "Anna",
-    "preset_modes": ["no_frost", "asleep", "away", "vacation", "home"],
+    "preset_modes": [
+      "no_frost",
+      "asleep",
+      "away",
+      "vacation",
+      "home"
+    ],
     "select_schedule": "Normaal",
     "sensors": {
       "illuminance": 0.25,

--- a/tests/data/anna/legacy_anna.json
+++ b/tests/data/anna/legacy_anna.json
@@ -13,15 +13,15 @@
       "flame_state": true,
       "heating_state": true
     },
-    "boiler_temperature": {
+    "dev_class": "heater_central",
+    "location": "0000aaaa0000aaaa0000aaaa0000aa00",
+    "maximum_boiler_temperature": {
       "current": 23.6,
       "lower_bound": 50.0,
       "resolution": 1.0,
       "setpoint": 50.0,
       "upper_bound": 90.0
     },
-    "dev_class": "heater_central",
-    "location": "0000aaaa0000aaaa0000aaaa0000aa00",
     "model": "Generic heater",
     "name": "OpenTherm",
     "sensors": {
@@ -29,7 +29,8 @@
       "intended_boiler_temperature": 17.0,
       "modulation_level": 0.0,
       "return_temperature": 21.7,
-      "water_pressure": 1.2
+      "water_pressure": 1.2,
+      "water_temperature": 23.6
     },
     "vendor": "Bosch Thermotechniek B.V."
   },

--- a/tests/data/anna/legacy_anna_2.json
+++ b/tests/data/anna/legacy_anna_2.json
@@ -51,15 +51,15 @@
       "flame_state": false,
       "heating_state": false
     },
-    "boiler_temperature": {
+    "dev_class": "heater_central",
+    "location": "be81e3f8275b4129852c4d8d550ae2eb",
+    "maximum_boiler_temperature": {
       "current": 54.0,
       "lower_bound": 50.0,
       "resolution": 1.0,
       "setpoint": 70.0,
       "upper_bound": 90.0
     },
-    "dev_class": "heater_central",
-    "location": "be81e3f8275b4129852c4d8d550ae2eb",
     "model": "Generic heater",
     "name": "OpenTherm",
     "sensors": {
@@ -67,7 +67,8 @@
       "intended_boiler_temperature": 0.0,
       "modulation_level": 0.0,
       "return_temperature": 0.0,
-      "water_pressure": 1.7
+      "water_pressure": 1.7,
+      "water_temperature": 54.0
     }
   }
 }

--- a/tests/test_adam.py
+++ b/tests/test_adam.py
@@ -23,7 +23,7 @@ class TestPlugwiseAdam(TestPlugwise):  # pylint: disable=attribute-defined-outsi
 
         testdata = await self.load_testdata(SMILE_TYPE, self.smile_setup)
         server, api, client = await self.connect_wrapper(raise_timeout=True)
-        await self.device_test(api, "2023-12-17 00:00:01", testdata, skip_testing=True)
+        await self.device_test(api, "2023-12-17 00:00:01", testdata)
         assert "Thermostat data in Zone" in caplog.text
 
         await api.close_connection()
@@ -45,7 +45,7 @@ class TestPlugwiseAdam(TestPlugwise):  # pylint: disable=attribute-defined-outsi
             smile_version="3.9.0",
         )
 
-        test_items = await self.device_test(api, "2025-10-12 00:00:01", testdata, skip_testing=True)
+        test_items = await self.device_test(api, "2025-10-12 00:00:01", testdata)
         assert api.gateway_id == "da224107914542988a88561b4452b0f6"
         assert self.entity_items == 234
         assert test_items == self.entity_items
@@ -218,7 +218,7 @@ class TestPlugwiseAdam(TestPlugwise):  # pylint: disable=attribute-defined-outsi
         server, api, client = await self.connect_wrapper()
         assert api.smile.hostname == "smile000000"
 
-        await self.device_test(api, "2023-12-17 00:00:01", testdata, skip_testing=True)
+        await self.device_test(api, "2023-12-17 00:00:01", testdata)
 
         await api.close_connection()
         await self.disconnect(server, client)
@@ -238,7 +238,7 @@ class TestPlugwiseAdam(TestPlugwise):  # pylint: disable=attribute-defined-outsi
             smile_version="3.0.15",
         )
 
-        test_items = await self.device_test(api, "2022-05-16 00:00:01", testdata, skip_testing=True)
+        test_items = await self.device_test(api, "2022-05-16 00:00:01", testdata)
         assert api.gateway_id == "fe799307f1624099878210aa0b9f1475"
         assert self.entity_items == 386
         assert test_items == self.entity_items
@@ -313,7 +313,7 @@ class TestPlugwiseAdam(TestPlugwise):  # pylint: disable=attribute-defined-outsi
             smile_version="3.0.15",
         )
 
-        test_items = await self.device_test(api, "2022-05-16 00:00:01", testdata, skip_testing=True)
+        test_items = await self.device_test(api, "2022-05-16 00:00:01", testdata)
         assert self.entity_items == 394
         assert test_items == self.entity_items
 
@@ -350,7 +350,7 @@ class TestPlugwiseAdam(TestPlugwise):  # pylint: disable=attribute-defined-outsi
         testdata = await self.load_testdata(SMILE_TYPE, self.smile_setup)
         server, api, client = await self.connect_wrapper()
 
-        test_items = await self.device_test(api, "2022-01-02 00:00:01", testdata, skip_testing=True)
+        test_items = await self.device_test(api, "2022-01-02 00:00:01", testdata)
         assert self.entity_items == 542
         assert test_items == self.entity_items
         assert self.cooling_present
@@ -374,7 +374,7 @@ class TestPlugwiseAdam(TestPlugwise):  # pylint: disable=attribute-defined-outsi
             smile_version=None,
         )
 
-        test_items = await self.device_test(api, "2022-01-02 00:00:01", testdata, skip_testing=True)
+        test_items = await self.device_test(api, "2022-01-02 00:00:01", testdata)
         assert self.entity_items == 73
         assert test_items == self.entity_items
         assert self.cooling_present
@@ -398,7 +398,7 @@ class TestPlugwiseAdam(TestPlugwise):  # pylint: disable=attribute-defined-outsi
             smile_version="3.0.15",
         )
 
-        test_items = await self.device_test(api, "2020-03-22 00:00:01", testdata, skip_testing=True)
+        test_items = await self.device_test(api, "2020-03-22 00:00:01", testdata)
         assert api.gateway_id == "b128b4bbbd1f47e9bf4d756e8fb5ee94"
         assert self.entity_items == 85
         assert test_items == self.entity_items
@@ -439,7 +439,7 @@ class TestPlugwiseAdam(TestPlugwise):  # pylint: disable=attribute-defined-outsi
         testdata = await self.load_testdata(SMILE_TYPE, self.smile_setup)
         server, api, client = await self.connect_wrapper()
 
-        test_items = await self.device_test(api, "2021-06-20 00:00:01", testdata, skip_testing=True)
+        test_items = await self.device_test(api, "2021-06-20 00:00:01", testdata)
         assert api.gateway_id == "b5c2386c6f6342669e50fe49dd05b188"
         assert self.entity_items == 273
         assert test_items == self.entity_items

--- a/tests/test_adam.py
+++ b/tests/test_adam.py
@@ -400,7 +400,7 @@ class TestPlugwiseAdam(TestPlugwise):  # pylint: disable=attribute-defined-outsi
 
         test_items = await self.device_test(api, "2020-03-22 00:00:01", testdata)
         assert api.gateway_id == "b128b4bbbd1f47e9bf4d756e8fb5ee94"
-        assert self.entity_items == 83
+        assert self.entity_items == 85
         assert test_items == self.entity_items
         assert "6fb89e35caeb4b1cb275184895202d84" in self.notifications
 

--- a/tests/test_adam.py
+++ b/tests/test_adam.py
@@ -375,7 +375,7 @@ class TestPlugwiseAdam(TestPlugwise):  # pylint: disable=attribute-defined-outsi
         )
 
         test_items = await self.device_test(api, "2022-01-02 00:00:01", testdata)
-        assert self.entity_items == 71
+        assert self.entity_items == 73
         assert test_items == self.entity_items
         assert self.cooling_present
         # assert self._cooling_enabled - no cooling_enabled indication present

--- a/tests/test_adam.py
+++ b/tests/test_adam.py
@@ -47,7 +47,7 @@ class TestPlugwiseAdam(TestPlugwise):  # pylint: disable=attribute-defined-outsi
 
         test_items = await self.device_test(api, "2025-10-12 00:00:01", testdata)
         assert api.gateway_id == "da224107914542988a88561b4452b0f6"
-        assert self.entity_items == 232
+        assert self.entity_items == 234
         assert test_items == self.entity_items
         assert self.entity_list == [
             "da224107914542988a88561b4452b0f6",

--- a/tests/test_adam.py
+++ b/tests/test_adam.py
@@ -351,7 +351,7 @@ class TestPlugwiseAdam(TestPlugwise):  # pylint: disable=attribute-defined-outsi
         server, api, client = await self.connect_wrapper()
 
         test_items = await self.device_test(api, "2022-01-02 00:00:01", testdata)
-        assert self.entity_items == 540
+        assert self.entity_items == 542
         assert test_items == self.entity_items
         assert self.cooling_present
         assert self._cooling_enabled

--- a/tests/test_adam.py
+++ b/tests/test_adam.py
@@ -441,7 +441,7 @@ class TestPlugwiseAdam(TestPlugwise):  # pylint: disable=attribute-defined-outsi
 
         test_items = await self.device_test(api, "2021-06-20 00:00:01", testdata)
         assert api.gateway_id == "b5c2386c6f6342669e50fe49dd05b188"
-        assert self.entity_items == 271
+        assert self.entity_items == 273
         assert test_items == self.entity_items
 
         # Negative test

--- a/tests/test_adam.py
+++ b/tests/test_adam.py
@@ -47,8 +47,8 @@ class TestPlugwiseAdam(TestPlugwise):  # pylint: disable=attribute-defined-outsi
 
         test_items = await self.device_test(api, "2025-10-12 00:00:01", testdata, skip_testing=True)
         assert api.gateway_id == "da224107914542988a88561b4452b0f6"
-        assert self.entity_items == 234
-        assert test_items == self.entity_items
+        # assert self.entity_items == 234
+        # assert test_items == self.entity_items
         assert self.entity_list == [
             "da224107914542988a88561b4452b0f6",
             "056ee145a816487eaa69243c3280f8bf",
@@ -240,8 +240,8 @@ class TestPlugwiseAdam(TestPlugwise):  # pylint: disable=attribute-defined-outsi
 
         test_items = await self.device_test(api, "2022-05-16 00:00:01", testdata, skip_testing=True)
         assert api.gateway_id == "fe799307f1624099878210aa0b9f1475"
-        assert self.entity_items == 386
-        assert test_items == self.entity_items
+        # assert self.entity_items == 386
+        # assert test_items == self.entity_items
 
         assert "af82e4ccf9c548528166d38e560662a4" in self.notifications
         await api.delete_notification()
@@ -314,8 +314,8 @@ class TestPlugwiseAdam(TestPlugwise):  # pylint: disable=attribute-defined-outsi
         )
 
         test_items = await self.device_test(api, "2022-05-16 00:00:01", testdata, skip_testing=True)
-        assert self.entity_items == 394
-        assert test_items == self.entity_items
+        # assert self.entity_items == 394
+        # assert test_items == self.entity_items
 
         assert "af82e4ccf9c548528166d38e560662a4" in self.notifications
 
@@ -351,8 +351,8 @@ class TestPlugwiseAdam(TestPlugwise):  # pylint: disable=attribute-defined-outsi
         server, api, client = await self.connect_wrapper()
 
         test_items = await self.device_test(api, "2022-01-02 00:00:01", testdata, skip_testing=True)
-        assert self.entity_items == 542
-        assert test_items == self.entity_items
+        # assert self.entity_items == 542
+        # assert test_items == self.entity_items
         assert self.cooling_present
         assert self._cooling_enabled
 
@@ -375,8 +375,8 @@ class TestPlugwiseAdam(TestPlugwise):  # pylint: disable=attribute-defined-outsi
         )
 
         test_items = await self.device_test(api, "2022-01-02 00:00:01", testdata, skip_testing=True)
-        assert self.entity_items == 73
-        assert test_items == self.entity_items
+        # assert self.entity_items == 73
+        # assert test_items == self.entity_items
         assert self.cooling_present
         # assert self._cooling_enabled - no cooling_enabled indication present
 
@@ -400,8 +400,8 @@ class TestPlugwiseAdam(TestPlugwise):  # pylint: disable=attribute-defined-outsi
 
         test_items = await self.device_test(api, "2020-03-22 00:00:01", testdata, skip_testing=True)
         assert api.gateway_id == "b128b4bbbd1f47e9bf4d756e8fb5ee94"
-        assert self.entity_items == 85
-        assert test_items == self.entity_items
+        # assert self.entity_items == 85
+        # assert test_items == self.entity_items
         assert "6fb89e35caeb4b1cb275184895202d84" in self.notifications
 
         result = await self.tinker_thermostat(
@@ -441,8 +441,8 @@ class TestPlugwiseAdam(TestPlugwise):  # pylint: disable=attribute-defined-outsi
 
         test_items = await self.device_test(api, "2021-06-20 00:00:01", testdata, skip_testing=True)
         assert api.gateway_id == "b5c2386c6f6342669e50fe49dd05b188"
-        assert self.entity_items == 273
-        assert test_items == self.entity_items
+        # assert self.entity_items == 273
+        # assert test_items == self.entity_items
 
         # Negative test
         result = await self.tinker_thermostat(

--- a/tests/test_adam.py
+++ b/tests/test_adam.py
@@ -375,7 +375,7 @@ class TestPlugwiseAdam(TestPlugwise):  # pylint: disable=attribute-defined-outsi
         )
 
         test_items = await self.device_test(api, "2022-01-02 00:00:01", testdata)
-        assert self.entity_items == 73
+        assert self.entity_items == 74
         assert test_items == self.entity_items
         assert self.cooling_present
         # assert self._cooling_enabled - no cooling_enabled indication present

--- a/tests/test_adam.py
+++ b/tests/test_adam.py
@@ -47,8 +47,8 @@ class TestPlugwiseAdam(TestPlugwise):  # pylint: disable=attribute-defined-outsi
 
         test_items = await self.device_test(api, "2025-10-12 00:00:01", testdata, skip_testing=True)
         assert api.gateway_id == "da224107914542988a88561b4452b0f6"
-        # assert self.entity_items == 234
-        # assert test_items == self.entity_items
+        assert self.entity_items == 234
+        assert test_items == self.entity_items
         assert self.entity_list == [
             "da224107914542988a88561b4452b0f6",
             "056ee145a816487eaa69243c3280f8bf",
@@ -240,8 +240,8 @@ class TestPlugwiseAdam(TestPlugwise):  # pylint: disable=attribute-defined-outsi
 
         test_items = await self.device_test(api, "2022-05-16 00:00:01", testdata, skip_testing=True)
         assert api.gateway_id == "fe799307f1624099878210aa0b9f1475"
-        # assert self.entity_items == 386
-        # assert test_items == self.entity_items
+        assert self.entity_items == 386
+        assert test_items == self.entity_items
 
         assert "af82e4ccf9c548528166d38e560662a4" in self.notifications
         await api.delete_notification()
@@ -314,8 +314,8 @@ class TestPlugwiseAdam(TestPlugwise):  # pylint: disable=attribute-defined-outsi
         )
 
         test_items = await self.device_test(api, "2022-05-16 00:00:01", testdata, skip_testing=True)
-        # assert self.entity_items == 394
-        # assert test_items == self.entity_items
+        assert self.entity_items == 394
+        assert test_items == self.entity_items
 
         assert "af82e4ccf9c548528166d38e560662a4" in self.notifications
 
@@ -351,8 +351,8 @@ class TestPlugwiseAdam(TestPlugwise):  # pylint: disable=attribute-defined-outsi
         server, api, client = await self.connect_wrapper()
 
         test_items = await self.device_test(api, "2022-01-02 00:00:01", testdata, skip_testing=True)
-        # assert self.entity_items == 542
-        # assert test_items == self.entity_items
+        assert self.entity_items == 542
+        assert test_items == self.entity_items
         assert self.cooling_present
         assert self._cooling_enabled
 
@@ -375,8 +375,8 @@ class TestPlugwiseAdam(TestPlugwise):  # pylint: disable=attribute-defined-outsi
         )
 
         test_items = await self.device_test(api, "2022-01-02 00:00:01", testdata, skip_testing=True)
-        # assert self.entity_items == 73
-        # assert test_items == self.entity_items
+        assert self.entity_items == 73
+        assert test_items == self.entity_items
         assert self.cooling_present
         # assert self._cooling_enabled - no cooling_enabled indication present
 
@@ -400,8 +400,8 @@ class TestPlugwiseAdam(TestPlugwise):  # pylint: disable=attribute-defined-outsi
 
         test_items = await self.device_test(api, "2020-03-22 00:00:01", testdata, skip_testing=True)
         assert api.gateway_id == "b128b4bbbd1f47e9bf4d756e8fb5ee94"
-        # assert self.entity_items == 85
-        # assert test_items == self.entity_items
+        assert self.entity_items == 85
+        assert test_items == self.entity_items
         assert "6fb89e35caeb4b1cb275184895202d84" in self.notifications
 
         result = await self.tinker_thermostat(
@@ -441,8 +441,8 @@ class TestPlugwiseAdam(TestPlugwise):  # pylint: disable=attribute-defined-outsi
 
         test_items = await self.device_test(api, "2021-06-20 00:00:01", testdata, skip_testing=True)
         assert api.gateway_id == "b5c2386c6f6342669e50fe49dd05b188"
-        # assert self.entity_items == 273
-        # assert test_items == self.entity_items
+        assert self.entity_items == 273
+        assert test_items == self.entity_items
 
         # Negative test
         result = await self.tinker_thermostat(

--- a/tests/test_adam.py
+++ b/tests/test_adam.py
@@ -23,7 +23,7 @@ class TestPlugwiseAdam(TestPlugwise):  # pylint: disable=attribute-defined-outsi
 
         testdata = await self.load_testdata(SMILE_TYPE, self.smile_setup)
         server, api, client = await self.connect_wrapper(raise_timeout=True)
-        await self.device_test(api, "2023-12-17 00:00:01", testdata)
+        await self.device_test(api, "2023-12-17 00:00:01", testdata, skip_testing=True)
         assert "Thermostat data in Zone" in caplog.text
 
         await api.close_connection()
@@ -45,7 +45,7 @@ class TestPlugwiseAdam(TestPlugwise):  # pylint: disable=attribute-defined-outsi
             smile_version="3.9.0",
         )
 
-        test_items = await self.device_test(api, "2025-10-12 00:00:01", testdata)
+        test_items = await self.device_test(api, "2025-10-12 00:00:01", testdata, skip_testing=True)
         assert api.gateway_id == "da224107914542988a88561b4452b0f6"
         assert self.entity_items == 234
         assert test_items == self.entity_items
@@ -218,7 +218,7 @@ class TestPlugwiseAdam(TestPlugwise):  # pylint: disable=attribute-defined-outsi
         server, api, client = await self.connect_wrapper()
         assert api.smile.hostname == "smile000000"
 
-        await self.device_test(api, "2023-12-17 00:00:01", testdata)
+        await self.device_test(api, "2023-12-17 00:00:01", testdata, skip_testing=True)
 
         await api.close_connection()
         await self.disconnect(server, client)
@@ -238,7 +238,7 @@ class TestPlugwiseAdam(TestPlugwise):  # pylint: disable=attribute-defined-outsi
             smile_version="3.0.15",
         )
 
-        test_items = await self.device_test(api, "2022-05-16 00:00:01", testdata)
+        test_items = await self.device_test(api, "2022-05-16 00:00:01", testdata, skip_testing=True)
         assert api.gateway_id == "fe799307f1624099878210aa0b9f1475"
         assert self.entity_items == 386
         assert test_items == self.entity_items
@@ -313,7 +313,7 @@ class TestPlugwiseAdam(TestPlugwise):  # pylint: disable=attribute-defined-outsi
             smile_version="3.0.15",
         )
 
-        test_items = await self.device_test(api, "2022-05-16 00:00:01", testdata)
+        test_items = await self.device_test(api, "2022-05-16 00:00:01", testdata, skip_testing=True)
         assert self.entity_items == 394
         assert test_items == self.entity_items
 
@@ -350,7 +350,7 @@ class TestPlugwiseAdam(TestPlugwise):  # pylint: disable=attribute-defined-outsi
         testdata = await self.load_testdata(SMILE_TYPE, self.smile_setup)
         server, api, client = await self.connect_wrapper()
 
-        test_items = await self.device_test(api, "2022-01-02 00:00:01", testdata)
+        test_items = await self.device_test(api, "2022-01-02 00:00:01", testdata, skip_testing=True)
         assert self.entity_items == 542
         assert test_items == self.entity_items
         assert self.cooling_present
@@ -374,7 +374,7 @@ class TestPlugwiseAdam(TestPlugwise):  # pylint: disable=attribute-defined-outsi
             smile_version=None,
         )
 
-        test_items = await self.device_test(api, "2022-01-02 00:00:01", testdata)
+        test_items = await self.device_test(api, "2022-01-02 00:00:01", testdata, skip_testing=True)
         assert self.entity_items == 73
         assert test_items == self.entity_items
         assert self.cooling_present
@@ -398,7 +398,7 @@ class TestPlugwiseAdam(TestPlugwise):  # pylint: disable=attribute-defined-outsi
             smile_version="3.0.15",
         )
 
-        test_items = await self.device_test(api, "2020-03-22 00:00:01", testdata)
+        test_items = await self.device_test(api, "2020-03-22 00:00:01", testdata, skip_testing=True)
         assert api.gateway_id == "b128b4bbbd1f47e9bf4d756e8fb5ee94"
         assert self.entity_items == 85
         assert test_items == self.entity_items
@@ -439,7 +439,7 @@ class TestPlugwiseAdam(TestPlugwise):  # pylint: disable=attribute-defined-outsi
         testdata = await self.load_testdata(SMILE_TYPE, self.smile_setup)
         server, api, client = await self.connect_wrapper()
 
-        test_items = await self.device_test(api, "2021-06-20 00:00:01", testdata)
+        test_items = await self.device_test(api, "2021-06-20 00:00:01", testdata, skip_testing=True)
         assert api.gateway_id == "b5c2386c6f6342669e50fe49dd05b188"
         assert self.entity_items == 273
         assert test_items == self.entity_items

--- a/tests/test_adam.py
+++ b/tests/test_adam.py
@@ -351,7 +351,7 @@ class TestPlugwiseAdam(TestPlugwise):  # pylint: disable=attribute-defined-outsi
         server, api, client = await self.connect_wrapper()
 
         test_items = await self.device_test(api, "2022-01-02 00:00:01", testdata)
-        assert self.entity_items == 542
+        assert self.entity_items == 543
         assert test_items == self.entity_items
         assert self.cooling_present
         assert self._cooling_enabled

--- a/tests/test_anna.py
+++ b/tests/test_anna.py
@@ -29,7 +29,7 @@ class TestPlugwiseAnna(TestPlugwise):  # pylint: disable=attribute-defined-outsi
 
         await self.device_test(api, "2020-04-05 00:00:01", testdata, skip_testing=True)
         assert api.gateway_id == "0466eae8520144c78afb29628384edeb"
-        assert self.entity_items == 64
+        # assert self.entity_items == 64
         assert not self.notifications
 
         assert not self.cooling_present
@@ -101,7 +101,7 @@ class TestPlugwiseAnna(TestPlugwise):  # pylint: disable=attribute-defined-outsi
         )
 
         await self.device_test(api, "2020-04-05 00:00:01", testdata, skip_testing=True)
-        assert self.entity_items == 64
+        # assert self.entity_items == 64
         assert not self.notifications
 
         result = await self.tinker_thermostat(
@@ -130,7 +130,7 @@ class TestPlugwiseAnna(TestPlugwise):  # pylint: disable=attribute-defined-outsi
         )
 
         await self.device_test(api, "2020-04-05 00:00:01", testdata, skip_testing=True)
-        assert self.entity_items == 64
+        # assert self.entity_items == 64
 
         result = await self.tinker_thermostat(
             api,
@@ -158,7 +158,7 @@ class TestPlugwiseAnna(TestPlugwise):  # pylint: disable=attribute-defined-outsi
         )
 
         await self.device_test(api, "2022-05-16 00:00:01", testdata, skip_testing=True)
-        assert self.entity_items == 41
+        # assert self.entity_items == 41
         assert not self.notifications
 
         result = await self.tinker_thermostat(
@@ -186,7 +186,7 @@ class TestPlugwiseAnna(TestPlugwise):  # pylint: disable=attribute-defined-outsi
 
         await self.device_test(api, "2020-04-12 00:00:01", testdata, skip_testing=True)
         assert api.gateway_id == "015ae9ea3f964e668e490fa39da3870b"
-        assert self.entity_items == 72
+        # assert self.entity_items == 72
         assert not self.notifications
         assert self.cooling_present
         assert not self._cooling_enabled
@@ -216,7 +216,7 @@ class TestPlugwiseAnna(TestPlugwise):  # pylint: disable=attribute-defined-outsi
         await self.device_test(
             api, "2020-04-13 00:00:01", testdata_updated, initialize=False
         )
-        assert self.entity_items == 69
+        # assert self.entity_items == 69
         await api.close_connection()
         await self.disconnect(server, client)
 
@@ -241,7 +241,7 @@ class TestPlugwiseAnna(TestPlugwise):  # pylint: disable=attribute-defined-outsi
         )
 
         await self.device_test(api, "2020-04-19 00:00:01", testdata, skip_testing=True)
-        assert self.entity_items == 69
+        # assert self.entity_items == 69
         assert self.cooling_present
         assert not self.notifications
 
@@ -287,7 +287,7 @@ class TestPlugwiseAnna(TestPlugwise):  # pylint: disable=attribute-defined-outsi
         )
 
         await self.device_test(api, "2020-04-19 00:00:01", testdata, skip_testing=True)
-        assert self.entity_items == 69
+        # assert self.entity_items == 69
         assert self.cooling_present
         assert self._cooling_enabled
         assert self._cooling_active
@@ -313,7 +313,7 @@ class TestPlugwiseAnna(TestPlugwise):  # pylint: disable=attribute-defined-outsi
 
         await self.device_test(api, "2020-04-12 00:00:01", testdata, skip_testing=True)
         assert api.gateway_id == "015ae9ea3f964e668e490fa39da3870b"
-        assert self.entity_items == 68
+        # assert self.entity_items == 68
         assert not self.notifications
         assert not self.cooling_present
 
@@ -336,7 +336,7 @@ class TestPlugwiseAnna(TestPlugwise):  # pylint: disable=attribute-defined-outsi
         )
 
         await self.device_test(api, "2022-03-13 00:00:01", testdata, skip_testing=True)
-        assert self.entity_items == 63
+        # assert self.entity_items == 63
         assert api.gateway_id == "fb49af122f6e4b0f91267e1cf7666d6f"
         assert self.cooling_present
         assert not self._cooling_enabled
@@ -356,7 +356,7 @@ class TestPlugwiseAnna(TestPlugwise):  # pylint: disable=attribute-defined-outsi
 
         await self.device_test(api, "2022-03-13 00:00:01", testdata, skip_testing=True)
         assert not self._cooling_enabled
-        assert self.entity_items == 68
+        # assert self.entity_items == 68
 
         result = await self.tinker_thermostat(
             api,
@@ -387,7 +387,7 @@ class TestPlugwiseAnna(TestPlugwise):  # pylint: disable=attribute-defined-outsi
         )
 
         await self.device_test(api, "2022-03-10 00:00:01", testdata, skip_testing=True)
-        assert self.entity_items == 68
+        # assert self.entity_items == 68
         assert not self.notifications
 
         assert self.cooling_present
@@ -440,7 +440,7 @@ class TestPlugwiseAnna(TestPlugwise):  # pylint: disable=attribute-defined-outsi
         )
 
         await self.device_test(api, "2022-05-16 00:00:01", testdata, skip_testing=True)
-        assert self.entity_items == 69
+        # assert self.entity_items == 69
         assert self.cooling_present
         assert not self._cooling_enabled
 
@@ -509,7 +509,7 @@ class TestPlugwiseAnna(TestPlugwise):  # pylint: disable=attribute-defined-outsi
         )
 
         await self.device_test(api, "2022-05-16 00:00:01", testdata, skip_testing=True)
-        assert self.entity_items == 69
+        # assert self.entity_items == 69
         assert self.cooling_present
         assert self._cooling_enabled
 
@@ -532,7 +532,7 @@ class TestPlugwiseAnna(TestPlugwise):  # pylint: disable=attribute-defined-outsi
         )
 
         await self.device_test(api, "2022-05-16 00:00:01", testdata, skip_testing=True)
-        assert self.entity_items == 69
+        # assert self.entity_items == 69
         assert self.cooling_present
         assert not self._cooling_enabled
 
@@ -555,7 +555,7 @@ class TestPlugwiseAnna(TestPlugwise):  # pylint: disable=attribute-defined-outsi
         )
 
         await self.device_test(api, "2025-11-02 00:00:01", testdata, skip_testing=True)
-        assert self.entity_items == 78
+        # assert self.entity_items == 78
 
         await api.close_connection()
         await self.disconnect(server, client)
@@ -576,7 +576,7 @@ class TestPlugwiseAnna(TestPlugwise):  # pylint: disable=attribute-defined-outsi
         )
 
         await self.device_test(api, "2022-05-16 00:00:01", testdata, skip_testing=True)
-        assert self.entity_items == 12
+        # assert self.entity_items == 12
 
         await api.close_connection()
         await self.disconnect(server, client)

--- a/tests/test_anna.py
+++ b/tests/test_anna.py
@@ -27,7 +27,7 @@ class TestPlugwiseAnna(TestPlugwise):  # pylint: disable=attribute-defined-outsi
             smile_version="4.0.15",
         )
 
-        await self.device_test(api, "2020-04-05 00:00:01", testdata, skip_testing=True)
+        await self.device_test(api, "2020-04-05 00:00:01", testdata)
         assert api.gateway_id == "0466eae8520144c78afb29628384edeb"
         assert self.entity_items == 64
         assert not self.notifications
@@ -100,7 +100,7 @@ class TestPlugwiseAnna(TestPlugwise):  # pylint: disable=attribute-defined-outsi
             smile_version="4.0.15",
         )
 
-        await self.device_test(api, "2020-04-05 00:00:01", testdata, skip_testing=True)
+        await self.device_test(api, "2020-04-05 00:00:01", testdata)
         assert self.entity_items == 64
         assert not self.notifications
 
@@ -129,7 +129,7 @@ class TestPlugwiseAnna(TestPlugwise):  # pylint: disable=attribute-defined-outsi
             smile_version="4.0.15",
         )
 
-        await self.device_test(api, "2020-04-05 00:00:01", testdata, skip_testing=True)
+        await self.device_test(api, "2020-04-05 00:00:01", testdata)
         assert self.entity_items == 64
 
         result = await self.tinker_thermostat(
@@ -157,7 +157,7 @@ class TestPlugwiseAnna(TestPlugwise):  # pylint: disable=attribute-defined-outsi
             smile_version="4.4.1",
         )
 
-        await self.device_test(api, "2022-05-16 00:00:01", testdata, skip_testing=True)
+        await self.device_test(api, "2022-05-16 00:00:01", testdata)
         assert self.entity_items == 41
         assert not self.notifications
 
@@ -184,7 +184,7 @@ class TestPlugwiseAnna(TestPlugwise):  # pylint: disable=attribute-defined-outsi
             smile_version="4.0.15",
         )
 
-        await self.device_test(api, "2020-04-12 00:00:01", testdata, skip_testing=True)
+        await self.device_test(api, "2020-04-12 00:00:01", testdata)
         assert api.gateway_id == "015ae9ea3f964e668e490fa39da3870b"
         assert self.entity_items == 72
         assert not self.notifications
@@ -240,7 +240,7 @@ class TestPlugwiseAnna(TestPlugwise):  # pylint: disable=attribute-defined-outsi
             smile_version="4.0.15",
         )
 
-        await self.device_test(api, "2020-04-19 00:00:01", testdata, skip_testing=True)
+        await self.device_test(api, "2020-04-19 00:00:01", testdata)
         assert self.entity_items == 69
         assert self.cooling_present
         assert not self.notifications
@@ -286,7 +286,7 @@ class TestPlugwiseAnna(TestPlugwise):  # pylint: disable=attribute-defined-outsi
             smile_version="4.10.10",
         )
 
-        await self.device_test(api, "2020-04-19 00:00:01", testdata, skip_testing=True)
+        await self.device_test(api, "2020-04-19 00:00:01", testdata)
         assert self.entity_items == 69
         assert self.cooling_present
         assert self._cooling_enabled
@@ -311,7 +311,7 @@ class TestPlugwiseAnna(TestPlugwise):  # pylint: disable=attribute-defined-outsi
             smile_version="4.0.15",
         )
 
-        await self.device_test(api, "2020-04-12 00:00:01", testdata, skip_testing=True)
+        await self.device_test(api, "2020-04-12 00:00:01", testdata)
         assert api.gateway_id == "015ae9ea3f964e668e490fa39da3870b"
         assert self.entity_items == 68
         assert not self.notifications
@@ -335,7 +335,7 @@ class TestPlugwiseAnna(TestPlugwise):  # pylint: disable=attribute-defined-outsi
             smile_version="4.4.1",
         )
 
-        await self.device_test(api, "2022-03-13 00:00:01", testdata, skip_testing=True)
+        await self.device_test(api, "2022-03-13 00:00:01", testdata)
         assert self.entity_items == 63
         assert api.gateway_id == "fb49af122f6e4b0f91267e1cf7666d6f"
         assert self.cooling_present
@@ -354,7 +354,7 @@ class TestPlugwiseAnna(TestPlugwise):  # pylint: disable=attribute-defined-outsi
         server, api, client = await self.connect_wrapper()
         assert api.smile.hostname == "smile000000"
 
-        await self.device_test(api, "2022-03-13 00:00:01", testdata, skip_testing=True)
+        await self.device_test(api, "2022-03-13 00:00:01", testdata)
         assert not self._cooling_enabled
         assert self.entity_items == 68
 
@@ -386,7 +386,7 @@ class TestPlugwiseAnna(TestPlugwise):  # pylint: disable=attribute-defined-outsi
             smile_version="4.2.1",
         )
 
-        await self.device_test(api, "2022-03-10 00:00:01", testdata, skip_testing=True)
+        await self.device_test(api, "2022-03-10 00:00:01", testdata)
         assert self.entity_items == 68
         assert not self.notifications
 
@@ -439,7 +439,7 @@ class TestPlugwiseAnna(TestPlugwise):  # pylint: disable=attribute-defined-outsi
             smile_version=None,
         )
 
-        await self.device_test(api, "2022-05-16 00:00:01", testdata, skip_testing=True)
+        await self.device_test(api, "2022-05-16 00:00:01", testdata)
         assert self.entity_items == 69
         assert self.cooling_present
         assert not self._cooling_enabled
@@ -508,7 +508,7 @@ class TestPlugwiseAnna(TestPlugwise):  # pylint: disable=attribute-defined-outsi
             smile_version=None,
         )
 
-        await self.device_test(api, "2022-05-16 00:00:01", testdata, skip_testing=True)
+        await self.device_test(api, "2022-05-16 00:00:01", testdata)
         assert self.entity_items == 69
         assert self.cooling_present
         assert self._cooling_enabled
@@ -531,7 +531,7 @@ class TestPlugwiseAnna(TestPlugwise):  # pylint: disable=attribute-defined-outsi
             smile_version=None,
         )
 
-        await self.device_test(api, "2022-05-16 00:00:01", testdata, skip_testing=True)
+        await self.device_test(api, "2022-05-16 00:00:01", testdata)
         assert self.entity_items == 69
         assert self.cooling_present
         assert not self._cooling_enabled
@@ -554,7 +554,7 @@ class TestPlugwiseAnna(TestPlugwise):  # pylint: disable=attribute-defined-outsi
             smile_version=None,
         )
 
-        await self.device_test(api, "2025-11-02 00:00:01", testdata, skip_testing=True)
+        await self.device_test(api, "2025-11-02 00:00:01", testdata)
         assert self.entity_items == 78
 
         await api.close_connection()
@@ -575,7 +575,7 @@ class TestPlugwiseAnna(TestPlugwise):  # pylint: disable=attribute-defined-outsi
             smile_version=None,
         )
 
-        await self.device_test(api, "2022-05-16 00:00:01", testdata, skip_testing=True)
+        await self.device_test(api, "2022-05-16 00:00:01", testdata)
         assert self.entity_items == 12
 
         await api.close_connection()

--- a/tests/test_anna.py
+++ b/tests/test_anna.py
@@ -29,7 +29,7 @@ class TestPlugwiseAnna(TestPlugwise):  # pylint: disable=attribute-defined-outsi
 
         await self.device_test(api, "2020-04-05 00:00:01", testdata)
         assert api.gateway_id == "0466eae8520144c78afb29628384edeb"
-        assert self.entity_items == 62
+        assert self.entity_items == 64
         assert not self.notifications
 
         assert not self.cooling_present
@@ -101,7 +101,7 @@ class TestPlugwiseAnna(TestPlugwise):  # pylint: disable=attribute-defined-outsi
         )
 
         await self.device_test(api, "2020-04-05 00:00:01", testdata)
-        assert self.entity_items == 62
+        assert self.entity_items == 64
         assert not self.notifications
 
         result = await self.tinker_thermostat(
@@ -130,7 +130,7 @@ class TestPlugwiseAnna(TestPlugwise):  # pylint: disable=attribute-defined-outsi
         )
 
         await self.device_test(api, "2020-04-05 00:00:01", testdata)
-        assert self.entity_items == 62
+        assert self.entity_items == 64
 
         result = await self.tinker_thermostat(
             api,
@@ -186,7 +186,7 @@ class TestPlugwiseAnna(TestPlugwise):  # pylint: disable=attribute-defined-outsi
 
         await self.device_test(api, "2020-04-12 00:00:01", testdata)
         assert api.gateway_id == "015ae9ea3f964e668e490fa39da3870b"
-        assert self.entity_items == 70
+        assert self.entity_items == 72
         assert not self.notifications
         assert self.cooling_present
         assert not self._cooling_enabled
@@ -216,7 +216,7 @@ class TestPlugwiseAnna(TestPlugwise):  # pylint: disable=attribute-defined-outsi
         await self.device_test(
             api, "2020-04-13 00:00:01", testdata_updated, initialize=False
         )
-        assert self.entity_items == 67
+        assert self.entity_items == 69
         await api.close_connection()
         await self.disconnect(server, client)
 
@@ -241,7 +241,7 @@ class TestPlugwiseAnna(TestPlugwise):  # pylint: disable=attribute-defined-outsi
         )
 
         await self.device_test(api, "2020-04-19 00:00:01", testdata)
-        assert self.entity_items == 67
+        assert self.entity_items == 69
         assert self.cooling_present
         assert not self.notifications
 
@@ -287,7 +287,7 @@ class TestPlugwiseAnna(TestPlugwise):  # pylint: disable=attribute-defined-outsi
         )
 
         await self.device_test(api, "2020-04-19 00:00:01", testdata)
-        assert self.entity_items == 67
+        assert self.entity_items == 69
         assert self.cooling_present
         assert self._cooling_enabled
         assert self._cooling_active
@@ -313,7 +313,7 @@ class TestPlugwiseAnna(TestPlugwise):  # pylint: disable=attribute-defined-outsi
 
         await self.device_test(api, "2020-04-12 00:00:01", testdata)
         assert api.gateway_id == "015ae9ea3f964e668e490fa39da3870b"
-        assert self.entity_items == 66
+        assert self.entity_items == 68
         assert not self.notifications
         assert not self.cooling_present
 
@@ -336,7 +336,7 @@ class TestPlugwiseAnna(TestPlugwise):  # pylint: disable=attribute-defined-outsi
         )
 
         await self.device_test(api, "2022-03-13 00:00:01", testdata)
-        assert self.entity_items == 62
+        assert self.entity_items == 63
         assert api.gateway_id == "fb49af122f6e4b0f91267e1cf7666d6f"
         assert self.cooling_present
         assert not self._cooling_enabled
@@ -356,7 +356,7 @@ class TestPlugwiseAnna(TestPlugwise):  # pylint: disable=attribute-defined-outsi
 
         await self.device_test(api, "2022-03-13 00:00:01", testdata)
         assert not self._cooling_enabled
-        assert self.entity_items == 66
+        assert self.entity_items == 68
 
         result = await self.tinker_thermostat(
             api,
@@ -387,7 +387,7 @@ class TestPlugwiseAnna(TestPlugwise):  # pylint: disable=attribute-defined-outsi
         )
 
         await self.device_test(api, "2022-03-10 00:00:01", testdata)
-        assert self.entity_items == 66
+        assert self.entity_items == 68
         assert not self.notifications
 
         assert self.cooling_present
@@ -440,7 +440,7 @@ class TestPlugwiseAnna(TestPlugwise):  # pylint: disable=attribute-defined-outsi
         )
 
         await self.device_test(api, "2022-05-16 00:00:01", testdata)
-        assert self.entity_items == 67
+        assert self.entity_items == 69
         assert self.cooling_present
         assert not self._cooling_enabled
 
@@ -509,7 +509,7 @@ class TestPlugwiseAnna(TestPlugwise):  # pylint: disable=attribute-defined-outsi
         )
 
         await self.device_test(api, "2022-05-16 00:00:01", testdata)
-        assert self.entity_items == 67
+        assert self.entity_items == 69
         assert self.cooling_present
         assert self._cooling_enabled
 
@@ -532,7 +532,7 @@ class TestPlugwiseAnna(TestPlugwise):  # pylint: disable=attribute-defined-outsi
         )
 
         await self.device_test(api, "2022-05-16 00:00:01", testdata)
-        assert self.entity_items == 67
+        assert self.entity_items == 69
         assert self.cooling_present
         assert not self._cooling_enabled
 
@@ -555,7 +555,7 @@ class TestPlugwiseAnna(TestPlugwise):  # pylint: disable=attribute-defined-outsi
         )
 
         await self.device_test(api, "2025-11-02 00:00:01", testdata)
-        assert self.entity_items == 77
+        assert self.entity_items == 78
 
         await api.close_connection()
         await self.disconnect(server, client)

--- a/tests/test_anna.py
+++ b/tests/test_anna.py
@@ -27,7 +27,7 @@ class TestPlugwiseAnna(TestPlugwise):  # pylint: disable=attribute-defined-outsi
             smile_version="4.0.15",
         )
 
-        await self.device_test(api, "2020-04-05 00:00:01", testdata)
+        await self.device_test(api, "2020-04-05 00:00:01", testdata, skip_testing=True)
         assert api.gateway_id == "0466eae8520144c78afb29628384edeb"
         assert self.entity_items == 64
         assert not self.notifications
@@ -100,7 +100,7 @@ class TestPlugwiseAnna(TestPlugwise):  # pylint: disable=attribute-defined-outsi
             smile_version="4.0.15",
         )
 
-        await self.device_test(api, "2020-04-05 00:00:01", testdata)
+        await self.device_test(api, "2020-04-05 00:00:01", testdata, skip_testing=True)
         assert self.entity_items == 64
         assert not self.notifications
 
@@ -129,7 +129,7 @@ class TestPlugwiseAnna(TestPlugwise):  # pylint: disable=attribute-defined-outsi
             smile_version="4.0.15",
         )
 
-        await self.device_test(api, "2020-04-05 00:00:01", testdata)
+        await self.device_test(api, "2020-04-05 00:00:01", testdata, skip_testing=True)
         assert self.entity_items == 64
 
         result = await self.tinker_thermostat(
@@ -157,7 +157,7 @@ class TestPlugwiseAnna(TestPlugwise):  # pylint: disable=attribute-defined-outsi
             smile_version="4.4.1",
         )
 
-        await self.device_test(api, "2022-05-16 00:00:01", testdata)
+        await self.device_test(api, "2022-05-16 00:00:01", testdata, skip_testing=True)
         assert self.entity_items == 41
         assert not self.notifications
 
@@ -184,7 +184,7 @@ class TestPlugwiseAnna(TestPlugwise):  # pylint: disable=attribute-defined-outsi
             smile_version="4.0.15",
         )
 
-        await self.device_test(api, "2020-04-12 00:00:01", testdata)
+        await self.device_test(api, "2020-04-12 00:00:01", testdata, skip_testing=True)
         assert api.gateway_id == "015ae9ea3f964e668e490fa39da3870b"
         assert self.entity_items == 72
         assert not self.notifications
@@ -240,7 +240,7 @@ class TestPlugwiseAnna(TestPlugwise):  # pylint: disable=attribute-defined-outsi
             smile_version="4.0.15",
         )
 
-        await self.device_test(api, "2020-04-19 00:00:01", testdata)
+        await self.device_test(api, "2020-04-19 00:00:01", testdata, skip_testing=True)
         assert self.entity_items == 69
         assert self.cooling_present
         assert not self.notifications
@@ -286,7 +286,7 @@ class TestPlugwiseAnna(TestPlugwise):  # pylint: disable=attribute-defined-outsi
             smile_version="4.10.10",
         )
 
-        await self.device_test(api, "2020-04-19 00:00:01", testdata)
+        await self.device_test(api, "2020-04-19 00:00:01", testdata, skip_testing=True)
         assert self.entity_items == 69
         assert self.cooling_present
         assert self._cooling_enabled
@@ -311,7 +311,7 @@ class TestPlugwiseAnna(TestPlugwise):  # pylint: disable=attribute-defined-outsi
             smile_version="4.0.15",
         )
 
-        await self.device_test(api, "2020-04-12 00:00:01", testdata)
+        await self.device_test(api, "2020-04-12 00:00:01", testdata, skip_testing=True)
         assert api.gateway_id == "015ae9ea3f964e668e490fa39da3870b"
         assert self.entity_items == 68
         assert not self.notifications
@@ -335,7 +335,7 @@ class TestPlugwiseAnna(TestPlugwise):  # pylint: disable=attribute-defined-outsi
             smile_version="4.4.1",
         )
 
-        await self.device_test(api, "2022-03-13 00:00:01", testdata)
+        await self.device_test(api, "2022-03-13 00:00:01", testdata, skip_testing=True)
         assert self.entity_items == 63
         assert api.gateway_id == "fb49af122f6e4b0f91267e1cf7666d6f"
         assert self.cooling_present
@@ -354,7 +354,7 @@ class TestPlugwiseAnna(TestPlugwise):  # pylint: disable=attribute-defined-outsi
         server, api, client = await self.connect_wrapper()
         assert api.smile.hostname == "smile000000"
 
-        await self.device_test(api, "2022-03-13 00:00:01", testdata)
+        await self.device_test(api, "2022-03-13 00:00:01", testdata, skip_testing=True)
         assert not self._cooling_enabled
         assert self.entity_items == 68
 
@@ -386,7 +386,7 @@ class TestPlugwiseAnna(TestPlugwise):  # pylint: disable=attribute-defined-outsi
             smile_version="4.2.1",
         )
 
-        await self.device_test(api, "2022-03-10 00:00:01", testdata)
+        await self.device_test(api, "2022-03-10 00:00:01", testdata, skip_testing=True)
         assert self.entity_items == 68
         assert not self.notifications
 
@@ -439,7 +439,7 @@ class TestPlugwiseAnna(TestPlugwise):  # pylint: disable=attribute-defined-outsi
             smile_version=None,
         )
 
-        await self.device_test(api, "2022-05-16 00:00:01", testdata)
+        await self.device_test(api, "2022-05-16 00:00:01", testdata, skip_testing=True)
         assert self.entity_items == 69
         assert self.cooling_present
         assert not self._cooling_enabled
@@ -508,7 +508,7 @@ class TestPlugwiseAnna(TestPlugwise):  # pylint: disable=attribute-defined-outsi
             smile_version=None,
         )
 
-        await self.device_test(api, "2022-05-16 00:00:01", testdata)
+        await self.device_test(api, "2022-05-16 00:00:01", testdata, skip_testing=True)
         assert self.entity_items == 69
         assert self.cooling_present
         assert self._cooling_enabled
@@ -531,7 +531,7 @@ class TestPlugwiseAnna(TestPlugwise):  # pylint: disable=attribute-defined-outsi
             smile_version=None,
         )
 
-        await self.device_test(api, "2022-05-16 00:00:01", testdata)
+        await self.device_test(api, "2022-05-16 00:00:01", testdata, skip_testing=True)
         assert self.entity_items == 69
         assert self.cooling_present
         assert not self._cooling_enabled
@@ -554,7 +554,7 @@ class TestPlugwiseAnna(TestPlugwise):  # pylint: disable=attribute-defined-outsi
             smile_version=None,
         )
 
-        await self.device_test(api, "2025-11-02 00:00:01", testdata)
+        await self.device_test(api, "2025-11-02 00:00:01", testdata, skip_testing=True)
         assert self.entity_items == 78
 
         await api.close_connection()
@@ -575,7 +575,7 @@ class TestPlugwiseAnna(TestPlugwise):  # pylint: disable=attribute-defined-outsi
             smile_version=None,
         )
 
-        await self.device_test(api, "2022-05-16 00:00:01", testdata)
+        await self.device_test(api, "2022-05-16 00:00:01", testdata, skip_testing=True)
         assert self.entity_items == 12
 
         await api.close_connection()

--- a/tests/test_anna.py
+++ b/tests/test_anna.py
@@ -29,7 +29,7 @@ class TestPlugwiseAnna(TestPlugwise):  # pylint: disable=attribute-defined-outsi
 
         await self.device_test(api, "2020-04-05 00:00:01", testdata, skip_testing=True)
         assert api.gateway_id == "0466eae8520144c78afb29628384edeb"
-        # assert self.entity_items == 64
+        assert self.entity_items == 64
         assert not self.notifications
 
         assert not self.cooling_present
@@ -101,7 +101,7 @@ class TestPlugwiseAnna(TestPlugwise):  # pylint: disable=attribute-defined-outsi
         )
 
         await self.device_test(api, "2020-04-05 00:00:01", testdata, skip_testing=True)
-        # assert self.entity_items == 64
+        assert self.entity_items == 64
         assert not self.notifications
 
         result = await self.tinker_thermostat(
@@ -130,7 +130,7 @@ class TestPlugwiseAnna(TestPlugwise):  # pylint: disable=attribute-defined-outsi
         )
 
         await self.device_test(api, "2020-04-05 00:00:01", testdata, skip_testing=True)
-        # assert self.entity_items == 64
+        assert self.entity_items == 64
 
         result = await self.tinker_thermostat(
             api,
@@ -158,7 +158,7 @@ class TestPlugwiseAnna(TestPlugwise):  # pylint: disable=attribute-defined-outsi
         )
 
         await self.device_test(api, "2022-05-16 00:00:01", testdata, skip_testing=True)
-        # assert self.entity_items == 41
+        assert self.entity_items == 41
         assert not self.notifications
 
         result = await self.tinker_thermostat(
@@ -186,7 +186,7 @@ class TestPlugwiseAnna(TestPlugwise):  # pylint: disable=attribute-defined-outsi
 
         await self.device_test(api, "2020-04-12 00:00:01", testdata, skip_testing=True)
         assert api.gateway_id == "015ae9ea3f964e668e490fa39da3870b"
-        # assert self.entity_items == 72
+        assert self.entity_items == 72
         assert not self.notifications
         assert self.cooling_present
         assert not self._cooling_enabled
@@ -216,7 +216,7 @@ class TestPlugwiseAnna(TestPlugwise):  # pylint: disable=attribute-defined-outsi
         await self.device_test(
             api, "2020-04-13 00:00:01", testdata_updated, initialize=False
         )
-        # assert self.entity_items == 69
+        assert self.entity_items == 69
         await api.close_connection()
         await self.disconnect(server, client)
 
@@ -241,7 +241,7 @@ class TestPlugwiseAnna(TestPlugwise):  # pylint: disable=attribute-defined-outsi
         )
 
         await self.device_test(api, "2020-04-19 00:00:01", testdata, skip_testing=True)
-        # assert self.entity_items == 69
+        assert self.entity_items == 69
         assert self.cooling_present
         assert not self.notifications
 
@@ -287,7 +287,7 @@ class TestPlugwiseAnna(TestPlugwise):  # pylint: disable=attribute-defined-outsi
         )
 
         await self.device_test(api, "2020-04-19 00:00:01", testdata, skip_testing=True)
-        # assert self.entity_items == 69
+        assert self.entity_items == 69
         assert self.cooling_present
         assert self._cooling_enabled
         assert self._cooling_active
@@ -313,7 +313,7 @@ class TestPlugwiseAnna(TestPlugwise):  # pylint: disable=attribute-defined-outsi
 
         await self.device_test(api, "2020-04-12 00:00:01", testdata, skip_testing=True)
         assert api.gateway_id == "015ae9ea3f964e668e490fa39da3870b"
-        # assert self.entity_items == 68
+        assert self.entity_items == 68
         assert not self.notifications
         assert not self.cooling_present
 
@@ -336,7 +336,7 @@ class TestPlugwiseAnna(TestPlugwise):  # pylint: disable=attribute-defined-outsi
         )
 
         await self.device_test(api, "2022-03-13 00:00:01", testdata, skip_testing=True)
-        # assert self.entity_items == 63
+        assert self.entity_items == 63
         assert api.gateway_id == "fb49af122f6e4b0f91267e1cf7666d6f"
         assert self.cooling_present
         assert not self._cooling_enabled
@@ -356,7 +356,7 @@ class TestPlugwiseAnna(TestPlugwise):  # pylint: disable=attribute-defined-outsi
 
         await self.device_test(api, "2022-03-13 00:00:01", testdata, skip_testing=True)
         assert not self._cooling_enabled
-        # assert self.entity_items == 68
+        assert self.entity_items == 68
 
         result = await self.tinker_thermostat(
             api,
@@ -387,7 +387,7 @@ class TestPlugwiseAnna(TestPlugwise):  # pylint: disable=attribute-defined-outsi
         )
 
         await self.device_test(api, "2022-03-10 00:00:01", testdata, skip_testing=True)
-        # assert self.entity_items == 68
+        assert self.entity_items == 68
         assert not self.notifications
 
         assert self.cooling_present
@@ -440,7 +440,7 @@ class TestPlugwiseAnna(TestPlugwise):  # pylint: disable=attribute-defined-outsi
         )
 
         await self.device_test(api, "2022-05-16 00:00:01", testdata, skip_testing=True)
-        # assert self.entity_items == 69
+        assert self.entity_items == 69
         assert self.cooling_present
         assert not self._cooling_enabled
 
@@ -509,7 +509,7 @@ class TestPlugwiseAnna(TestPlugwise):  # pylint: disable=attribute-defined-outsi
         )
 
         await self.device_test(api, "2022-05-16 00:00:01", testdata, skip_testing=True)
-        # assert self.entity_items == 69
+        assert self.entity_items == 69
         assert self.cooling_present
         assert self._cooling_enabled
 
@@ -532,7 +532,7 @@ class TestPlugwiseAnna(TestPlugwise):  # pylint: disable=attribute-defined-outsi
         )
 
         await self.device_test(api, "2022-05-16 00:00:01", testdata, skip_testing=True)
-        # assert self.entity_items == 69
+        assert self.entity_items == 69
         assert self.cooling_present
         assert not self._cooling_enabled
 
@@ -555,7 +555,7 @@ class TestPlugwiseAnna(TestPlugwise):  # pylint: disable=attribute-defined-outsi
         )
 
         await self.device_test(api, "2025-11-02 00:00:01", testdata, skip_testing=True)
-        # assert self.entity_items == 78
+        assert self.entity_items == 78
 
         await api.close_connection()
         await self.disconnect(server, client)
@@ -576,7 +576,7 @@ class TestPlugwiseAnna(TestPlugwise):  # pylint: disable=attribute-defined-outsi
         )
 
         await self.device_test(api, "2022-05-16 00:00:01", testdata, skip_testing=True)
-        # assert self.entity_items == 12
+        assert self.entity_items == 12
 
         await api.close_connection()
         await self.disconnect(server, client)

--- a/tests/test_anna.py
+++ b/tests/test_anna.py
@@ -186,7 +186,7 @@ class TestPlugwiseAnna(TestPlugwise):  # pylint: disable=attribute-defined-outsi
 
         await self.device_test(api, "2020-04-12 00:00:01", testdata)
         assert api.gateway_id == "015ae9ea3f964e668e490fa39da3870b"
-        assert self.entity_items == 72
+        assert self.entity_items == 73
         assert not self.notifications
         assert self.cooling_present
         assert not self._cooling_enabled
@@ -313,7 +313,7 @@ class TestPlugwiseAnna(TestPlugwise):  # pylint: disable=attribute-defined-outsi
 
         await self.device_test(api, "2020-04-12 00:00:01", testdata)
         assert api.gateway_id == "015ae9ea3f964e668e490fa39da3870b"
-        assert self.entity_items == 68
+        assert self.entity_items == 69
         assert not self.notifications
         assert not self.cooling_present
 
@@ -440,7 +440,7 @@ class TestPlugwiseAnna(TestPlugwise):  # pylint: disable=attribute-defined-outsi
         )
 
         await self.device_test(api, "2022-05-16 00:00:01", testdata)
-        assert self.entity_items == 69
+        assert self.entity_items == 70
         assert self.cooling_present
         assert not self._cooling_enabled
 
@@ -509,7 +509,7 @@ class TestPlugwiseAnna(TestPlugwise):  # pylint: disable=attribute-defined-outsi
         )
 
         await self.device_test(api, "2022-05-16 00:00:01", testdata)
-        assert self.entity_items == 69
+        assert self.entity_items == 70
         assert self.cooling_present
         assert self._cooling_enabled
 
@@ -532,7 +532,7 @@ class TestPlugwiseAnna(TestPlugwise):  # pylint: disable=attribute-defined-outsi
         )
 
         await self.device_test(api, "2022-05-16 00:00:01", testdata)
-        assert self.entity_items == 69
+        assert self.entity_items == 70
         assert self.cooling_present
         assert not self._cooling_enabled
 

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -916,8 +916,8 @@ class TestPlugwise:  # pylint: disable=attribute-defined-outside-init
         new_temp = 60.0
         _LOGGER.info("- Adjusting temperature to %s", new_temp)
         for test in [
-            "boiler_temperature",
-            "dhw_temperature",
+            "maximum_boiler_temperature",
+            "max_dhw_temperature",
             "bogus_temperature",
         ]:
             _LOGGER.info("  + for %s", test)

--- a/tests/test_legacy_anna.py
+++ b/tests/test_legacy_anna.py
@@ -30,7 +30,7 @@ class TestPlugwiseAnna(TestPlugwise):  # pylint: disable=attribute-defined-outsi
 
         await self.device_test(api, "2020-03-22 00:00:01", testdata)
         assert api.gateway_id == "0000aaaa0000aaaa0000aaaa0000aa00"
-        assert self.entity_items == 44
+        assert self.entity_items == 45
         assert not api.reboot
 
         result = await self.tinker_legacy_thermostat(api, schedule_on=False)
@@ -65,7 +65,7 @@ class TestPlugwiseAnna(TestPlugwise):  # pylint: disable=attribute-defined-outsi
         await self.device_test(api, "2020-05-03 00:00:01", testdata)
 
         assert api.gateway_id == "be81e3f8275b4129852c4d8d550ae2eb"
-        assert self.entity_items == 44
+        assert self.entity_items == 45
 
         result = await self.tinker_legacy_thermostat(api)
         assert result


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for new maximum boiler and domestic hot water temperature controls.
  * Added `water_temperature` readings to compatible heating and cooling devices.
  * Added domestic hot water comfort switch support (`dhw_cm_switch`) where available.
  * Improved DHW mode handling to work with the newer temperature control model.
* **Bug Fixes**
  * Updated device data handling so legacy and current devices expose the correct temperature fields and switches consistently.
* **Chores / Tests**
  * Updated fixtures, test data, and expected entity counts to match the revised data shape.
* **Documentation**
  * Added a changelog entry for the upcoming `water_heaters` introduction (v1.14.0a0).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->