### PR TITLE
Change no thermostat schedule defined representation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## Ongoing
+
+- Change representation of no-thermostat-schedule-defined to a single `off` option via PR [#899](https://github.com/plugwise/python-plugwise/pull/899)
+
 ## v1.14.1
 
 - Improve manual fixtures script, reorder set_schedule_state() arguments for better compatibility with set_dhw_mode(), via PR[#897](https://github.com/plugwise/python-plugwise/pull/897)

--- a/fixtures/adam_bad_thermostat/data.json
+++ b/fixtures/adam_bad_thermostat/data.json
@@ -45,7 +45,9 @@
   },
   "3ee6b9486cb04c258a3130fff2b144a4": {
     "active_preset": "home",
-    "available_schedules": [],
+    "available_schedules": [
+      "off"
+    ],
     "climate_mode": "heat",
     "control_state": "idle",
     "dev_class": "climate",
@@ -58,7 +60,7 @@
       "vacation",
       "no_frost"
     ],
-    "select_schedule": null,
+    "select_schedule": "off",
     "sensors": {
       "temperature": 20.3
     },

--- a/fixtures/adam_heatpump_cooling/data.json
+++ b/fixtures/adam_heatpump_cooling/data.json
@@ -2,10 +2,10 @@
   "04b15f6e884448288f811d29fb7b1b30": {
     "active_preset": "away",
     "available_schedules": [
+      "off",
       "Opstaan weekdag",
       "Werkdag schema",
-      "Weekend",
-      "off"
+      "Weekend"
     ],
     "climate_mode": "cool",
     "control_state": "idle",
@@ -141,10 +141,10 @@
   "20e735858f8146cead98b873177a4f99": {
     "active_preset": "away",
     "available_schedules": [
+      "off",
       "Opstaan weekdag",
       "Werkdag schema",
-      "Weekend",
-      "off"
+      "Weekend"
     ],
     "climate_mode": "cool",
     "control_state": "idle",
@@ -269,10 +269,10 @@
   "5cc21042f87f4b4c94ccb5537c47a53f": {
     "active_preset": "away",
     "available_schedules": [
+      "off",
       "Opstaan weekdag",
       "Werkdag schema",
-      "Weekend",
-      "off"
+      "Weekend"
     ],
     "climate_mode": "auto",
     "control_state": "idle",
@@ -429,10 +429,10 @@
   "8cf650a4c10c44819e426bed406aec34": {
     "active_preset": "away",
     "available_schedules": [
+      "off",
       "Opstaan weekdag",
       "Werkdag schema",
-      "Weekend",
-      "off"
+      "Weekend"
     ],
     "climate_mode": "auto",
     "control_state": "idle",
@@ -475,10 +475,10 @@
   "93ac3f7bf25342f58cbb77c4a99ac0b3": {
     "active_preset": "away",
     "available_schedules": [
+      "off",
       "Opstaan weekdag",
       "Werkdag schema",
-      "Weekend",
-      "off"
+      "Weekend"
     ],
     "climate_mode": "cool",
     "control_state": "idle",
@@ -540,10 +540,10 @@
   "9a27714b970547ee9a6bdadc2b815ad5": {
     "active_preset": "away",
     "available_schedules": [
+      "off",
       "Opstaan weekdag",
       "Werkdag schema",
-      "Weekend",
-      "off"
+      "Weekend"
     ],
     "climate_mode": "cool",
     "control_state": "idle",
@@ -606,10 +606,10 @@
   "a562019b0b1f47a4bde8ebe3dbe3e8a9": {
     "active_preset": "away",
     "available_schedules": [
+      "off",
       "Opstaan weekdag",
       "Werkdag schema",
-      "Weekend",
-      "off"
+      "Weekend"
     ],
     "climate_mode": "auto",
     "control_state": "idle",
@@ -652,10 +652,10 @@
   "b52908550469425b812c87f766fe5303": {
     "active_preset": "away",
     "available_schedules": [
+      "off",
       "Opstaan weekdag",
       "Werkdag schema",
-      "Weekend",
-      "off"
+      "Weekend"
     ],
     "climate_mode": "cool",
     "control_state": "idle",
@@ -796,10 +796,10 @@
   "e39529c79ab54fda9bed26cfc0447546": {
     "active_preset": "away",
     "available_schedules": [
+      "off",
       "Opstaan weekdag",
       "Werkdag schema",
-      "Weekend",
-      "off"
+      "Weekend"
     ],
     "climate_mode": "cool",
     "control_state": "idle",
@@ -912,10 +912,10 @@
   "fa5fa6b34f6b40a0972988b20e888ed4": {
     "active_preset": "away",
     "available_schedules": [
+      "off",
       "Opstaan weekdag",
       "Werkdag schema",
-      "Weekend",
-      "off"
+      "Weekend"
     ],
     "climate_mode": "auto",
     "control_state": "idle",

--- a/fixtures/adam_jip/data.json
+++ b/fixtures/adam_jip/data.json
@@ -1,7 +1,9 @@
 {
   "06aecb3d00354375924f50c47af36bd2": {
     "active_preset": "no_frost",
-    "available_schedules": [],
+    "available_schedules": [
+      "off"
+    ],
     "climate_mode": "heat",
     "control_state": "idle",
     "dev_class": "climate",
@@ -14,7 +16,7 @@
       "vacation",
       "no_frost"
     ],
-    "select_schedule": null,
+    "select_schedule": "off",
     "select_zone_profile": "active",
     "sensors": {
       "temperature": 24.2
@@ -42,7 +44,9 @@
   },
   "13228dab8ce04617af318a2888b3c548": {
     "active_preset": "home",
-    "available_schedules": [],
+    "available_schedules": [
+      "off"
+    ],
     "climate_mode": "heat",
     "control_state": "idle",
     "dev_class": "climate",
@@ -55,7 +59,7 @@
       "vacation",
       "no_frost"
     ],
-    "select_schedule": null,
+    "select_schedule": "off",
     "select_zone_profile": "active",
     "sensors": {
       "temperature": 27.4
@@ -282,7 +286,9 @@
   },
   "d27aede973b54be484f6842d1b2802ad": {
     "active_preset": "home",
-    "available_schedules": [],
+    "available_schedules": [
+      "off"
+    ],
     "climate_mode": "heat",
     "control_state": "idle",
     "dev_class": "climate",
@@ -295,7 +301,7 @@
       "vacation",
       "no_frost"
     ],
-    "select_schedule": null,
+    "select_schedule": "off",
     "select_zone_profile": "active",
     "sensors": {
       "temperature": 30.0
@@ -347,7 +353,9 @@
   },
   "d58fec52899f4f1c92e4f8fad6d8c48c": {
     "active_preset": "home",
-    "available_schedules": [],
+    "available_schedules": [
+      "off"
+    ],
     "climate_mode": "heat",
     "control_state": "idle",
     "dev_class": "climate",
@@ -360,7 +368,7 @@
       "vacation",
       "no_frost"
     ],
-    "select_schedule": null,
+    "select_schedule": "off",
     "select_zone_profile": "active",
     "sensors": {
       "temperature": 30.0

--- a/fixtures/adam_multiple_devices_per_zone/data.json
+++ b/fixtures/adam_multiple_devices_per_zone/data.json
@@ -23,12 +23,12 @@
   "08963fec7c53423ca5680aa4cb502c63": {
     "active_preset": "away",
     "available_schedules": [
+      "off",
       "CV Roan",
       "Bios Schema met Film Avond",
       "GF7  Woonkamer",
       "Badkamer Schema",
-      "CV Jessie",
-      "off"
+      "CV Jessie"
     ],
     "climate_mode": "auto",
     "control_state": "idle",
@@ -64,12 +64,12 @@
   "12493538af164a409c6a1c79e38afe1c": {
     "active_preset": "away",
     "available_schedules": [
+      "off",
       "CV Roan",
       "Bios Schema met Film Avond",
       "GF7  Woonkamer",
       "Badkamer Schema",
-      "CV Jessie",
-      "off"
+      "CV Jessie"
     ],
     "climate_mode": "heat",
     "control_state": "idle",
@@ -129,12 +129,12 @@
   "446ac08dd04d4eff8ac57489757b7314": {
     "active_preset": "no_frost",
     "available_schedules": [
+      "off",
       "CV Roan",
       "Bios Schema met Film Avond",
       "GF7  Woonkamer",
       "Badkamer Schema",
-      "CV Jessie",
-      "off"
+      "CV Jessie"
     ],
     "climate_mode": "heat",
     "control_state": "idle",
@@ -285,12 +285,12 @@
   "82fa13f017d240daa0d0ea1775420f24": {
     "active_preset": "asleep",
     "available_schedules": [
+      "off",
       "CV Roan",
       "Bios Schema met Film Avond",
       "GF7  Woonkamer",
       "Badkamer Schema",
-      "CV Jessie",
-      "off"
+      "CV Jessie"
     ],
     "climate_mode": "auto",
     "control_state": "idle",
@@ -440,12 +440,12 @@
   "c50f167537524366a5af7aa3942feb1e": {
     "active_preset": "home",
     "available_schedules": [
+      "off",
       "CV Roan",
       "Bios Schema met Film Avond",
       "GF7  Woonkamer",
       "Badkamer Schema",
-      "CV Jessie",
-      "off"
+      "CV Jessie"
     ],
     "climate_mode": "auto",
     "control_state": "heating",

--- a/fixtures/adam_onoff_cooling_fake_firmware/data.json
+++ b/fixtures/adam_onoff_cooling_fake_firmware/data.json
@@ -91,10 +91,10 @@
   "fa5fa6b34f6b40a0972988b20e888ed4": {
     "active_preset": "away",
     "available_schedules": [
+      "off",
       "Opstaan weekdag",
       "Werkdag schema",
-      "Weekend",
-      "off"
+      "Weekend"
     ],
     "climate_mode": "auto",
     "control_state": "idle",

--- a/fixtures/adam_plus_anna/data.json
+++ b/fixtures/adam_plus_anna/data.json
@@ -2,8 +2,8 @@
   "009490cc2f674ce6b576863fbb64f867": {
     "active_preset": "home",
     "available_schedules": [
-      "Weekschema",
-      "off"
+      "off",
+      "Weekschema"
     ],
     "climate_mode": "auto",
     "control_state": "idle",

--- a/fixtures/adam_plus_anna_new/data.json
+++ b/fixtures/adam_plus_anna_new/data.json
@@ -302,11 +302,11 @@
   "f2bf9048bef64cc5b6d5110154e33c81": {
     "active_preset": "home",
     "available_schedules": [
+      "off",
       "Badkamer",
       "Vakantie",
       "Weekschema",
-      "Test",
-      "off"
+      "Test"
     ],
     "climate_mode": "auto",
     "control_state": "heating",
@@ -351,11 +351,11 @@
   "f871b8c4d63549319221e294e4f88074": {
     "active_preset": "vacation",
     "available_schedules": [
+      "off",
       "Badkamer",
       "Vakantie",
       "Weekschema",
-      "Test",
-      "off"
+      "Test"
     ],
     "climate_mode": "heat",
     "control_state": "idle",

--- a/fixtures/adam_plus_anna_new_regulation_off/data.json
+++ b/fixtures/adam_plus_anna_new_regulation_off/data.json
@@ -254,11 +254,11 @@
   "f2bf9048bef64cc5b6d5110154e33c81": {
     "active_preset": "home",
     "available_schedules": [
+      "off",
       "Badkamer",
       "Test",
       "Vakantie",
-      "Weekschema",
-      "off"
+      "Weekschema"
     ],
     "climate_mode": "off",
     "control_state": "idle",
@@ -301,11 +301,11 @@
   "f871b8c4d63549319221e294e4f88074": {
     "active_preset": "home",
     "available_schedules": [
+      "off",
       "Badkamer",
       "Test",
       "Vakantie",
-      "Weekschema",
-      "off"
+      "Weekschema"
     ],
     "climate_mode": "off",
     "control_state": "idle",

--- a/fixtures/adam_zone_per_device/data.json
+++ b/fixtures/adam_zone_per_device/data.json
@@ -23,12 +23,12 @@
   "08963fec7c53423ca5680aa4cb502c63": {
     "active_preset": "away",
     "available_schedules": [
+      "off",
       "CV Roan",
       "Bios Schema met Film Avond",
       "GF7  Woonkamer",
       "Badkamer Schema",
-      "CV Jessie",
-      "off"
+      "CV Jessie"
     ],
     "climate_mode": "auto",
     "control_state": "idle",
@@ -65,12 +65,12 @@
   "12493538af164a409c6a1c79e38afe1c": {
     "active_preset": "away",
     "available_schedules": [
+      "off",
       "CV Roan",
       "Bios Schema met Film Avond",
       "GF7  Woonkamer",
       "Badkamer Schema",
-      "CV Jessie",
-      "off"
+      "CV Jessie"
     ],
     "climate_mode": "heat",
     "control_state": "idle",
@@ -130,12 +130,12 @@
   "446ac08dd04d4eff8ac57489757b7314": {
     "active_preset": "no_frost",
     "available_schedules": [
+      "off",
       "CV Roan",
       "Bios Schema met Film Avond",
       "GF7  Woonkamer",
       "Badkamer Schema",
-      "CV Jessie",
-      "off"
+      "CV Jessie"
     ],
     "climate_mode": "heat",
     "control_state": "idle",
@@ -286,12 +286,12 @@
   "82fa13f017d240daa0d0ea1775420f24": {
     "active_preset": "asleep",
     "available_schedules": [
+      "off",
       "CV Roan",
       "Bios Schema met Film Avond",
       "GF7  Woonkamer",
       "Badkamer Schema",
-      "CV Jessie",
-      "off"
+      "CV Jessie"
     ],
     "climate_mode": "auto",
     "control_state": "idle",
@@ -441,12 +441,12 @@
   "c50f167537524366a5af7aa3942feb1e": {
     "active_preset": "home",
     "available_schedules": [
+      "off",
       "CV Roan",
       "Bios Schema met Film Avond",
       "GF7  Woonkamer",
       "Badkamer Schema",
-      "CV Jessie",
-      "off"
+      "CV Jessie"
     ],
     "climate_mode": "auto",
     "control_state": "heating",

--- a/fixtures/anna_elga_2/data.json
+++ b/fixtures/anna_elga_2/data.json
@@ -36,8 +36,8 @@
   "ebd90df1ab334565b5895f37590ccff4": {
     "active_preset": "home",
     "available_schedules": [
-      "Thermostat schedule",
-      "off"
+      "off",
+      "Thermostat schedule"
     ],
     "climate_mode": "auto",
     "control_state": "heating",

--- a/fixtures/anna_elga_2_cooling/data.json
+++ b/fixtures/anna_elga_2_cooling/data.json
@@ -43,8 +43,8 @@
   "ebd90df1ab334565b5895f37590ccff4": {
     "active_preset": "home",
     "available_schedules": [
-      "Thermostat schedule",
-      "off"
+      "off",
+      "Thermostat schedule"
     ],
     "climate_mode": "auto",
     "control_state": "cooling",

--- a/fixtures/anna_elga_2_schedule_off/data.json
+++ b/fixtures/anna_elga_2_schedule_off/data.json
@@ -43,8 +43,8 @@
   "ebd90df1ab334565b5895f37590ccff4": {
     "active_preset": "home",
     "available_schedules": [
-      "Thermostat schedule",
-      "off"
+      "off",
+      "Thermostat schedule"
     ],
     "climate_mode": "heat_cool",
     "control_state": "idle",

--- a/fixtures/anna_elga_no_cooling/data.json
+++ b/fixtures/anna_elga_no_cooling/data.json
@@ -66,8 +66,8 @@
   "3cb70739631c4d17a86b8b12e8a5161b": {
     "active_preset": "home",
     "available_schedules": [
-      "standaard",
-      "off"
+      "off",
+      "standaard"
     ],
     "climate_mode": "auto",
     "control_state": "heating",

--- a/fixtures/anna_heatpump_cooling/data.json
+++ b/fixtures/anna_heatpump_cooling/data.json
@@ -62,8 +62,8 @@
   "3cb70739631c4d17a86b8b12e8a5161b": {
     "active_preset": "home",
     "available_schedules": [
-      "standaard",
-      "off"
+      "off",
+      "standaard"
     ],
     "climate_mode": "heat_cool",
     "control_state": "cooling",

--- a/fixtures/anna_heatpump_cooling_fake_firmware/data.json
+++ b/fixtures/anna_heatpump_cooling_fake_firmware/data.json
@@ -62,8 +62,8 @@
   "3cb70739631c4d17a86b8b12e8a5161b": {
     "active_preset": "home",
     "available_schedules": [
-      "standaard",
-      "off"
+      "off",
+      "standaard"
     ],
     "climate_mode": "heat_cool",
     "control_state": "cooling",

--- a/fixtures/anna_heatpump_heating/data.json
+++ b/fixtures/anna_heatpump_heating/data.json
@@ -68,8 +68,8 @@
   "3cb70739631c4d17a86b8b12e8a5161b": {
     "active_preset": "home",
     "available_schedules": [
-      "standaard",
-      "off"
+      "off",
+      "standaard"
     ],
     "climate_mode": "auto",
     "control_state": "heating",

--- a/fixtures/anna_loria_cooling_active/data.json
+++ b/fixtures/anna_loria_cooling_active/data.json
@@ -2,9 +2,9 @@
   "582dfbdace4d4aeb832923ce7d1ddda0": {
     "active_preset": "home",
     "available_schedules": [
+      "off",
       "Winter",
-      "Test ",
-      "off"
+      "Test "
     ],
     "climate_mode": "auto",
     "control_state": "cooling",

--- a/fixtures/anna_loria_driessens/data.json
+++ b/fixtures/anna_loria_driessens/data.json
@@ -20,11 +20,11 @@
   "9fb768d699e44c7fb5cc50309dc4e7d4": {
     "active_preset": "home",
     "available_schedules": [
+      "off",
       "Verwarmen@9-23u",
       "VAKANTIE (winter)",
       "VERWARMEN",
-      "KOELEN",
-      "off"
+      "KOELEN"
     ],
     "climate_mode": "auto",
     "control_state": "idle",

--- a/fixtures/anna_loria_heating_idle/data.json
+++ b/fixtures/anna_loria_heating_idle/data.json
@@ -2,9 +2,9 @@
   "582dfbdace4d4aeb832923ce7d1ddda0": {
     "active_preset": "home",
     "available_schedules": [
+      "off",
       "Winter",
-      "Test ",
-      "off"
+      "Test "
     ],
     "climate_mode": "auto",
     "control_state": "idle",

--- a/fixtures/anna_p1/data.json
+++ b/fixtures/anna_p1/data.json
@@ -2,8 +2,8 @@
   "1e5e55b958ac445583602f767cb45942": {
     "active_preset": "home",
     "available_schedules": [
-      "Thermostat schedule",
-      "off"
+      "off",
+      "Thermostat schedule"
     ],
     "climate_mode": "heat",
     "control_state": "idle",

--- a/fixtures/anna_v4/data.json
+++ b/fixtures/anna_v4/data.json
@@ -2,9 +2,9 @@
   "01b85360fdd243d0aaad4d6ac2a5ba7e": {
     "active_preset": "home",
     "available_schedules": [
+      "off",
       "Standaard",
-      "Thuiswerken",
-      "off"
+      "Thuiswerken"
     ],
     "climate_mode": "heat",
     "control_state": "heating",

--- a/fixtures/anna_v4_dhw/data.json
+++ b/fixtures/anna_v4_dhw/data.json
@@ -2,9 +2,9 @@
   "01b85360fdd243d0aaad4d6ac2a5ba7e": {
     "active_preset": "home",
     "available_schedules": [
+      "off",
       "Standaard",
-      "Thuiswerken",
-      "off"
+      "Thuiswerken"
     ],
     "climate_mode": "heat",
     "control_state": "idle",

--- a/fixtures/anna_v4_no_tag/data.json
+++ b/fixtures/anna_v4_no_tag/data.json
@@ -2,9 +2,9 @@
   "01b85360fdd243d0aaad4d6ac2a5ba7e": {
     "active_preset": "home",
     "available_schedules": [
+      "off",
       "Standaard",
-      "Thuiswerken",
-      "off"
+      "Thuiswerken"
     ],
     "climate_mode": "auto",
     "control_state": "heating",

--- a/fixtures/anna_without_boiler_fw441/data.json
+++ b/fixtures/anna_without_boiler_fw441/data.json
@@ -2,9 +2,9 @@
   "7ffbb3ab4b6c4ab2915d7510f7bf8fe9": {
     "active_preset": "home",
     "available_schedules": [
+      "off",
       "Test",
-      "Normaal",
-      "off"
+      "Normaal"
     ],
     "climate_mode": "auto",
     "control_state": "idle",

--- a/fixtures/legacy_anna/data.json
+++ b/fixtures/legacy_anna/data.json
@@ -36,7 +36,9 @@
   },
   "0d266432d64443e283b5d708ae98b455": {
     "active_preset": "home",
-    "available_schedules": [],
+    "available_schedules": [
+      "off"
+    ],
     "climate_mode": "heat",
     "control_state": "heating",
     "dev_class": "thermostat",
@@ -52,7 +54,7 @@
       "home",
       "no_frost"
     ],
-    "select_schedule": null,
+    "select_schedule": "off",
     "sensors": {
       "illuminance": 150.8,
       "setpoint": 20.5,

--- a/fixtures/legacy_anna_2/data.json
+++ b/fixtures/legacy_anna_2/data.json
@@ -2,8 +2,8 @@
   "9e7377867dc24e51b8098a5ba02bd89d": {
     "active_preset": null,
     "available_schedules": [
-      "Thermostat schedule",
-      "off"
+      "off",
+      "Thermostat schedule"
     ],
     "climate_mode": "heat",
     "control_state": "idle",

--- a/fixtures/m_adam_cooling/data.json
+++ b/fixtures/m_adam_cooling/data.json
@@ -213,11 +213,11 @@
   "f2bf9048bef64cc5b6d5110154e33c81": {
     "active_preset": "home",
     "available_schedules": [
+      "off",
       "Badkamer",
       "Vakantie",
       "Weekschema",
-      "Test",
-      "off"
+      "Test"
     ],
     "climate_mode": "cool",
     "control_state": "cooling",
@@ -262,11 +262,11 @@
   "f871b8c4d63549319221e294e4f88074": {
     "active_preset": "vacation",
     "available_schedules": [
+      "off",
       "Badkamer",
       "Vakantie",
       "Weekschema",
-      "Test",
-      "off"
+      "Test"
     ],
     "climate_mode": "auto",
     "control_state": "cooling",

--- a/fixtures/m_adam_heating/data.json
+++ b/fixtures/m_adam_heating/data.json
@@ -218,11 +218,11 @@
   "f2bf9048bef64cc5b6d5110154e33c81": {
     "active_preset": "home",
     "available_schedules": [
+      "off",
       "Badkamer",
       "Vakantie",
       "Weekschema",
-      "Test",
-      "off"
+      "Test"
     ],
     "climate_mode": "heat",
     "control_state": "preheating",
@@ -267,11 +267,11 @@
   "f871b8c4d63549319221e294e4f88074": {
     "active_preset": "vacation",
     "available_schedules": [
+      "off",
       "Badkamer",
       "Vakantie",
       "Weekschema",
-      "Test",
-      "off"
+      "Test"
     ],
     "climate_mode": "auto",
     "control_state": "idle",

--- a/fixtures/m_adam_heating_off_schedule/data.json
+++ b/fixtures/m_adam_heating_off_schedule/data.json
@@ -218,11 +218,11 @@
   "f2bf9048bef64cc5b6d5110154e33c81": {
     "active_preset": "home",
     "available_schedules": [
+      "off",
       "Badkamer",
       "Vakantie",
       "Weekschema",
-      "Test",
-      "off"
+      "Test"
     ],
     "climate_mode": "off",
     "control_state": "idle",
@@ -267,11 +267,11 @@
   "f871b8c4d63549319221e294e4f88074": {
     "active_preset": "vacation",
     "available_schedules": [
+      "off",
       "Badkamer",
       "Vakantie",
       "Weekschema",
-      "Test",
-      "off"
+      "Test"
     ],
     "climate_mode": "off",
     "control_state": "idle",

--- a/fixtures/m_adam_jip/data.json
+++ b/fixtures/m_adam_jip/data.json
@@ -1,7 +1,9 @@
 {
   "06aecb3d00354375924f50c47af36bd2": {
     "active_preset": "no_frost",
-    "available_schedules": [],
+    "available_schedules": [
+      "off"
+    ],
     "climate_mode": "off",
     "dev_class": "climate",
     "model": "ThermoZone",
@@ -13,7 +15,7 @@
       "vacation",
       "no_frost"
     ],
-    "select_schedule": null,
+    "select_schedule": "off",
     "select_zone_profile": "active",
     "sensors": {
       "temperature": 24.2
@@ -41,7 +43,9 @@
   },
   "13228dab8ce04617af318a2888b3c548": {
     "active_preset": "home",
-    "available_schedules": [],
+    "available_schedules": [
+      "off"
+    ],
     "climate_mode": "heat",
     "control_state": "idle",
     "dev_class": "climate",
@@ -54,7 +58,7 @@
       "vacation",
       "no_frost"
     ],
-    "select_schedule": null,
+    "select_schedule": "off",
     "select_zone_profile": "active",
     "sensors": {
       "temperature": 27.4
@@ -281,7 +285,9 @@
   },
   "d27aede973b54be484f6842d1b2802ad": {
     "active_preset": "home",
-    "available_schedules": [],
+    "available_schedules": [
+      "off"
+    ],
     "climate_mode": "heat",
     "control_state": "idle",
     "dev_class": "climate",
@@ -294,7 +300,7 @@
       "vacation",
       "no_frost"
     ],
-    "select_schedule": null,
+    "select_schedule": "off",
     "select_zone_profile": "active",
     "sensors": {
       "temperature": 30.0
@@ -346,7 +352,9 @@
   },
   "d58fec52899f4f1c92e4f8fad6d8c48c": {
     "active_preset": "home",
-    "available_schedules": [],
+    "available_schedules": [
+      "off"
+    ],
     "climate_mode": "heat",
     "control_state": "idle",
     "dev_class": "climate",
@@ -359,7 +367,7 @@
       "vacation",
       "no_frost"
     ],
-    "select_schedule": null,
+    "select_schedule": "off",
     "select_zone_profile": "active",
     "sensors": {
       "temperature": 30.0

--- a/fixtures/m_adam_multiple_devices_per_zone/data.json
+++ b/fixtures/m_adam_multiple_devices_per_zone/data.json
@@ -23,12 +23,12 @@
   "08963fec7c53423ca5680aa4cb502c63": {
     "active_preset": "away",
     "available_schedules": [
+      "off",
       "CV Roan",
       "Bios Schema met Film Avond",
       "GF7  Woonkamer",
       "Badkamer Schema",
-      "CV Jessie",
-      "off"
+      "CV Jessie"
     ],
     "climate_mode": "auto",
     "control_state": "idle",
@@ -64,12 +64,12 @@
   "12493538af164a409c6a1c79e38afe1c": {
     "active_preset": "away",
     "available_schedules": [
+      "off",
       "CV Roan",
       "Bios Schema met Film Avond",
       "GF7  Woonkamer",
       "Badkamer Schema",
-      "CV Jessie",
-      "off"
+      "CV Jessie"
     ],
     "climate_mode": "heat",
     "control_state": "idle",
@@ -278,12 +278,12 @@
   "82fa13f017d240daa0d0ea1775420f24": {
     "active_preset": "asleep",
     "available_schedules": [
+      "off",
       "CV Roan",
       "Bios Schema met Film Avond",
       "GF7  Woonkamer",
       "Badkamer Schema",
-      "CV Jessie",
-      "off"
+      "CV Jessie"
     ],
     "climate_mode": "auto",
     "control_state": "idle",
@@ -433,12 +433,12 @@
   "c50f167537524366a5af7aa3942feb1e": {
     "active_preset": "home",
     "available_schedules": [
+      "off",
       "CV Roan",
       "Bios Schema met Film Avond",
       "GF7  Woonkamer",
       "Badkamer Schema",
-      "CV Jessie",
-      "off"
+      "CV Jessie"
     ],
     "climate_mode": "auto",
     "control_state": "heating",

--- a/fixtures/m_anna_heatpump_cooling/data.json
+++ b/fixtures/m_anna_heatpump_cooling/data.json
@@ -68,8 +68,8 @@
   "3cb70739631c4d17a86b8b12e8a5161b": {
     "active_preset": "home",
     "available_schedules": [
-      "standaard",
-      "off"
+      "off",
+      "standaard"
     ],
     "climate_mode": "auto",
     "control_state": "cooling",

--- a/fixtures/m_anna_heatpump_idle/data.json
+++ b/fixtures/m_anna_heatpump_idle/data.json
@@ -68,8 +68,8 @@
   "3cb70739631c4d17a86b8b12e8a5161b": {
     "active_preset": "home",
     "available_schedules": [
-      "standaard",
-      "off"
+      "off",
+      "standaard"
     ],
     "climate_mode": "auto",
     "control_state": "idle",

--- a/plugwise/data.py
+++ b/plugwise/data.py
@@ -12,7 +12,6 @@ from plugwise.constants import (
     ANNA,
     MAX_SETPOINT,
     MIN_SETPOINT,
-    NONE,
     OFF,
     ActuatorData,
     GwEntityData,

--- a/plugwise/data.py
+++ b/plugwise/data.py
@@ -276,18 +276,18 @@ class SmileData(SmileHelper):
             entity["active_preset"] = self._preset(loc_id)
 
         # Schedule
-        entity["available_schedules"] = []
-        entity["select_schedule"] = None
+        entity["available_schedules"] = [OFF]
+        entity["select_schedule"] = OFF
         self._count += 2
         avail_schedules, sel_schedule = self._schedules(loc_id)
-        if avail_schedules != [NONE]:
+        if avail_schedules != [OFF]:
             entity["available_schedules"] = avail_schedules
             entity["select_schedule"] = sel_schedule
 
         # Set HA climate HVACMode: auto, heat, heat_cool, cool and off
         entity["climate_mode"] = "auto"
         self._count += 1
-        if sel_schedule in (NONE, OFF):
+        if sel_schedule == OFF:
             entity["climate_mode"] = "heat"
             if self._cooling_present:
                 entity["climate_mode"] = (
@@ -297,10 +297,9 @@ class SmileData(SmileHelper):
         if self.check_reg_mode("off"):
             entity["climate_mode"] = "off"
 
-        if NONE not in avail_schedules:
-            self._get_schedule_states_with_off(
-                loc_id, avail_schedules, sel_schedule, entity
-            )
+        self._get_schedule_states_with_off(
+            loc_id, avail_schedules, sel_schedule, entity
+        )
 
     def check_reg_mode(self, mode: str) -> bool:
         """Helper-function for device_data_climate()."""
@@ -326,15 +325,12 @@ class SmileData(SmileHelper):
     def _get_schedule_states_with_off(
         self, location: str, schedules: list[str], selected: str, entity: GwEntityData
     ) -> None:
-        """Collect schedules with states for each thermostat.
-
-        Also, replace NONE by OFF when none of the schedules are active.
-        """
+        """Collect schedules with states for each thermostat."""
         all_off = True
         self._schedule_old_states[location] = {}
         for schedule in schedules:
-            active: bool = schedule == selected and entity["climate_mode"] == "auto"
             self._schedule_old_states[location][schedule] = "off"
+            active: bool = schedule == selected and entity["climate_mode"] == "auto"
             if active:
                 self._schedule_old_states[location][schedule] = "on"
                 all_off = False

--- a/plugwise/helper.py
+++ b/plugwise/helper.py
@@ -984,9 +984,9 @@ class SmileHelper(SmileCommon):
         Obtain the available schedules/schedules. Adam: a schedule can be connected to more than one location.
         NEW: when a location_id is present then the schedule is active. Valid for both Adam and non-legacy Anna.
         """
-        available: list[str] = [NONE]
+        available: list[str] = [OFF]
         rule_ids: dict[str, dict[str, str]] = {}
-        selected = NONE
+        selected = OFF
         tag = "zone_preset_based_on_time_and_presence_with_override"
         if not (rule_ids := self._rule_ids_by_tag(tag, location)):
             return available, selected
@@ -1004,12 +1004,6 @@ class SmileHelper(SmileCommon):
             if location == data["location"] and active:
                 selected = name
             schedules.append(name)
-
-        if schedules:
-            available.remove(NONE)
-            available.append(OFF)
-            if selected == NONE:
-                selected = OFF
 
         return available, selected
 

--- a/plugwise/legacy/data.py
+++ b/plugwise/legacy/data.py
@@ -7,7 +7,7 @@ from __future__ import annotations
 
 # Dict as class
 # Version detection
-from plugwise.constants import NONE, OFF, GwEntityData
+from plugwise.constants import OFF, GwEntityData
 from plugwise.legacy.helper import SmileLegacyHelper
 from plugwise.util import remove_empty_platform_dicts
 
@@ -63,18 +63,18 @@ class SmileLegacyData(SmileLegacyHelper):
             entity["active_preset"] = self._preset()
 
         # Schedule
-        entity["available_schedules"] = []
-        entity["select_schedule"] = None
+        entity["available_schedules"] = [OFF]
+        entity["select_schedule"] = OFF
         self._count += 2
         avail_schedules, sel_schedule = self._schedules()
-        if avail_schedules != [NONE]:
+        if avail_schedules != [OFF]:
             entity["available_schedules"] = avail_schedules
             entity["select_schedule"] = sel_schedule
 
         # Set HA climate HVACMode: auto, heat
         entity["climate_mode"] = "auto"
         self._count += 1
-        if sel_schedule in (NONE, OFF):
+        if sel_schedule == OFF:
             entity["climate_mode"] = "heat"
 
     def _get_anna_control_state(self, entity: GwEntityData) -> None:

--- a/plugwise/legacy/helper.py
+++ b/plugwise/legacy/helper.py
@@ -413,8 +413,8 @@ class SmileLegacyHelper(SmileCommon):
 
     def _schedules(self) -> tuple[list[str], str]:
         """Collect the schedule for the legacy thermostat."""
-        available: list[str] = [NONE]
-        rule_id = selected = NONE
+        available: list[str] = [OFF]
+        rule_id = selected = OFF
         name: str | None = None
 
         search = self._domain_objects
@@ -433,7 +433,7 @@ class SmileLegacyHelper(SmileCommon):
             search.find(f'./rule[@id="{rule_id}"]/directives/when/then') is not None
         )
         if directives and name is not None:
-            available = [name, OFF]
+            available = [OFF, name]
             selected = name if active else OFF
 
         return available, selected

--- a/tests/data/adam/adam_bad_thermostat.json
+++ b/tests/data/adam/adam_bad_thermostat.json
@@ -45,7 +45,7 @@
   },
   "3ee6b9486cb04c258a3130fff2b144a4": {
     "active_preset": "home",
-    "available_schedules": [],
+    "available_schedules": ["off"],
     "climate_mode": "heat",
     "control_state": "idle",
     "dev_class": "climate",
@@ -58,7 +58,7 @@
       "vacation",
       "no_frost"
     ],
-    "select_schedule": null,
+    "select_schedule": "off",
     "sensors": {
       "temperature": 20.3
     },

--- a/tests/data/adam/adam_bad_thermostat.json
+++ b/tests/data/adam/adam_bad_thermostat.json
@@ -45,7 +45,9 @@
   },
   "3ee6b9486cb04c258a3130fff2b144a4": {
     "active_preset": "home",
-    "available_schedules": ["off"],
+    "available_schedules": [
+      "off"
+    ],
     "climate_mode": "heat",
     "control_state": "idle",
     "dev_class": "climate",

--- a/tests/data/adam/adam_heatpump_cooling.json
+++ b/tests/data/adam/adam_heatpump_cooling.json
@@ -2,10 +2,10 @@
   "04b15f6e884448288f811d29fb7b1b30": {
     "active_preset": "away",
     "available_schedules": [
+      "off",
       "Opstaan weekdag",
       "Werkdag schema",
-      "Weekend",
-      "off"
+      "Weekend"
     ],
     "climate_mode": "cool",
     "control_state": "idle",
@@ -141,10 +141,10 @@
   "20e735858f8146cead98b873177a4f99": {
     "active_preset": "away",
     "available_schedules": [
+      "off",
       "Opstaan weekdag",
       "Werkdag schema",
-      "Weekend",
-      "off"
+      "Weekend"
     ],
     "climate_mode": "cool",
     "control_state": "idle",
@@ -269,10 +269,10 @@
   "5cc21042f87f4b4c94ccb5537c47a53f": {
     "active_preset": "away",
     "available_schedules": [
+      "off",
       "Opstaan weekdag",
       "Werkdag schema",
-      "Weekend",
-      "off"
+      "Weekend"
     ],
     "climate_mode": "auto",
     "control_state": "idle",
@@ -429,10 +429,10 @@
   "8cf650a4c10c44819e426bed406aec34": {
     "active_preset": "away",
     "available_schedules": [
+      "off",
       "Opstaan weekdag",
       "Werkdag schema",
-      "Weekend",
-      "off"
+      "Weekend"
     ],
     "climate_mode": "auto",
     "control_state": "idle",
@@ -475,10 +475,10 @@
   "93ac3f7bf25342f58cbb77c4a99ac0b3": {
     "active_preset": "away",
     "available_schedules": [
+      "off",
       "Opstaan weekdag",
       "Werkdag schema",
-      "Weekend",
-      "off"
+      "Weekend"
     ],
     "climate_mode": "cool",
     "control_state": "idle",
@@ -540,10 +540,10 @@
   "9a27714b970547ee9a6bdadc2b815ad5": {
     "active_preset": "away",
     "available_schedules": [
+      "off",
       "Opstaan weekdag",
       "Werkdag schema",
-      "Weekend",
-      "off"
+      "Weekend"
     ],
     "climate_mode": "cool",
     "control_state": "idle",
@@ -606,10 +606,10 @@
   "a562019b0b1f47a4bde8ebe3dbe3e8a9": {
     "active_preset": "away",
     "available_schedules": [
+      "off",
       "Opstaan weekdag",
       "Werkdag schema",
-      "Weekend",
-      "off"
+      "Weekend"
     ],
     "climate_mode": "auto",
     "control_state": "idle",
@@ -652,10 +652,10 @@
   "b52908550469425b812c87f766fe5303": {
     "active_preset": "away",
     "available_schedules": [
+      "off",
       "Opstaan weekdag",
       "Werkdag schema",
-      "Weekend",
-      "off"
+      "Weekend"
     ],
     "climate_mode": "cool",
     "control_state": "idle",
@@ -796,10 +796,10 @@
   "e39529c79ab54fda9bed26cfc0447546": {
     "active_preset": "away",
     "available_schedules": [
+      "off",
       "Opstaan weekdag",
       "Werkdag schema",
-      "Weekend",
-      "off"
+      "Weekend"
     ],
     "climate_mode": "cool",
     "control_state": "idle",
@@ -912,10 +912,10 @@
   "fa5fa6b34f6b40a0972988b20e888ed4": {
     "active_preset": "away",
     "available_schedules": [
+      "off",
       "Opstaan weekdag",
       "Werkdag schema",
-      "Weekend",
-      "off"
+      "Weekend"
     ],
     "climate_mode": "auto",
     "control_state": "idle",

--- a/tests/data/adam/adam_jip.json
+++ b/tests/data/adam/adam_jip.json
@@ -1,7 +1,7 @@
 {
   "06aecb3d00354375924f50c47af36bd2": {
     "active_preset": "no_frost",
-    "available_schedules": [],
+    "available_schedules": ["off"],
     "climate_mode": "heat",
     "control_state": "idle",
     "dev_class": "climate",
@@ -14,7 +14,7 @@
       "vacation",
       "no_frost"
     ],
-    "select_schedule": null,
+    "select_schedule": "off",
     "select_zone_profile": "active",
     "sensors": {
       "temperature": 24.2
@@ -42,7 +42,7 @@
   },
   "13228dab8ce04617af318a2888b3c548": {
     "active_preset": "home",
-    "available_schedules": [],
+    "available_schedules": ["off"],
     "climate_mode": "heat",
     "control_state": "idle",
     "dev_class": "climate",
@@ -55,7 +55,7 @@
       "vacation",
       "no_frost"
     ],
-    "select_schedule": null,
+    "select_schedule": "off",
     "select_zone_profile": "active",
     "sensors": {
       "temperature": 27.4
@@ -282,7 +282,7 @@
   },
   "d27aede973b54be484f6842d1b2802ad": {
     "active_preset": "home",
-    "available_schedules": [],
+    "available_schedules": ["off"],
     "climate_mode": "heat",
     "control_state": "idle",
     "dev_class": "climate",
@@ -295,7 +295,7 @@
       "vacation",
       "no_frost"
     ],
-    "select_schedule": null,
+    "select_schedule": "off",
     "select_zone_profile": "active",
     "sensors": {
       "temperature": 30.0
@@ -347,7 +347,7 @@
   },
   "d58fec52899f4f1c92e4f8fad6d8c48c": {
     "active_preset": "home",
-    "available_schedules": [],
+    "available_schedules": ["off"],
     "climate_mode": "heat",
     "control_state": "idle",
     "dev_class": "climate",
@@ -360,7 +360,7 @@
       "vacation",
       "no_frost"
     ],
-    "select_schedule": null,
+    "select_schedule": "off",
     "select_zone_profile": "active",
     "sensors": {
       "temperature": 30.0

--- a/tests/data/adam/adam_jip.json
+++ b/tests/data/adam/adam_jip.json
@@ -1,7 +1,9 @@
 {
   "06aecb3d00354375924f50c47af36bd2": {
     "active_preset": "no_frost",
-    "available_schedules": ["off"],
+    "available_schedules": [
+      "off"
+    ],
     "climate_mode": "heat",
     "control_state": "idle",
     "dev_class": "climate",
@@ -42,7 +44,9 @@
   },
   "13228dab8ce04617af318a2888b3c548": {
     "active_preset": "home",
-    "available_schedules": ["off"],
+    "available_schedules": [
+      "off"
+    ],
     "climate_mode": "heat",
     "control_state": "idle",
     "dev_class": "climate",
@@ -282,7 +286,9 @@
   },
   "d27aede973b54be484f6842d1b2802ad": {
     "active_preset": "home",
-    "available_schedules": ["off"],
+    "available_schedules": [
+      "off"
+    ],
     "climate_mode": "heat",
     "control_state": "idle",
     "dev_class": "climate",
@@ -347,7 +353,9 @@
   },
   "d58fec52899f4f1c92e4f8fad6d8c48c": {
     "active_preset": "home",
-    "available_schedules": ["off"],
+    "available_schedules": [
+      "off"
+    ],
     "climate_mode": "heat",
     "control_state": "idle",
     "dev_class": "climate",

--- a/tests/data/adam/adam_multiple_devices_per_zone.json
+++ b/tests/data/adam/adam_multiple_devices_per_zone.json
@@ -23,19 +23,25 @@
   "08963fec7c53423ca5680aa4cb502c63": {
     "active_preset": "away",
     "available_schedules": [
+      "off",
       "CV Roan",
       "Bios Schema met Film Avond",
       "GF7  Woonkamer",
       "Badkamer Schema",
-      "CV Jessie",
-      "off"
+      "CV Jessie"
     ],
     "climate_mode": "auto",
     "control_state": "idle",
     "dev_class": "climate",
     "model": "ThermoZone",
     "name": "Badkamer",
-    "preset_modes": ["home", "asleep", "away", "vacation", "no_frost"],
+    "preset_modes": [
+      "home",
+      "asleep",
+      "away",
+      "vacation",
+      "no_frost"
+    ],
     "select_schedule": "Badkamer Schema",
     "sensors": {
       "temperature": 18.9
@@ -58,19 +64,25 @@
   "12493538af164a409c6a1c79e38afe1c": {
     "active_preset": "away",
     "available_schedules": [
+      "off",
       "CV Roan",
       "Bios Schema met Film Avond",
       "GF7  Woonkamer",
       "Badkamer Schema",
-      "CV Jessie",
-      "off"
+      "CV Jessie"
     ],
     "climate_mode": "heat",
     "control_state": "idle",
     "dev_class": "climate",
     "model": "ThermoZone",
     "name": "Bios",
-    "preset_modes": ["home", "asleep", "away", "vacation", "no_frost"],
+    "preset_modes": [
+      "home",
+      "asleep",
+      "away",
+      "vacation",
+      "no_frost"
+    ],
     "select_schedule": "off",
     "sensors": {
       "electricity_consumed": 0.0,
@@ -84,8 +96,12 @@
       "upper_bound": 100.0
     },
     "thermostats": {
-      "primary": ["df4a4a8169904cdb9c03d61a21f42140"],
-      "secondary": ["a2c3583e0a6349358998b760cea82d2a"]
+      "primary": [
+        "df4a4a8169904cdb9c03d61a21f42140"
+      ],
+      "secondary": [
+        "a2c3583e0a6349358998b760cea82d2a"
+      ]
     },
     "vendor": "Plugwise"
   },
@@ -113,19 +129,25 @@
   "446ac08dd04d4eff8ac57489757b7314": {
     "active_preset": "no_frost",
     "available_schedules": [
+      "off",
       "CV Roan",
       "Bios Schema met Film Avond",
       "GF7  Woonkamer",
       "Badkamer Schema",
-      "CV Jessie",
-      "off"
+      "CV Jessie"
     ],
     "climate_mode": "heat",
     "control_state": "idle",
     "dev_class": "climate",
     "model": "ThermoZone",
     "name": "Garage",
-    "preset_modes": ["home", "asleep", "away", "vacation", "no_frost"],
+    "preset_modes": [
+      "home",
+      "asleep",
+      "away",
+      "vacation",
+      "no_frost"
+    ],
     "select_schedule": "off",
     "sensors": {
       "temperature": 15.6
@@ -137,7 +159,9 @@
       "upper_bound": 100.0
     },
     "thermostats": {
-      "primary": ["e7693eb9582644e5b865dba8d4447cf1"],
+      "primary": [
+        "e7693eb9582644e5b865dba8d4447cf1"
+      ],
       "secondary": []
     },
     "vendor": "Plugwise"
@@ -261,19 +285,25 @@
   "82fa13f017d240daa0d0ea1775420f24": {
     "active_preset": "asleep",
     "available_schedules": [
+      "off",
       "CV Roan",
       "Bios Schema met Film Avond",
       "GF7  Woonkamer",
       "Badkamer Schema",
-      "CV Jessie",
-      "off"
+      "CV Jessie"
     ],
     "climate_mode": "auto",
     "control_state": "idle",
     "dev_class": "climate",
     "model": "ThermoZone",
     "name": "Jessie",
-    "preset_modes": ["home", "asleep", "away", "vacation", "no_frost"],
+    "preset_modes": [
+      "home",
+      "asleep",
+      "away",
+      "vacation",
+      "no_frost"
+    ],
     "select_schedule": "CV Jessie",
     "sensors": {
       "temperature": 17.2
@@ -285,8 +315,12 @@
       "upper_bound": 100.0
     },
     "thermostats": {
-      "primary": ["6a3bf693d05e48e0b460c815a4fdd09d"],
-      "secondary": ["d3da73bde12a47d5a6b8f9dad971f2ec"]
+      "primary": [
+        "6a3bf693d05e48e0b460c815a4fdd09d"
+      ],
+      "secondary": [
+        "d3da73bde12a47d5a6b8f9dad971f2ec"
+      ]
     },
     "vendor": "Plugwise"
   },
@@ -406,19 +440,25 @@
   "c50f167537524366a5af7aa3942feb1e": {
     "active_preset": "home",
     "available_schedules": [
+      "off",
       "CV Roan",
       "Bios Schema met Film Avond",
       "GF7  Woonkamer",
       "Badkamer Schema",
-      "CV Jessie",
-      "off"
+      "CV Jessie"
     ],
     "climate_mode": "auto",
     "control_state": "heating",
     "dev_class": "climate",
     "model": "ThermoZone",
     "name": "Woonkamer",
-    "preset_modes": ["home", "asleep", "away", "vacation", "no_frost"],
+    "preset_modes": [
+      "home",
+      "asleep",
+      "away",
+      "vacation",
+      "no_frost"
+    ],
     "select_schedule": "GF7  Woonkamer",
     "sensors": {
       "electricity_consumed": 35.6,
@@ -432,8 +472,12 @@
       "upper_bound": 100.0
     },
     "thermostats": {
-      "primary": ["b59bcebaf94b499ea7d46e4a66fb62d8"],
-      "secondary": ["b310b72a0e354bfab43089919b9a88bf"]
+      "primary": [
+        "b59bcebaf94b499ea7d46e4a66fb62d8"
+      ],
+      "secondary": [
+        "b310b72a0e354bfab43089919b9a88bf"
+      ]
     },
     "vendor": "Plugwise"
   },

--- a/tests/data/adam/adam_onoff_cooling_fake_firmware.json
+++ b/tests/data/adam/adam_onoff_cooling_fake_firmware.json
@@ -91,10 +91,10 @@
   "fa5fa6b34f6b40a0972988b20e888ed4": {
     "active_preset": "away",
     "available_schedules": [
+      "off",
       "Opstaan weekdag",
       "Werkdag schema",
-      "Weekend",
-      "off"
+      "Weekend"
     ],
     "climate_mode": "auto",
     "control_state": "idle",

--- a/tests/data/adam/adam_plus_anna.json
+++ b/tests/data/adam/adam_plus_anna.json
@@ -2,8 +2,8 @@
   "009490cc2f674ce6b576863fbb64f867": {
     "active_preset": "home",
     "available_schedules": [
-      "Weekschema",
-      "off"
+      "off",
+      "Weekschema"
     ],
     "climate_mode": "auto",
     "control_state": "idle",

--- a/tests/data/adam/adam_plus_anna_new.json
+++ b/tests/data/adam/adam_plus_anna_new.json
@@ -302,11 +302,11 @@
   "f2bf9048bef64cc5b6d5110154e33c81": {
     "active_preset": "home",
     "available_schedules": [
+      "off",
       "Badkamer",
       "Vakantie",
       "Weekschema",
-      "Test",
-      "off"
+      "Test"
     ],
     "climate_mode": "auto",
     "control_state": "heating",
@@ -351,11 +351,11 @@
   "f871b8c4d63549319221e294e4f88074": {
     "active_preset": "vacation",
     "available_schedules": [
+      "off",
       "Badkamer",
       "Vakantie",
       "Weekschema",
-      "Test",
-      "off"
+      "Test"
     ],
     "climate_mode": "heat",
     "control_state": "idle",

--- a/tests/data/adam/adam_plus_anna_new_UPDATED_DATA.json
+++ b/tests/data/adam/adam_plus_anna_new_UPDATED_DATA.json
@@ -54,8 +54,12 @@
   },
   "f871b8c4d63549319221e294e4f88074": {
     "thermostats": {
-      "primary": ["e2f4322d57924fa090fbbc48b3a140dc"],
-      "secondary": ["1772a4ea304041adb83f357b751341ff"]
+      "primary": [
+        "e2f4322d57924fa090fbbc48b3a140dc"
+      ],
+      "secondary": [
+        "1772a4ea304041adb83f357b751341ff"
+      ]
     }
   }
 }

--- a/tests/data/adam/adam_plus_anna_new_regulation_off.json
+++ b/tests/data/adam/adam_plus_anna_new_regulation_off.json
@@ -254,11 +254,11 @@
   "f2bf9048bef64cc5b6d5110154e33c81": {
     "active_preset": "home",
     "available_schedules": [
+      "off",
       "Badkamer",
       "Test",
       "Vakantie",
-      "Weekschema",
-      "off"
+      "Weekschema"
     ],
     "climate_mode": "off",
     "control_state": "idle",
@@ -301,11 +301,11 @@
   "f871b8c4d63549319221e294e4f88074": {
     "active_preset": "home",
     "available_schedules": [
+      "off",
       "Badkamer",
       "Test",
       "Vakantie",
-      "Weekschema",
-      "off"
+      "Weekschema"
     ],
     "climate_mode": "off",
     "control_state": "idle",

--- a/tests/data/adam/adam_zone_per_device.json
+++ b/tests/data/adam/adam_zone_per_device.json
@@ -23,19 +23,25 @@
   "08963fec7c53423ca5680aa4cb502c63": {
     "active_preset": "away",
     "available_schedules": [
+      "off",
       "CV Roan",
       "Bios Schema met Film Avond",
       "GF7  Woonkamer",
       "Badkamer Schema",
-      "CV Jessie",
-      "off"
+      "CV Jessie"
     ],
     "climate_mode": "auto",
     "control_state": "idle",
     "dev_class": "climate",
     "model": "ThermoZone",
     "name": "Badkamer",
-    "preset_modes": ["home", "asleep", "away", "vacation", "no_frost"],
+    "preset_modes": [
+      "home",
+      "asleep",
+      "away",
+      "vacation",
+      "no_frost"
+    ],
     "select_schedule": "Badkamer Schema",
     "sensors": {
       "temperature": 18.8
@@ -47,27 +53,37 @@
       "upper_bound": 100.0
     },
     "thermostats": {
-      "primary": ["f1fee6043d3642a9b0a65297455f008e"],
-      "secondary": ["680423ff840043738f42cc7f1ff97a36"]
+      "primary": [
+        "f1fee6043d3642a9b0a65297455f008e"
+      ],
+      "secondary": [
+        "680423ff840043738f42cc7f1ff97a36"
+      ]
     },
     "vendor": "Plugwise"
   },
   "12493538af164a409c6a1c79e38afe1c": {
     "active_preset": "away",
     "available_schedules": [
+      "off",
       "CV Roan",
       "Bios Schema met Film Avond",
       "GF7  Woonkamer",
       "Badkamer Schema",
-      "CV Jessie",
-      "off"
+      "CV Jessie"
     ],
     "climate_mode": "heat",
     "control_state": "idle",
     "dev_class": "climate",
     "model": "ThermoZone",
     "name": "Bios",
-    "preset_modes": ["home", "asleep", "away", "vacation", "no_frost"],
+    "preset_modes": [
+      "home",
+      "asleep",
+      "away",
+      "vacation",
+      "no_frost"
+    ],
     "select_schedule": "off",
     "sensors": {
       "electricity_consumed": 0.0,
@@ -81,8 +97,12 @@
       "upper_bound": 100.0
     },
     "thermostats": {
-      "primary": ["df4a4a8169904cdb9c03d61a21f42140"],
-      "secondary": ["a2c3583e0a6349358998b760cea82d2a"]
+      "primary": [
+        "df4a4a8169904cdb9c03d61a21f42140"
+      ],
+      "secondary": [
+        "a2c3583e0a6349358998b760cea82d2a"
+      ]
     },
     "vendor": "Plugwise"
   },
@@ -110,19 +130,25 @@
   "446ac08dd04d4eff8ac57489757b7314": {
     "active_preset": "no_frost",
     "available_schedules": [
+      "off",
       "CV Roan",
       "Bios Schema met Film Avond",
       "GF7  Woonkamer",
       "Badkamer Schema",
-      "CV Jessie",
-      "off"
+      "CV Jessie"
     ],
     "climate_mode": "heat",
     "control_state": "idle",
     "dev_class": "climate",
     "model": "ThermoZone",
     "name": "Garage",
-    "preset_modes": ["home", "asleep", "away", "vacation", "no_frost"],
+    "preset_modes": [
+      "home",
+      "asleep",
+      "away",
+      "vacation",
+      "no_frost"
+    ],
     "select_schedule": "off",
     "sensors": {
       "temperature": 15.6
@@ -134,7 +160,9 @@
       "upper_bound": 100.0
     },
     "thermostats": {
-      "primary": ["e7693eb9582644e5b865dba8d4447cf1"],
+      "primary": [
+        "e7693eb9582644e5b865dba8d4447cf1"
+      ],
       "secondary": []
     },
     "vendor": "Plugwise"
@@ -258,19 +286,25 @@
   "82fa13f017d240daa0d0ea1775420f24": {
     "active_preset": "asleep",
     "available_schedules": [
+      "off",
       "CV Roan",
       "Bios Schema met Film Avond",
       "GF7  Woonkamer",
       "Badkamer Schema",
-      "CV Jessie",
-      "off"
+      "CV Jessie"
     ],
     "climate_mode": "auto",
     "control_state": "idle",
     "dev_class": "climate",
     "model": "ThermoZone",
     "name": "Jessie",
-    "preset_modes": ["home", "asleep", "away", "vacation", "no_frost"],
+    "preset_modes": [
+      "home",
+      "asleep",
+      "away",
+      "vacation",
+      "no_frost"
+    ],
     "select_schedule": "CV Jessie",
     "sensors": {
       "temperature": 17.1
@@ -282,8 +316,12 @@
       "upper_bound": 100.0
     },
     "thermostats": {
-      "primary": ["6a3bf693d05e48e0b460c815a4fdd09d"],
-      "secondary": ["d3da73bde12a47d5a6b8f9dad971f2ec"]
+      "primary": [
+        "6a3bf693d05e48e0b460c815a4fdd09d"
+      ],
+      "secondary": [
+        "d3da73bde12a47d5a6b8f9dad971f2ec"
+      ]
     },
     "vendor": "Plugwise"
   },
@@ -403,19 +441,25 @@
   "c50f167537524366a5af7aa3942feb1e": {
     "active_preset": "home",
     "available_schedules": [
+      "off",
       "CV Roan",
       "Bios Schema met Film Avond",
       "GF7  Woonkamer",
       "Badkamer Schema",
-      "CV Jessie",
-      "off"
+      "CV Jessie"
     ],
     "climate_mode": "auto",
     "control_state": "heating",
     "dev_class": "climate",
     "model": "ThermoZone",
     "name": "Woonkamer",
-    "preset_modes": ["home", "asleep", "away", "vacation", "no_frost"],
+    "preset_modes": [
+      "home",
+      "asleep",
+      "away",
+      "vacation",
+      "no_frost"
+    ],
     "select_schedule": "GF7  Woonkamer",
     "sensors": {
       "electricity_consumed": 35.8,
@@ -429,8 +473,12 @@
       "upper_bound": 100.0
     },
     "thermostats": {
-      "primary": ["b59bcebaf94b499ea7d46e4a66fb62d8"],
-      "secondary": ["b310b72a0e354bfab43089919b9a88bf"]
+      "primary": [
+        "b59bcebaf94b499ea7d46e4a66fb62d8"
+      ],
+      "secondary": [
+        "b310b72a0e354bfab43089919b9a88bf"
+      ]
     },
     "vendor": "Plugwise"
   },

--- a/tests/data/anna/anna_elga_2.json
+++ b/tests/data/anna/anna_elga_2.json
@@ -36,8 +36,8 @@
   "ebd90df1ab334565b5895f37590ccff4": {
     "active_preset": "home",
     "available_schedules": [
-      "Thermostat schedule",
-      "off"
+      "off",
+      "Thermostat schedule"
     ],
     "climate_mode": "auto",
     "control_state": "heating",

--- a/tests/data/anna/anna_elga_2_cooling.json
+++ b/tests/data/anna/anna_elga_2_cooling.json
@@ -43,8 +43,8 @@
   "ebd90df1ab334565b5895f37590ccff4": {
     "active_preset": "home",
     "available_schedules": [
-      "Thermostat schedule",
-      "off"
+      "off",
+      "Thermostat schedule"
     ],
     "climate_mode": "auto",
     "control_state": "cooling",

--- a/tests/data/anna/anna_elga_2_cooling_UPDATED_DATA.json
+++ b/tests/data/anna/anna_elga_2_cooling_UPDATED_DATA.json
@@ -42,7 +42,10 @@
   },
   "ebd90df1ab334565b5895f37590ccff4": {
     "active_preset": "home",
-    "available_schedules": ["Thermostat schedule", "off"],
+    "available_schedules": [
+      "off",
+      "Thermostat schedule"
+    ],
     "climate_mode": "auto",
     "control_state": "heating",
     "dev_class": "thermostat",
@@ -51,7 +54,13 @@
     "location": "d3ce834534114348be628b61b26d9220",
     "model": "ThermoTouch",
     "name": "Anna",
-    "preset_modes": ["away", "no_frost", "vacation", "home", "asleep"],
+    "preset_modes": [
+      "away",
+      "no_frost",
+      "vacation",
+      "home",
+      "asleep"
+    ],
     "select_schedule": "Thermostat schedule",
     "sensors": {
       "cooling_activation_outdoor_temperature": 26.0,

--- a/tests/data/anna/anna_elga_2_schedule_off.json
+++ b/tests/data/anna/anna_elga_2_schedule_off.json
@@ -43,8 +43,8 @@
   "ebd90df1ab334565b5895f37590ccff4": {
     "active_preset": "home",
     "available_schedules": [
-      "Thermostat schedule",
-      "off"
+      "off",
+      "Thermostat schedule"
     ],
     "climate_mode": "heat_cool",
     "control_state": "idle",

--- a/tests/data/anna/anna_elga_no_cooling.json
+++ b/tests/data/anna/anna_elga_no_cooling.json
@@ -66,8 +66,8 @@
   "3cb70739631c4d17a86b8b12e8a5161b": {
     "active_preset": "home",
     "available_schedules": [
-      "standaard",
-      "off"
+      "off",
+      "standaard"
     ],
     "climate_mode": "auto",
     "control_state": "heating",

--- a/tests/data/anna/anna_heatpump_cooling.json
+++ b/tests/data/anna/anna_heatpump_cooling.json
@@ -62,8 +62,8 @@
   "3cb70739631c4d17a86b8b12e8a5161b": {
     "active_preset": "home",
     "available_schedules": [
-      "standaard",
-      "off"
+      "off",
+      "standaard"
     ],
     "climate_mode": "heat_cool",
     "control_state": "cooling",

--- a/tests/data/anna/anna_heatpump_cooling_fake_firmware.json
+++ b/tests/data/anna/anna_heatpump_cooling_fake_firmware.json
@@ -62,8 +62,8 @@
   "3cb70739631c4d17a86b8b12e8a5161b": {
     "active_preset": "home",
     "available_schedules": [
-      "standaard",
-      "off"
+      "off",
+      "standaard"
     ],
     "climate_mode": "heat_cool",
     "control_state": "cooling",

--- a/tests/data/anna/anna_heatpump_heating.json
+++ b/tests/data/anna/anna_heatpump_heating.json
@@ -68,8 +68,8 @@
   "3cb70739631c4d17a86b8b12e8a5161b": {
     "active_preset": "home",
     "available_schedules": [
-      "standaard",
-      "off"
+      "off",
+      "standaard"
     ],
     "climate_mode": "auto",
     "control_state": "heating",

--- a/tests/data/anna/anna_heatpump_heating_UPDATED_DATA.json
+++ b/tests/data/anna/anna_heatpump_heating_UPDATED_DATA.json
@@ -32,7 +32,6 @@
       "return_temperature": 25.1,
       "water_pressure": 1.57,
       "outdoor_air_temperature": 3.0
-
     },
     "switches": {
       "dhw_cm_switch": false

--- a/tests/data/anna/anna_loria_cooling_active.json
+++ b/tests/data/anna/anna_loria_cooling_active.json
@@ -2,9 +2,9 @@
   "582dfbdace4d4aeb832923ce7d1ddda0": {
     "active_preset": "home",
     "available_schedules": [
+      "off",
       "Winter",
-      "Test ",
-      "off"
+      "Test "
     ],
     "climate_mode": "auto",
     "control_state": "cooling",

--- a/tests/data/anna/anna_loria_driessens.json
+++ b/tests/data/anna/anna_loria_driessens.json
@@ -20,11 +20,11 @@
   "9fb768d699e44c7fb5cc50309dc4e7d4": {
     "active_preset": "home",
     "available_schedules": [
+      "off",
       "Verwarmen@9-23u",
       "VAKANTIE (winter)",
       "VERWARMEN",
-      "KOELEN",
-      "off"
+      "KOELEN"
     ],
     "climate_mode": "auto",
     "control_state": "idle",

--- a/tests/data/anna/anna_loria_heating_idle.json
+++ b/tests/data/anna/anna_loria_heating_idle.json
@@ -2,9 +2,9 @@
   "582dfbdace4d4aeb832923ce7d1ddda0": {
     "active_preset": "home",
     "available_schedules": [
+      "off",
       "Winter",
-      "Test ",
-      "off"
+      "Test "
     ],
     "climate_mode": "auto",
     "control_state": "idle",

--- a/tests/data/anna/anna_p1.json
+++ b/tests/data/anna/anna_p1.json
@@ -2,8 +2,8 @@
   "1e5e55b958ac445583602f767cb45942": {
     "active_preset": "home",
     "available_schedules": [
-      "Thermostat schedule",
-      "off"
+      "off",
+      "Thermostat schedule"
     ],
     "climate_mode": "heat",
     "control_state": "idle",

--- a/tests/data/anna/anna_v4.json
+++ b/tests/data/anna/anna_v4.json
@@ -2,9 +2,9 @@
   "01b85360fdd243d0aaad4d6ac2a5ba7e": {
     "active_preset": "home",
     "available_schedules": [
+      "off",
       "Standaard",
-      "Thuiswerken",
-      "off"
+      "Thuiswerken"
     ],
     "climate_mode": "heat",
     "control_state": "heating",

--- a/tests/data/anna/anna_v4_UPDATED_DATA.json
+++ b/tests/data/anna/anna_v4_UPDATED_DATA.json
@@ -1,7 +1,10 @@
 {
   "cd0e6156b1f04d5f952349ffbe397481": {
     "dhw_mode": "comfort",
-    "dhw_modes": ["comfort", "eco"],
+    "dhw_modes": [
+      "comfort",
+      "eco"
+    ],
     "binary_sensors": {
       "dhw_state": false,
       "heating_state": false,

--- a/tests/data/anna/anna_v4_dhw.json
+++ b/tests/data/anna/anna_v4_dhw.json
@@ -2,9 +2,9 @@
   "01b85360fdd243d0aaad4d6ac2a5ba7e": {
     "active_preset": "home",
     "available_schedules": [
+      "off",
       "Standaard",
-      "Thuiswerken",
-      "off"
+      "Thuiswerken"
     ],
     "climate_mode": "heat",
     "control_state": "idle",

--- a/tests/data/anna/anna_v4_no_tag.json
+++ b/tests/data/anna/anna_v4_no_tag.json
@@ -2,9 +2,9 @@
   "01b85360fdd243d0aaad4d6ac2a5ba7e": {
     "active_preset": "home",
     "available_schedules": [
+      "off",
       "Standaard",
-      "Thuiswerken",
-      "off"
+      "Thuiswerken"
     ],
     "climate_mode": "auto",
     "control_state": "heating",

--- a/tests/data/anna/anna_without_boiler_fw441.json
+++ b/tests/data/anna/anna_without_boiler_fw441.json
@@ -2,9 +2,9 @@
   "7ffbb3ab4b6c4ab2915d7510f7bf8fe9": {
     "active_preset": "home",
     "available_schedules": [
+      "off",
       "Test",
-      "Normaal",
-      "off"
+      "Normaal"
     ],
     "climate_mode": "auto",
     "control_state": "idle",

--- a/tests/data/anna/legacy_anna.json
+++ b/tests/data/anna/legacy_anna.json
@@ -36,7 +36,9 @@
   },
   "0d266432d64443e283b5d708ae98b455": {
     "active_preset": "home",
-    "available_schedules": ["off"],
+    "available_schedules": [
+      "off"
+    ],
     "climate_mode": "heat",
     "control_state": "heating",
     "dev_class": "thermostat",

--- a/tests/data/anna/legacy_anna.json
+++ b/tests/data/anna/legacy_anna.json
@@ -36,7 +36,7 @@
   },
   "0d266432d64443e283b5d708ae98b455": {
     "active_preset": "home",
-    "available_schedules": [],
+    "available_schedules": ["off"],
     "climate_mode": "heat",
     "control_state": "heating",
     "dev_class": "thermostat",
@@ -52,7 +52,7 @@
       "home",
       "no_frost"
     ],
-    "select_schedule": null,
+    "select_schedule": "off",
     "sensors": {
       "illuminance": 150.8,
       "setpoint": 20.5,

--- a/tests/data/anna/legacy_anna_2.json
+++ b/tests/data/anna/legacy_anna_2.json
@@ -2,8 +2,8 @@
   "9e7377867dc24e51b8098a5ba02bd89d": {
     "active_preset": null,
     "available_schedules": [
-      "Thermostat schedule",
-      "off"
+      "off",
+      "Thermostat schedule"
     ],
     "climate_mode": "heat",
     "control_state": "idle",

--- a/tests/data/stretch/stretch_v23.json
+++ b/tests/data/stretch/stretch_v23.json
@@ -304,7 +304,9 @@
   },
   "f7b145c8492f4dd7a4de760456fdef3e": {
     "dev_class": "switching",
-    "members": ["407aa1c1099d463c9137a3a9eda787fd"],
+    "members": [
+      "407aa1c1099d463c9137a3a9eda787fd"
+    ],
     "model": "Group",
     "name": "Test",
     "switches": {


### PR DESCRIPTION
At present, no thermostat schedule defined result in:
- `available_schedules = []`
- `selected_schedule = None`

In HA this will lead to the related Select not being shown.

When a user defines a schedule, this change will not be picked up automatically by the Plugwise integration. An integration-reload will be required to show the user-update.

Proposed solution: show `off` as a the single option when no schedule is defined. This should result in the Select being present with no other options to select. When the user creates a schedule the change should automatically be picked up.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

- **Bug Fixes**
  - Thermostats without a defined schedule now consistently show the **“off”** option instead of blank/undefined values.
  - Schedule availability and the currently selected schedule stay consistent between current and legacy thermostat setups.
  - The **“off”** option is now listed first in schedule selections for easier access.

- **Documentation**
  - Updated release notes/changelog to reflect the new “no thermostat schedule” representation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->