### PR TITLE
Rename water_heater dicts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,10 @@
 # Changelog
 
-## v1.14.4
+## Ongoing
+
+- Rename dict-keys: `max_dhw_temperature` to `dhw_temperature`, `maximum_boiler_temperature` to `boiler_temperature` via PR [#908](https://github.com/plugwise/python-plugwise/pull/908)
+
+## v1.14.3.post1
 
 - Correct typing of select_schedule, manual fixture update
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## Ongoing
+## v1.14.5
 
 - Rename dict-keys: `max_dhw_temperature` to `dhw_temperature`, `maximum_boiler_temperature` to `boiler_temperature` via PR [#908](https://github.com/plugwise/python-plugwise/pull/908)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 - Rename dict-keys: `max_dhw_temperature` to `dhw_temperature`, `maximum_boiler_temperature` to `boiler_temperature` via PR [#908](https://github.com/plugwise/python-plugwise/pull/908)
 
-## v1.14.3.post1
+## v1.14.4
 
 - Correct typing of select_schedule, manual fixture update
 

--- a/fixtures/adam_bad_thermostat/data.json
+++ b/fixtures/adam_bad_thermostat/data.json
@@ -6,27 +6,27 @@
       "flame_state": false,
       "heating_state": false
     },
-    "dev_class": "heater_central",
-    "dhw_mode": "eco",
-    "dhw_modes": [
-      "comfort",
-      "eco"
-    ],
-    "location": "856285a783f24bf4b2573c8bc510eabf",
-    "max_dhw_temperature": {
-      "current": 49.9,
-      "lower_bound": 0.0,
-      "resolution": 1.0,
-      "setpoint": 50.0,
-      "upper_bound": 100.0
-    },
-    "maximum_boiler_temperature": {
+    "boiler_temperature": {
       "current": 20.9,
       "lower_bound": 25.0,
       "resolution": 0.01,
       "setpoint": 38.0,
       "upper_bound": 45.0
     },
+    "dev_class": "heater_central",
+    "dhw_mode": "eco",
+    "dhw_modes": [
+      "comfort",
+      "eco"
+    ],
+    "dhw_temperature": {
+      "current": 49.9,
+      "lower_bound": 0.0,
+      "resolution": 1.0,
+      "setpoint": 50.0,
+      "upper_bound": 100.0
+    },
+    "location": "856285a783f24bf4b2573c8bc510eabf",
     "model": "Generic heater",
     "model_id": "1.1",
     "name": "OpenTherm",

--- a/fixtures/adam_heatpump_cooling/data.json
+++ b/fixtures/adam_heatpump_cooling/data.json
@@ -54,27 +54,27 @@
       "flame_state": false,
       "heating_state": false
     },
-    "dev_class": "heater_central",
-    "dhw_mode": "comfort",
-    "dhw_modes": [
-      "comfort",
-      "eco"
-    ],
-    "location": "eedadcb297564f1483faa509179aebed",
-    "max_dhw_temperature": {
-      "current": 63.5,
-      "lower_bound": 40.0,
-      "resolution": 0.01,
-      "setpoint": 60.0,
-      "upper_bound": 65.0
-    },
-    "maximum_boiler_temperature": {
+    "boiler_temperature": {
       "current": 24.5,
       "lower_bound": 7.0,
       "resolution": 0.01,
       "setpoint": 35.0,
       "upper_bound": 50.0
     },
+    "dev_class": "heater_central",
+    "dhw_mode": "comfort",
+    "dhw_modes": [
+      "comfort",
+      "eco"
+    ],
+    "dhw_temperature": {
+      "current": 63.5,
+      "lower_bound": 40.0,
+      "resolution": 0.01,
+      "setpoint": 60.0,
+      "upper_bound": 65.0
+    },
+    "location": "eedadcb297564f1483faa509179aebed",
     "model": "Generic heater/cooler",
     "model_id": "17.1",
     "name": "OpenTherm",

--- a/fixtures/adam_jip/data.json
+++ b/fixtures/adam_jip/data.json
@@ -401,27 +401,27 @@
       "flame_state": false,
       "heating_state": false
     },
-    "dev_class": "heater_central",
-    "dhw_mode": "eco",
-    "dhw_modes": [
-      "comfort",
-      "eco"
-    ],
-    "location": "9e4433a9d69f40b3aefd15e74395eaec",
-    "max_dhw_temperature": {
-      "current": 37.3,
-      "lower_bound": 40.0,
-      "resolution": 0.01,
-      "setpoint": 60.0,
-      "upper_bound": 60.0
-    },
-    "maximum_boiler_temperature": {
+    "boiler_temperature": {
       "current": 37.3,
       "lower_bound": 20.0,
       "resolution": 0.01,
       "setpoint": 90.0,
       "upper_bound": 90.0
     },
+    "dev_class": "heater_central",
+    "dhw_mode": "eco",
+    "dhw_modes": [
+      "comfort",
+      "eco"
+    ],
+    "dhw_temperature": {
+      "current": 37.3,
+      "lower_bound": 40.0,
+      "resolution": 0.01,
+      "setpoint": 60.0,
+      "upper_bound": 60.0
+    },
+    "location": "9e4433a9d69f40b3aefd15e74395eaec",
     "model": "Generic heater",
     "model_id": "10.20",
     "name": "OpenTherm",

--- a/fixtures/adam_onoff_cooling_fake_firmware/data.json
+++ b/fixtures/adam_onoff_cooling_fake_firmware/data.json
@@ -7,27 +7,27 @@
       "flame_state": false,
       "heating_state": false
     },
-    "dev_class": "heater_central",
-    "dhw_mode": "comfort",
-    "dhw_modes": [
-      "comfort",
-      "eco"
-    ],
-    "location": "eedadcb297564f1483faa509179aebed",
-    "max_dhw_temperature": {
-      "current": 63.5,
-      "lower_bound": 40.0,
-      "resolution": 0.01,
-      "setpoint": 60.0,
-      "upper_bound": 65.0
-    },
-    "maximum_boiler_temperature": {
+    "boiler_temperature": {
       "current": 24.5,
       "lower_bound": 7.0,
       "resolution": 0.01,
       "setpoint": 35.0,
       "upper_bound": 50.0
     },
+    "dev_class": "heater_central",
+    "dhw_mode": "comfort",
+    "dhw_modes": [
+      "comfort",
+      "eco"
+    ],
+    "dhw_temperature": {
+      "current": 63.5,
+      "lower_bound": 40.0,
+      "resolution": 0.01,
+      "setpoint": 60.0,
+      "upper_bound": 65.0
+    },
+    "location": "eedadcb297564f1483faa509179aebed",
     "model": "Unknown",
     "name": "OnOff",
     "sensors": {

--- a/fixtures/adam_plus_anna/data.json
+++ b/fixtures/adam_plus_anna/data.json
@@ -44,19 +44,19 @@
       "flame_state": false,
       "heating_state": false
     },
-    "dev_class": "heater_central",
-    "dhw_modes": [
-      "comfort",
-      "eco"
-    ],
-    "location": "07d618f0bb80412687f065b8698ce3e7",
-    "maximum_boiler_temperature": {
+    "boiler_temperature": {
       "current": 48.0,
       "lower_bound": 0.0,
       "resolution": 1.0,
       "setpoint": 80.0,
       "upper_bound": 100.0
     },
+    "dev_class": "heater_central",
+    "dhw_modes": [
+      "comfort",
+      "eco"
+    ],
+    "location": "07d618f0bb80412687f065b8698ce3e7",
     "model": "Generic heater",
     "name": "OpenTherm",
     "select_dhw_mode": "eco",

--- a/fixtures/adam_plus_anna_new/data.json
+++ b/fixtures/adam_plus_anna_new/data.json
@@ -6,19 +6,19 @@
       "flame_state": true,
       "heating_state": true
     },
-    "dev_class": "heater_central",
-    "dhw_modes": [
-      "comfort",
-      "eco"
-    ],
-    "location": "bc93488efab249e5bc54fd7e175a6f91",
-    "maximum_boiler_temperature": {
+    "boiler_temperature": {
       "current": 43.0,
       "lower_bound": 25.0,
       "resolution": 0.01,
       "setpoint": 50.0,
       "upper_bound": 95.0
     },
+    "dev_class": "heater_central",
+    "dhw_modes": [
+      "comfort",
+      "eco"
+    ],
+    "location": "bc93488efab249e5bc54fd7e175a6f91",
     "model": "Generic heater",
     "name": "OpenTherm",
     "select_dhw_mode": "eco",

--- a/fixtures/adam_plus_anna_new_regulation_off/data.json
+++ b/fixtures/adam_plus_anna_new_regulation_off/data.json
@@ -6,19 +6,19 @@
       "flame_state": false,
       "heating_state": false
     },
-    "dev_class": "heater_central",
-    "dhw_modes": [
-      "comfort",
-      "eco"
-    ],
-    "location": "bc93488efab249e5bc54fd7e175a6f91",
-    "maximum_boiler_temperature": {
+    "boiler_temperature": {
       "current": 30.0,
       "lower_bound": 25.0,
       "resolution": 0.01,
       "setpoint": 50.0,
       "upper_bound": 95.0
     },
+    "dev_class": "heater_central",
+    "dhw_modes": [
+      "comfort",
+      "eco"
+    ],
+    "location": "bc93488efab249e5bc54fd7e175a6f91",
     "model": "Generic heater",
     "name": "OpenTherm",
     "select_dhw_mode": "eco",

--- a/fixtures/anna_elga_2_cooling/data.json
+++ b/fixtures/anna_elga_2_cooling/data.json
@@ -10,19 +10,19 @@
       "heating_state": false,
       "secondary_boiler_state": false
     },
-    "dev_class": "heater_central",
-    "dhw_modes": [
-      "comfort",
-      "eco"
-    ],
-    "location": "d34dfe6ab90b410c98068e75de3eb631",
-    "maximum_boiler_temperature": {
+    "boiler_temperature": {
       "current": 22.8,
       "lower_bound": 0.0,
       "resolution": 1.0,
       "setpoint": 60.0,
       "upper_bound": 100.0
     },
+    "dev_class": "heater_central",
+    "dhw_modes": [
+      "comfort",
+      "eco"
+    ],
+    "location": "d34dfe6ab90b410c98068e75de3eb631",
     "model": "Generic heater/cooler",
     "name": "OpenTherm",
     "select_dhw_mode": "comfort",

--- a/fixtures/anna_elga_2_schedule_off/data.json
+++ b/fixtures/anna_elga_2_schedule_off/data.json
@@ -10,19 +10,19 @@
       "heating_state": false,
       "secondary_boiler_state": false
     },
-    "dev_class": "heater_central",
-    "dhw_modes": [
-      "comfort",
-      "eco"
-    ],
-    "location": "d34dfe6ab90b410c98068e75de3eb631",
-    "maximum_boiler_temperature": {
+    "boiler_temperature": {
       "current": 22.8,
       "lower_bound": 0.0,
       "resolution": 1.0,
       "setpoint": 60.0,
       "upper_bound": 100.0
     },
+    "dev_class": "heater_central",
+    "dhw_modes": [
+      "comfort",
+      "eco"
+    ],
+    "location": "d34dfe6ab90b410c98068e75de3eb631",
     "model": "Generic heater/cooler",
     "name": "OpenTherm",
     "select_dhw_mode": "comfort",

--- a/fixtures/anna_elga_no_cooling/data.json
+++ b/fixtures/anna_elga_no_cooling/data.json
@@ -26,27 +26,27 @@
       "heating_state": true,
       "secondary_boiler_state": false
     },
-    "dev_class": "heater_central",
-    "dhw_mode": "eco",
-    "dhw_modes": [
-      "comfort",
-      "eco"
-    ],
-    "location": "a57efe5f145f498c9be62a9b63626fbf",
-    "max_dhw_temperature": {
-      "current": 46.3,
-      "lower_bound": 35.0,
-      "resolution": 0.01,
-      "setpoint": 53.0,
-      "upper_bound": 60.0
-    },
-    "maximum_boiler_temperature": {
+    "boiler_temperature": {
       "current": 29.1,
       "lower_bound": 0.0,
       "resolution": 1.0,
       "setpoint": 60.0,
       "upper_bound": 100.0
     },
+    "dev_class": "heater_central",
+    "dhw_mode": "eco",
+    "dhw_modes": [
+      "comfort",
+      "eco"
+    ],
+    "dhw_temperature": {
+      "current": 46.3,
+      "lower_bound": 35.0,
+      "resolution": 0.01,
+      "setpoint": 53.0,
+      "upper_bound": 60.0
+    },
+    "location": "a57efe5f145f498c9be62a9b63626fbf",
     "model": "Generic heater",
     "name": "OpenTherm",
     "sensors": {

--- a/fixtures/anna_heatpump_cooling/data.json
+++ b/fixtures/anna_heatpump_cooling/data.json
@@ -28,19 +28,19 @@
       "heating_state": false,
       "secondary_boiler_state": false
     },
-    "dev_class": "heater_central",
-    "dhw_modes": [
-      "comfort",
-      "eco"
-    ],
-    "location": "a57efe5f145f498c9be62a9b63626fbf",
-    "maximum_boiler_temperature": {
+    "boiler_temperature": {
       "current": 24.7,
       "lower_bound": 0.0,
       "resolution": 1.0,
       "setpoint": 60.0,
       "upper_bound": 100.0
     },
+    "dev_class": "heater_central",
+    "dhw_modes": [
+      "comfort",
+      "eco"
+    ],
+    "location": "a57efe5f145f498c9be62a9b63626fbf",
     "model": "Generic heater/cooler",
     "name": "OpenTherm",
     "select_dhw_mode": "eco",

--- a/fixtures/anna_heatpump_cooling_fake_firmware/data.json
+++ b/fixtures/anna_heatpump_cooling_fake_firmware/data.json
@@ -28,19 +28,19 @@
       "heating_state": false,
       "secondary_boiler_state": false
     },
-    "dev_class": "heater_central",
-    "dhw_modes": [
-      "comfort",
-      "eco"
-    ],
-    "location": "a57efe5f145f498c9be62a9b63626fbf",
-    "maximum_boiler_temperature": {
+    "boiler_temperature": {
       "current": 24.7,
       "lower_bound": 0.0,
       "resolution": 1.0,
       "setpoint": 60.0,
       "upper_bound": 100.0
     },
+    "dev_class": "heater_central",
+    "dhw_modes": [
+      "comfort",
+      "eco"
+    ],
+    "location": "a57efe5f145f498c9be62a9b63626fbf",
     "model": "Generic heater/cooler",
     "name": "OpenTherm",
     "select_dhw_mode": "eco",

--- a/fixtures/anna_heatpump_heating/data.json
+++ b/fixtures/anna_heatpump_heating/data.json
@@ -28,27 +28,27 @@
       "heating_state": true,
       "secondary_boiler_state": false
     },
-    "dev_class": "heater_central",
-    "dhw_mode": "eco",
-    "dhw_modes": [
-      "comfort",
-      "eco"
-    ],
-    "location": "a57efe5f145f498c9be62a9b63626fbf",
-    "max_dhw_temperature": {
-      "current": 46.3,
-      "lower_bound": 35.0,
-      "resolution": 0.01,
-      "setpoint": 53.0,
-      "upper_bound": 60.0
-    },
-    "maximum_boiler_temperature": {
+    "boiler_temperature": {
       "current": 29.1,
       "lower_bound": 0.0,
       "resolution": 1.0,
       "setpoint": 60.0,
       "upper_bound": 100.0
     },
+    "dev_class": "heater_central",
+    "dhw_mode": "eco",
+    "dhw_modes": [
+      "comfort",
+      "eco"
+    ],
+    "dhw_temperature": {
+      "current": 46.3,
+      "lower_bound": 35.0,
+      "resolution": 0.01,
+      "setpoint": 53.0,
+      "upper_bound": 60.0
+    },
+    "location": "a57efe5f145f498c9be62a9b63626fbf",
     "model": "Generic heater/cooler",
     "name": "OpenTherm",
     "sensors": {

--- a/fixtures/anna_loria_cooling_active/data.json
+++ b/fixtures/anna_loria_cooling_active/data.json
@@ -70,6 +70,13 @@
       "flame_state": false,
       "heating_state": false
     },
+    "boiler_temperature": {
+      "current": 25.3,
+      "lower_bound": 25.0,
+      "resolution": 0.01,
+      "setpoint": 40.0,
+      "upper_bound": 45.0
+    },
     "dev_class": "heater_central",
     "dhw_mode": "auto",
     "dhw_modes": [
@@ -79,21 +86,14 @@
       "eco",
       "comfort"
     ],
-    "location": "674b657c138a41a291d315d7471deb06",
-    "max_dhw_temperature": {
+    "dhw_temperature": {
       "current": 52.9,
       "lower_bound": 35.0,
       "resolution": 0.01,
       "setpoint": 53.0,
       "upper_bound": 60.0
     },
-    "maximum_boiler_temperature": {
-      "current": 25.3,
-      "lower_bound": 25.0,
-      "resolution": 0.01,
-      "setpoint": 40.0,
-      "upper_bound": 45.0
-    },
+    "location": "674b657c138a41a291d315d7471deb06",
     "model": "Generic heater/cooler",
     "model_id": "173",
     "name": "OpenTherm",

--- a/fixtures/anna_loria_driessens/data.json
+++ b/fixtures/anna_loria_driessens/data.json
@@ -72,6 +72,13 @@
       "flame_state": false,
       "heating_state": false
     },
+    "boiler_temperature": {
+      "current": 23.3,
+      "lower_bound": 25.0,
+      "resolution": 0.01,
+      "setpoint": 45.0,
+      "upper_bound": 45.0
+    },
     "dev_class": "heater_central",
     "dhw_mode": "auto",
     "dhw_modes": [
@@ -81,21 +88,14 @@
       "boost",
       "auto"
     ],
-    "location": "82c15f65c9bf44c592d69e16139355e3",
-    "max_dhw_temperature": {
+    "dhw_temperature": {
       "current": 49.5,
       "lower_bound": 35.0,
       "resolution": 0.01,
       "setpoint": 53.0,
       "upper_bound": 60.0
     },
-    "maximum_boiler_temperature": {
-      "current": 23.3,
-      "lower_bound": 25.0,
-      "resolution": 0.01,
-      "setpoint": 45.0,
-      "upper_bound": 45.0
-    },
+    "location": "82c15f65c9bf44c592d69e16139355e3",
     "model": "Generic heater/cooler",
     "model_id": "173",
     "name": "OpenTherm",

--- a/fixtures/anna_loria_heating_idle/data.json
+++ b/fixtures/anna_loria_heating_idle/data.json
@@ -70,6 +70,13 @@
       "flame_state": false,
       "heating_state": false
     },
+    "boiler_temperature": {
+      "current": 25.3,
+      "lower_bound": 25.0,
+      "resolution": 0.01,
+      "setpoint": 40.0,
+      "upper_bound": 45.0
+    },
     "dev_class": "heater_central",
     "dhw_mode": "auto",
     "dhw_modes": [
@@ -79,21 +86,14 @@
       "eco",
       "comfort"
     ],
-    "location": "674b657c138a41a291d315d7471deb06",
-    "max_dhw_temperature": {
+    "dhw_temperature": {
       "current": 52.9,
       "lower_bound": 35.0,
       "resolution": 0.01,
       "setpoint": 53.0,
       "upper_bound": 60.0
     },
-    "maximum_boiler_temperature": {
-      "current": 25.3,
-      "lower_bound": 25.0,
-      "resolution": 0.01,
-      "setpoint": 40.0,
-      "upper_bound": 45.0
-    },
+    "location": "674b657c138a41a291d315d7471deb06",
     "model": "Generic heater/cooler",
     "model_id": "173",
     "name": "OpenTherm",

--- a/fixtures/anna_v4/data.json
+++ b/fixtures/anna_v4/data.json
@@ -66,27 +66,27 @@
       "flame_state": false,
       "heating_state": true
     },
-    "dev_class": "heater_central",
-    "dhw_mode": "eco",
-    "dhw_modes": [
-      "comfort",
-      "eco"
-    ],
-    "location": "94c107dc6ac84ed98e9f68c0dd06bf71",
-    "max_dhw_temperature": {
-      "current": 45.0,
-      "lower_bound": 30.0,
-      "resolution": 0.01,
-      "setpoint": 60.0,
-      "upper_bound": 60.0
-    },
-    "maximum_boiler_temperature": {
+    "boiler_temperature": {
       "current": 45.0,
       "lower_bound": 0.0,
       "resolution": 1.0,
       "setpoint": 70.0,
       "upper_bound": 100.0
     },
+    "dev_class": "heater_central",
+    "dhw_mode": "eco",
+    "dhw_modes": [
+      "comfort",
+      "eco"
+    ],
+    "dhw_temperature": {
+      "current": 45.0,
+      "lower_bound": 30.0,
+      "resolution": 0.01,
+      "setpoint": 60.0,
+      "upper_bound": 60.0
+    },
+    "location": "94c107dc6ac84ed98e9f68c0dd06bf71",
     "model": "Generic heater",
     "model_id": "2.32",
     "name": "OpenTherm",

--- a/fixtures/anna_v4_dhw/data.json
+++ b/fixtures/anna_v4_dhw/data.json
@@ -66,27 +66,27 @@
       "flame_state": true,
       "heating_state": false
     },
-    "dev_class": "heater_central",
-    "dhw_mode": "eco",
-    "dhw_modes": [
-      "comfort",
-      "eco"
-    ],
-    "location": "94c107dc6ac84ed98e9f68c0dd06bf71",
-    "max_dhw_temperature": {
-      "current": 45.0,
-      "lower_bound": 30.0,
-      "resolution": 0.01,
-      "setpoint": 60.0,
-      "upper_bound": 60.0
-    },
-    "maximum_boiler_temperature": {
+    "boiler_temperature": {
       "current": 45.0,
       "lower_bound": 0.0,
       "resolution": 1.0,
       "setpoint": 70.0,
       "upper_bound": 100.0
     },
+    "dev_class": "heater_central",
+    "dhw_mode": "eco",
+    "dhw_modes": [
+      "comfort",
+      "eco"
+    ],
+    "dhw_temperature": {
+      "current": 45.0,
+      "lower_bound": 30.0,
+      "resolution": 0.01,
+      "setpoint": 60.0,
+      "upper_bound": 60.0
+    },
+    "location": "94c107dc6ac84ed98e9f68c0dd06bf71",
     "model": "Generic heater",
     "model_id": "2.32",
     "name": "OpenTherm",

--- a/fixtures/anna_v4_no_tag/data.json
+++ b/fixtures/anna_v4_no_tag/data.json
@@ -66,27 +66,27 @@
       "flame_state": false,
       "heating_state": true
     },
-    "dev_class": "heater_central",
-    "dhw_mode": "eco",
-    "dhw_modes": [
-      "comfort",
-      "eco"
-    ],
-    "location": "94c107dc6ac84ed98e9f68c0dd06bf71",
-    "max_dhw_temperature": {
-      "current": 45.0,
-      "lower_bound": 30.0,
-      "resolution": 0.01,
-      "setpoint": 60.0,
-      "upper_bound": 60.0
-    },
-    "maximum_boiler_temperature": {
+    "boiler_temperature": {
       "current": 45.0,
       "lower_bound": 0.0,
       "resolution": 1.0,
       "setpoint": 70.0,
       "upper_bound": 100.0
     },
+    "dev_class": "heater_central",
+    "dhw_mode": "eco",
+    "dhw_modes": [
+      "comfort",
+      "eco"
+    ],
+    "dhw_temperature": {
+      "current": 45.0,
+      "lower_bound": 30.0,
+      "resolution": 0.01,
+      "setpoint": 60.0,
+      "upper_bound": 60.0
+    },
+    "location": "94c107dc6ac84ed98e9f68c0dd06bf71",
     "model": "Generic heater",
     "model_id": "2.32",
     "name": "OpenTherm",

--- a/fixtures/legacy_anna/data.json
+++ b/fixtures/legacy_anna/data.json
@@ -13,15 +13,15 @@
       "flame_state": true,
       "heating_state": true
     },
-    "dev_class": "heater_central",
-    "location": "0000aaaa0000aaaa0000aaaa0000aa00",
-    "maximum_boiler_temperature": {
+    "boiler_temperature": {
       "current": 23.6,
       "lower_bound": 50.0,
       "resolution": 1.0,
       "setpoint": 50.0,
       "upper_bound": 90.0
     },
+    "dev_class": "heater_central",
+    "location": "0000aaaa0000aaaa0000aaaa0000aa00",
     "model": "Generic heater",
     "name": "OpenTherm",
     "sensors": {

--- a/fixtures/legacy_anna_2/data.json
+++ b/fixtures/legacy_anna_2/data.json
@@ -51,15 +51,15 @@
       "flame_state": false,
       "heating_state": false
     },
-    "dev_class": "heater_central",
-    "location": "be81e3f8275b4129852c4d8d550ae2eb",
-    "maximum_boiler_temperature": {
+    "boiler_temperature": {
       "current": 54.0,
       "lower_bound": 50.0,
       "resolution": 1.0,
       "setpoint": 70.0,
       "upper_bound": 90.0
     },
+    "dev_class": "heater_central",
+    "location": "be81e3f8275b4129852c4d8d550ae2eb",
     "model": "Generic heater",
     "name": "OpenTherm",
     "sensors": {

--- a/fixtures/m_adam_cooling/data.json
+++ b/fixtures/m_adam_cooling/data.json
@@ -7,19 +7,19 @@
       "flame_state": false,
       "heating_state": false
     },
-    "dev_class": "heater_central",
-    "dhw_modes": [
-      "comfort",
-      "eco"
-    ],
-    "location": "bc93488efab249e5bc54fd7e175a6f91",
-    "maximum_boiler_temperature": {
+    "boiler_temperature": {
       "current": 19.0,
       "lower_bound": 25.0,
       "resolution": 0.01,
       "setpoint": 50.0,
       "upper_bound": 95.0
     },
+    "dev_class": "heater_central",
+    "dhw_modes": [
+      "comfort",
+      "eco"
+    ],
+    "location": "bc93488efab249e5bc54fd7e175a6f91",
     "model": "Generic heater",
     "name": "OpenTherm",
     "select_dhw_mode": "eco",

--- a/fixtures/m_adam_heating/data.json
+++ b/fixtures/m_adam_heating/data.json
@@ -6,27 +6,27 @@
       "flame_state": false,
       "heating_state": true
     },
-    "dev_class": "heater_central",
-    "dhw_mode": "eco",
-    "dhw_modes": [
-      "comfort",
-      "eco"
-    ],
-    "location": "bc93488efab249e5bc54fd7e175a6f91",
-    "max_dhw_temperature": {
-      "current": 37.0,
-      "lower_bound": 40.0,
-      "resolution": 0.01,
-      "setpoint": 60.0,
-      "upper_bound": 60.0
-    },
-    "maximum_boiler_temperature": {
+    "boiler_temperature": {
       "current": 37.0,
       "lower_bound": 25.0,
       "resolution": 0.01,
       "setpoint": 50.0,
       "upper_bound": 95.0
     },
+    "dev_class": "heater_central",
+    "dhw_mode": "eco",
+    "dhw_modes": [
+      "comfort",
+      "eco"
+    ],
+    "dhw_temperature": {
+      "current": 37.0,
+      "lower_bound": 40.0,
+      "resolution": 0.01,
+      "setpoint": 60.0,
+      "upper_bound": 60.0
+    },
+    "location": "bc93488efab249e5bc54fd7e175a6f91",
     "model": "Generic heater",
     "name": "OpenTherm",
     "sensors": {

--- a/fixtures/m_adam_heating_off_schedule/data.json
+++ b/fixtures/m_adam_heating_off_schedule/data.json
@@ -6,27 +6,27 @@
       "flame_state": false,
       "heating_state": false
     },
-    "dev_class": "heater_central",
-    "dhw_mode": "eco",
-    "dhw_modes": [
-      "comfort",
-      "eco"
-    ],
-    "location": "bc93488efab249e5bc54fd7e175a6f91",
-    "max_dhw_temperature": {
-      "current": 37.0,
-      "lower_bound": 40.0,
-      "resolution": 0.01,
-      "setpoint": 60.0,
-      "upper_bound": 60.0
-    },
-    "maximum_boiler_temperature": {
+    "boiler_temperature": {
       "current": 37.0,
       "lower_bound": 25.0,
       "resolution": 0.01,
       "setpoint": 50.0,
       "upper_bound": 95.0
     },
+    "dev_class": "heater_central",
+    "dhw_mode": "eco",
+    "dhw_modes": [
+      "comfort",
+      "eco"
+    ],
+    "dhw_temperature": {
+      "current": 37.0,
+      "lower_bound": 40.0,
+      "resolution": 0.01,
+      "setpoint": 60.0,
+      "upper_bound": 60.0
+    },
+    "location": "bc93488efab249e5bc54fd7e175a6f91",
     "model": "Generic heater",
     "name": "OpenTherm",
     "sensors": {

--- a/fixtures/m_adam_jip/data.json
+++ b/fixtures/m_adam_jip/data.json
@@ -400,27 +400,27 @@
       "flame_state": false,
       "heating_state": false
     },
-    "dev_class": "heater_central",
-    "dhw_mode": "eco",
-    "dhw_modes": [
-      "comfort",
-      "eco"
-    ],
-    "location": "9e4433a9d69f40b3aefd15e74395eaec",
-    "max_dhw_temperature": {
-      "current": 37.3,
-      "lower_bound": 40.0,
-      "resolution": 0.01,
-      "setpoint": 60.0,
-      "upper_bound": 60.0
-    },
-    "maximum_boiler_temperature": {
+    "boiler_temperature": {
       "current": 37.3,
       "lower_bound": 20.0,
       "resolution": 0.01,
       "setpoint": 90.0,
       "upper_bound": 90.0
     },
+    "dev_class": "heater_central",
+    "dhw_mode": "eco",
+    "dhw_modes": [
+      "comfort",
+      "eco"
+    ],
+    "dhw_temperature": {
+      "current": 37.3,
+      "lower_bound": 40.0,
+      "resolution": 0.01,
+      "setpoint": 60.0,
+      "upper_bound": 60.0
+    },
+    "location": "9e4433a9d69f40b3aefd15e74395eaec",
     "model": "Generic heater",
     "model_id": "10.20",
     "name": "OpenTherm",

--- a/fixtures/m_anna_heatpump_cooling/data.json
+++ b/fixtures/m_anna_heatpump_cooling/data.json
@@ -52,7 +52,7 @@
     "model": "Generic heater/cooler",
     "name": "OpenTherm",
     "sensors": {
-      "dhw_temperature": 41.5,
+      "max_dhw_temperature": 41.5,
       "intended_boiler_temperature": 0.0,
       "modulation_level": 40,
       "outdoor_air_temperature": 28.0,

--- a/fixtures/m_anna_heatpump_cooling/data.json
+++ b/fixtures/m_anna_heatpump_cooling/data.json
@@ -28,31 +28,31 @@
       "heating_state": false,
       "secondary_boiler_state": false
     },
-    "dev_class": "heater_central",
-    "dhw_mode": "eco",
-    "dhw_modes": [
-      "comfort",
-      "eco"
-    ],
-    "location": "a57efe5f145f498c9be62a9b63626fbf",
-    "max_dhw_temperature": {
-      "current": 41.5,
-      "lower_bound": 35.0,
-      "resolution": 0.01,
-      "setpoint": 53.0,
-      "upper_bound": 60.0
-    },
-    "maximum_boiler_temperature": {
+    "boiler_temperature": {
       "current": 22.7,
       "lower_bound": 0.0,
       "resolution": 1.0,
       "setpoint": 60.0,
       "upper_bound": 100.0
     },
+    "dev_class": "heater_central",
+    "dhw_mode": "eco",
+    "dhw_modes": [
+      "comfort",
+      "eco"
+    ],
+    "dhw_temperature": {
+      "current": 41.5,
+      "lower_bound": 35.0,
+      "resolution": 0.01,
+      "setpoint": 53.0,
+      "upper_bound": 60.0
+    },
+    "location": "a57efe5f145f498c9be62a9b63626fbf",
     "model": "Generic heater/cooler",
     "name": "OpenTherm",
     "sensors": {
-      "max_dhw_temperature": 41.5,
+      "dhw_temperature": 41.5,
       "intended_boiler_temperature": 0.0,
       "modulation_level": 40,
       "outdoor_air_temperature": 28.0,

--- a/fixtures/m_anna_heatpump_idle/data.json
+++ b/fixtures/m_anna_heatpump_idle/data.json
@@ -28,31 +28,31 @@
       "heating_state": false,
       "secondary_boiler_state": false
     },
-    "dev_class": "heater_central",
-    "dhw_mode": "eco",
-    "dhw_modes": [
-      "comfort",
-      "eco"
-    ],
-    "location": "a57efe5f145f498c9be62a9b63626fbf",
-    "max_dhw_temperature": {
-      "current": 46.3,
-      "lower_bound": 35.0,
-      "resolution": 0.01,
-      "setpoint": 53.0,
-      "upper_bound": 60.0
-    },
-    "maximum_boiler_temperature": {
+    "boiler_temperature": {
       "current": 19.1,
       "lower_bound": 0.0,
       "resolution": 1.0,
       "setpoint": 60.0,
       "upper_bound": 100.0
     },
+    "dev_class": "heater_central",
+    "dhw_mode": "eco",
+    "dhw_modes": [
+      "comfort",
+      "eco"
+    ],
+    "dhw_temperature": {
+      "current": 46.3,
+      "lower_bound": 35.0,
+      "resolution": 0.01,
+      "setpoint": 53.0,
+      "upper_bound": 60.0
+    },
+    "location": "a57efe5f145f498c9be62a9b63626fbf",
     "model": "Generic heater/cooler",
     "name": "OpenTherm",
     "sensors": {
-      "max_dhw_temperature": 41.5,
+      "dhw_temperature": 41.5,
       "intended_boiler_temperature": 18.0,
       "modulation_level": 0,
       "outdoor_air_temperature": 28.2,

--- a/fixtures/m_anna_heatpump_idle/data.json
+++ b/fixtures/m_anna_heatpump_idle/data.json
@@ -52,7 +52,7 @@
     "model": "Generic heater/cooler",
     "name": "OpenTherm",
     "sensors": {
-      "dhw_temperature": 41.5,
+      "max_dhw_temperature": 41.5,
       "intended_boiler_temperature": 18.0,
       "modulation_level": 0,
       "outdoor_air_temperature": 28.2,

--- a/plugwise/common.py
+++ b/plugwise/common.py
@@ -309,7 +309,8 @@ class SmileCommon:
                 temp_dict["current"] = data["sensors"]["water_temperature"]
                 self._count += 1
 
-        if item == "boiler_temperature":
+        if item == "maximum_boiler_temperature":
+            item = "boiler_temperature"
             if "water_temperature" in data["sensors"]:
                 temp_dict["current"] = data["sensors"]["water_temperature"]
                 self._count += 1

--- a/plugwise/common.py
+++ b/plugwise/common.py
@@ -295,9 +295,9 @@ class SmileCommon:
     def _create_special_dicts(
         self, item: str, data: GwEntityData, temp_dict: ActuatorData
     ) -> tuple[str, ActuatorData]:
-        """Update the max_dhw_temperature and maximum_boiler_temperature dicts with a current key."""
+        """Update the dhw_temperature and boiler_temperature dicts with a current key."""
         if item == DHW_SETPOINT:
-            item = "max_dhw_temperature"
+            item = "dhw_temperature"
             if DHW_SETPOINT in data["sensors"]:
                 data["sensors"].pop(DHW_SETPOINT)
                 self._count -= 1
@@ -309,7 +309,7 @@ class SmileCommon:
                 temp_dict["current"] = data["sensors"]["water_temperature"]
                 self._count += 1
 
-        if item == "maximum_boiler_temperature":
+        if item == "boiler_temperature":
             if "water_temperature" in data["sensors"]:
                 temp_dict["current"] = data["sensors"]["water_temperature"]
                 self._count += 1

--- a/plugwise/constants.py
+++ b/plugwise/constants.py
@@ -592,8 +592,8 @@ class GwEntityData(TypedDict, total=False):
 
     # Dict-types
     binary_sensors: SmileBinarySensors
-    max_dhw_temperature: ActuatorData
-    maximum_boiler_temperature: ActuatorData
+    boiler_temperature: ActuatorData
+    dhw_temperature: ActuatorData
     sensors: SmileSensors
     switches: SmileSwitches
     temperature_offset: ActuatorData

--- a/plugwise/constants.py
+++ b/plugwise/constants.py
@@ -594,6 +594,8 @@ class GwEntityData(TypedDict, total=False):
     binary_sensors: SmileBinarySensors
     boiler_temperature: ActuatorData
     dhw_temperature: ActuatorData
+    max_dhw_temperature: ActuatorData
+    maximum_boiler_temperature: ActuatorData
     sensors: SmileSensors
     switches: SmileSwitches
     temperature_offset: ActuatorData

--- a/plugwise/data.py
+++ b/plugwise/data.py
@@ -79,7 +79,7 @@ class SmileData(SmileHelper):
 
             # Replace select_dhw_mode with dhw_mode when applicable
             if (
-                "max_dhw_temperature" in entity
+                "dhw_temperature" in entity
                 and (mode := entity.get("select_dhw_mode")) is not None
             ):
                 entity.pop("select_dhw_mode")

--- a/plugwise/legacy/helper.py
+++ b/plugwise/legacy/helper.py
@@ -349,13 +349,6 @@ class SmileLegacyHelper(SmileCommon):
     ) -> None:
         """Helper-function for _get_measurement_data()."""
         for item in ACTIVE_ACTUATORS:
-            # Skip max_dhw_temperature, not initially valid,
-            # skip thermostat for thermo_sensors
-            if item == "max_dhw_temperature" or (
-                item == "thermostat" and entity["dev_class"] == "thermo_sensor"
-            ):
-                continue
-
             temp_dict: ActuatorData = {}
             functionality = "thermostat_functionality"
 

--- a/plugwise/legacy/helper.py
+++ b/plugwise/legacy/helper.py
@@ -273,7 +273,7 @@ class SmileLegacyHelper(SmileCommon):
             self._get_lock_state(appliance, data, self._stretch_v2)
 
             if appliance.find("type").text in ACTUATOR_CLASSES:
-                self._get_actuator_functionalities(appliance, data, entity)
+                self._get_actuator_functionalities(appliance, data)
 
         # Anna: the Smile outdoor_temperature is present in the Home location
         # For some Anna's LOCATIONS is empty, falling back to domain_objects!
@@ -345,7 +345,6 @@ class SmileLegacyHelper(SmileCommon):
         self,
         xml: etree.Element,
         data: GwEntityData,
-        entity: GwEntityData,
     ) -> None:
         """Helper-function for _get_measurement_data()."""
         for item in ACTIVE_ACTUATORS:

--- a/plugwise/smile.py
+++ b/plugwise/smile.py
@@ -175,7 +175,9 @@ class SmileAPI(SmileData):
             case "temperature_offset":
                 await self.set_offset(dev_id, temperature)
                 return
-            case "max_dhw_temperature":
+            case "boiler_temperature":
+                key = "maximum_boiler_temperature"
+            case "dhw_temperature":
                 key = "domestic_hot_water_setpoint"
 
         temp = str(temperature)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name            = "plugwise"
-version         = "1.14.4"
+version         = "1.14.5"
 license         = "MIT"
 description     = "Plugwise Smile (Adam/Anna/P1) and Stretch module for Python 3."
 readme          = "README.md"

--- a/scripts/manual_fixtures.py
+++ b/scripts/manual_fixtures.py
@@ -127,7 +127,7 @@ m_adam_cooling["056ee145a816487eaa69243c3280f8bf"]["binary_sensors"][
 m_adam_cooling["056ee145a816487eaa69243c3280f8bf"]["binary_sensors"]["flame_state"] = (
     False
 )
-m_adam_cooling["056ee145a816487eaa69243c3280f8bf"]["maximum_boiler_temperature"]["current"] = 19.0
+m_adam_cooling["056ee145a816487eaa69243c3280f8bf"]["boiler_temperature"]["current"] = 19.0
 m_adam_cooling["056ee145a816487eaa69243c3280f8bf"]["sensors"][
     "intended_boiler_temperature"
 ] = 17.5
@@ -185,14 +185,14 @@ m_adam_heating["056ee145a816487eaa69243c3280f8bf"]["binary_sensors"][
 m_adam_heating["056ee145a816487eaa69243c3280f8bf"]["binary_sensors"]["flame_state"] = (
     False
 )
-m_adam_heating["056ee145a816487eaa69243c3280f8bf"]["maximum_boiler_temperature"]["current"] = 37.0
+m_adam_heating["056ee145a816487eaa69243c3280f8bf"]["boiler_temperature"]["current"] = 37.0
 m_adam_heating["056ee145a816487eaa69243c3280f8bf"]["sensors"][
     "intended_boiler_temperature"
 ] = 38.1
 m_adam_heating["056ee145a816487eaa69243c3280f8bf"]["sensors"][
     "water_temperature"
 ] = 37.0
-m_adam_heating["056ee145a816487eaa69243c3280f8bf"]["max_dhw_temperature"] = {
+m_adam_heating["056ee145a816487eaa69243c3280f8bf"]["dhw_temperature"] = {
     "current": 37.0,
     "setpoint": 60.0,
     "lower_bound": 40.0,
@@ -253,8 +253,8 @@ m_anna_heatpump_cooling["1cbf783bb11e4a7c8a6843dee3a86927"]["binary_sensors"][
     "cooling_state"
 ] = True
 
-m_anna_heatpump_cooling["1cbf783bb11e4a7c8a6843dee3a86927"]["maximum_boiler_temperature"]["current"] = 22.7
-m_anna_heatpump_cooling["1cbf783bb11e4a7c8a6843dee3a86927"]["max_dhw_temperature"]["current"] = 41.5
+m_anna_heatpump_cooling["1cbf783bb11e4a7c8a6843dee3a86927"]["boiler_temperature"]["current"] = 22.7
+m_anna_heatpump_cooling["1cbf783bb11e4a7c8a6843dee3a86927"]["dhw_temperature"]["current"] = 41.5
 m_anna_heatpump_cooling["1cbf783bb11e4a7c8a6843dee3a86927"]["sensors"][
     "dhw_temperature"
 ] = 41.5
@@ -312,8 +312,8 @@ m_anna_heatpump_idle["1cbf783bb11e4a7c8a6843dee3a86927"]["binary_sensors"][
     "cooling_state"
 ] = False
 
-m_anna_heatpump_idle["1cbf783bb11e4a7c8a6843dee3a86927"]["maximum_boiler_temperature"]["current"] = 19.1
-m_anna_heatpump_idle["1cbf783bb11e4a7c8a6843dee3a86927"]["max_dhw_temperature"]["current"] = 46.3
+m_anna_heatpump_idle["1cbf783bb11e4a7c8a6843dee3a86927"]["boiler_temperature"]["current"] = 19.1
+m_anna_heatpump_idle["1cbf783bb11e4a7c8a6843dee3a86927"]["dhw_temperature"]["current"] = 46.3
 m_anna_heatpump_idle["1cbf783bb11e4a7c8a6843dee3a86927"]["sensors"][
     "intended_boiler_temperature"
 ] = 18.0

--- a/tests/data/adam/adam_bad_thermostat.json
+++ b/tests/data/adam/adam_bad_thermostat.json
@@ -13,14 +13,14 @@
       "eco"
     ],
     "location": "856285a783f24bf4b2573c8bc510eabf",
-    "max_dhw_temperature": {
+    "dhw_temperature": {
       "current": 49.9,
       "lower_bound": 0.0,
       "resolution": 1.0,
       "setpoint": 50.0,
       "upper_bound": 100.0
     },
-    "maximum_boiler_temperature": {
+    "boiler_temperature": {
       "current": 20.9,
       "lower_bound": 25.0,
       "resolution": 0.01,

--- a/tests/data/adam/adam_heatpump_cooling.json
+++ b/tests/data/adam/adam_heatpump_cooling.json
@@ -61,14 +61,14 @@
       "eco"
     ],
     "location": "eedadcb297564f1483faa509179aebed",
-    "max_dhw_temperature": {
+    "dhw_temperature": {
       "current": 63.5,
       "lower_bound": 40.0,
       "resolution": 0.01,
       "setpoint": 60.0,
       "upper_bound": 65.0
     },
-    "maximum_boiler_temperature": {
+    "boiler_temperature": {
       "current": 24.5,
       "lower_bound": 7.0,
       "resolution": 0.01,

--- a/tests/data/adam/adam_jip.json
+++ b/tests/data/adam/adam_jip.json
@@ -408,14 +408,14 @@
       "eco"
     ],
     "location": "9e4433a9d69f40b3aefd15e74395eaec",
-    "max_dhw_temperature": {
+    "dhw_temperature": {
       "current": 37.3,
       "lower_bound": 40.0,
       "resolution": 0.01,
       "setpoint": 60.0,
       "upper_bound": 60.0
     },
-    "maximum_boiler_temperature": {
+    "boiler_temperature": {
       "current": 37.3,
       "lower_bound": 20.0,
       "resolution": 0.01,

--- a/tests/data/adam/adam_onoff_cooling_fake_firmware.json
+++ b/tests/data/adam/adam_onoff_cooling_fake_firmware.json
@@ -14,14 +14,14 @@
       "eco"
     ],
     "location": "eedadcb297564f1483faa509179aebed",
-    "max_dhw_temperature": {
+    "dhw_temperature": {
       "current": 63.5,
       "lower_bound": 40.0,
       "resolution": 0.01,
       "setpoint": 60.0,
       "upper_bound": 65.0
     },
-    "maximum_boiler_temperature": {
+    "boiler_temperature": {
       "current": 24.5,
       "lower_bound": 7.0,
       "resolution": 0.01,

--- a/tests/data/adam/adam_plus_anna.json
+++ b/tests/data/adam/adam_plus_anna.json
@@ -50,7 +50,7 @@
       "eco"
     ],
     "location": "07d618f0bb80412687f065b8698ce3e7",
-    "maximum_boiler_temperature": {
+    "boiler_temperature": {
       "current": 48.0,
       "lower_bound": 0.0,
       "resolution": 1.0,

--- a/tests/data/adam/adam_plus_anna_new.json
+++ b/tests/data/adam/adam_plus_anna_new.json
@@ -12,7 +12,7 @@
       "eco"
     ],
     "location": "bc93488efab249e5bc54fd7e175a6f91",
-    "maximum_boiler_temperature": {
+    "boiler_temperature": {
       "current": 43.0,
       "lower_bound": 25.0,
       "resolution": 0.01,

--- a/tests/data/adam/adam_plus_anna_new_regulation_off.json
+++ b/tests/data/adam/adam_plus_anna_new_regulation_off.json
@@ -12,7 +12,7 @@
       "eco"
     ],
     "location": "bc93488efab249e5bc54fd7e175a6f91",
-    "maximum_boiler_temperature": {
+    "boiler_temperature": {
       "current": 30.0,
       "lower_bound": 25.0,
       "resolution": 0.01,

--- a/tests/data/anna/anna_elga_2_cooling.json
+++ b/tests/data/anna/anna_elga_2_cooling.json
@@ -16,7 +16,7 @@
       "eco"
     ],
     "location": "d34dfe6ab90b410c98068e75de3eb631",
-    "maximum_boiler_temperature": {
+    "boiler_temperature": {
       "current": 22.8,
       "lower_bound": 0.0,
       "resolution": 1.0,

--- a/tests/data/anna/anna_elga_2_cooling_UPDATED_DATA.json
+++ b/tests/data/anna/anna_elga_2_cooling_UPDATED_DATA.json
@@ -16,7 +16,7 @@
       "eco"
     ],
     "location": "d34dfe6ab90b410c98068e75de3eb631",
-    "maximum_boiler_temperature": {
+    "boiler_temperature": {
       "current": 22.8,
       "lower_bound": 0.0,
       "resolution": 1.0,

--- a/tests/data/anna/anna_elga_2_schedule_off.json
+++ b/tests/data/anna/anna_elga_2_schedule_off.json
@@ -16,7 +16,7 @@
       "eco"
     ],
     "location": "d34dfe6ab90b410c98068e75de3eb631",
-    "maximum_boiler_temperature": {
+    "boiler_temperature": {
       "current": 22.8,
       "lower_bound": 0.0,
       "resolution": 1.0,

--- a/tests/data/anna/anna_elga_no_cooling.json
+++ b/tests/data/anna/anna_elga_no_cooling.json
@@ -33,14 +33,14 @@
       "eco"
     ],
     "location": "a57efe5f145f498c9be62a9b63626fbf",
-    "max_dhw_temperature": {
+    "dhw_temperature": {
       "current": 46.3,
       "lower_bound": 35.0,
       "resolution": 0.01,
       "setpoint": 53.0,
       "upper_bound": 60.0
     },
-    "maximum_boiler_temperature": {
+    "boiler_temperature": {
       "current": 29.1,
       "lower_bound": 0.0,
       "resolution": 1.0,

--- a/tests/data/anna/anna_heatpump_cooling.json
+++ b/tests/data/anna/anna_heatpump_cooling.json
@@ -34,7 +34,7 @@
       "eco"
     ],
     "location": "a57efe5f145f498c9be62a9b63626fbf",
-    "maximum_boiler_temperature": {
+    "boiler_temperature": {
       "current": 24.7,
       "lower_bound": 0.0,
       "resolution": 1.0,

--- a/tests/data/anna/anna_heatpump_cooling_fake_firmware.json
+++ b/tests/data/anna/anna_heatpump_cooling_fake_firmware.json
@@ -34,7 +34,7 @@
       "eco"
     ],
     "location": "a57efe5f145f498c9be62a9b63626fbf",
-    "maximum_boiler_temperature": {
+    "boiler_temperature": {
       "current": 24.7,
       "lower_bound": 0.0,
       "resolution": 1.0,

--- a/tests/data/anna/anna_heatpump_heating.json
+++ b/tests/data/anna/anna_heatpump_heating.json
@@ -35,14 +35,14 @@
       "eco"
     ],
     "location": "a57efe5f145f498c9be62a9b63626fbf",
-    "max_dhw_temperature": {
+    "dhw_temperature": {
       "current": 46.3,
       "lower_bound": 35.0,
       "resolution": 0.01,
       "setpoint": 53.0,
       "upper_bound": 60.0
     },
-    "maximum_boiler_temperature": {
+    "boiler_temperature": {
       "current": 29.1,
       "lower_bound": 0.0,
       "resolution": 1.0,

--- a/tests/data/anna/anna_heatpump_heating_UPDATED_DATA.json
+++ b/tests/data/anna/anna_heatpump_heating_UPDATED_DATA.json
@@ -16,7 +16,7 @@
       "eco"
     ],
     "location": "a57efe5f145f498c9be62a9b63626fbf",
-    "maximum_boiler_temperature": {
+    "boiler_temperature": {
       "current": 29.1,
       "setpoint": 60.0,
       "lower_bound": 0.0,

--- a/tests/data/anna/anna_loria_cooling_active.json
+++ b/tests/data/anna/anna_loria_cooling_active.json
@@ -80,14 +80,14 @@
       "comfort"
     ],
     "location": "674b657c138a41a291d315d7471deb06",
-    "max_dhw_temperature": {
+    "dhw_temperature": {
       "current": 52.9,
       "lower_bound": 35.0,
       "resolution": 0.01,
       "setpoint": 53.0,
       "upper_bound": 60.0
     },
-    "maximum_boiler_temperature": {
+    "boiler_temperature": {
       "current": 25.3,
       "lower_bound": 25.0,
       "resolution": 0.01,

--- a/tests/data/anna/anna_loria_driessens.json
+++ b/tests/data/anna/anna_loria_driessens.json
@@ -82,14 +82,14 @@
       "auto"
     ],
     "location": "82c15f65c9bf44c592d69e16139355e3",
-    "max_dhw_temperature": {
+    "dhw_temperature": {
       "current": 49.5,
       "lower_bound": 35.0,
       "resolution": 0.01,
       "setpoint": 53.0,
       "upper_bound": 60.0
     },
-    "maximum_boiler_temperature": {
+    "boiler_temperature": {
       "current": 23.3,
       "lower_bound": 25.0,
       "resolution": 0.01,

--- a/tests/data/anna/anna_loria_heating_idle.json
+++ b/tests/data/anna/anna_loria_heating_idle.json
@@ -80,14 +80,14 @@
       "comfort"
     ],
     "location": "674b657c138a41a291d315d7471deb06",
-    "max_dhw_temperature": {
+    "dhw_temperature": {
       "current": 52.9,
       "lower_bound": 35.0,
       "resolution": 0.01,
       "setpoint": 53.0,
       "upper_bound": 60.0
     },
-    "maximum_boiler_temperature": {
+    "boiler_temperature": {
       "current": 25.3,
       "lower_bound": 25.0,
       "resolution": 0.01,

--- a/tests/data/anna/anna_v4.json
+++ b/tests/data/anna/anna_v4.json
@@ -73,14 +73,14 @@
       "eco"
     ],
     "location": "94c107dc6ac84ed98e9f68c0dd06bf71",
-    "max_dhw_temperature": {
+    "dhw_temperature": {
       "current": 45.0,
       "lower_bound": 30.0,
       "resolution": 0.01,
       "setpoint": 60.0,
       "upper_bound": 60.0
     },
-    "maximum_boiler_temperature": {
+    "boiler_temperature": {
       "current": 45.0,
       "lower_bound": 0.0,
       "resolution": 1.0,

--- a/tests/data/anna/anna_v4_UPDATED_DATA.json
+++ b/tests/data/anna/anna_v4_UPDATED_DATA.json
@@ -10,14 +10,14 @@
       "heating_state": false,
       "flame_state": false
     },
-    "maximum_boiler_temperature": {
+    "boiler_temperature": {
       "current": 51.0,
       "setpoint": 69.0,
       "lower_bound": 0.0,
       "upper_bound": 100.0,
       "resolution": 1.0
     },
-    "max_dhw_temperature": {
+    "dhw_temperature": {
       "current": 51.0,
       "setpoint": 59.0,
       "lower_bound": 30.0,

--- a/tests/data/anna/anna_v4_dhw.json
+++ b/tests/data/anna/anna_v4_dhw.json
@@ -73,14 +73,14 @@
       "eco"
     ],
     "location": "94c107dc6ac84ed98e9f68c0dd06bf71",
-    "max_dhw_temperature": {
+    "dhw_temperature": {
       "current": 45.0,
       "lower_bound": 30.0,
       "resolution": 0.01,
       "setpoint": 60.0,
       "upper_bound": 60.0
     },
-    "maximum_boiler_temperature": {
+    "boiler_temperature": {
       "current": 45.0,
       "lower_bound": 0.0,
       "resolution": 1.0,

--- a/tests/data/anna/anna_v4_no_tag.json
+++ b/tests/data/anna/anna_v4_no_tag.json
@@ -73,14 +73,14 @@
       "eco"
     ],
     "location": "94c107dc6ac84ed98e9f68c0dd06bf71",
-    "max_dhw_temperature": {
+    "dhw_temperature": {
       "current": 45.0,
       "lower_bound": 30.0,
       "resolution": 0.01,
       "setpoint": 60.0,
       "upper_bound": 60.0
     },
-    "maximum_boiler_temperature": {
+    "boiler_temperature": {
       "current": 45.0,
       "lower_bound": 0.0,
       "resolution": 1.0,

--- a/tests/data/anna/legacy_anna.json
+++ b/tests/data/anna/legacy_anna.json
@@ -15,7 +15,7 @@
     },
     "dev_class": "heater_central",
     "location": "0000aaaa0000aaaa0000aaaa0000aa00",
-    "maximum_boiler_temperature": {
+    "boiler_temperature": {
       "current": 23.6,
       "lower_bound": 50.0,
       "resolution": 1.0,

--- a/tests/data/anna/legacy_anna_2.json
+++ b/tests/data/anna/legacy_anna_2.json
@@ -53,7 +53,7 @@
     },
     "dev_class": "heater_central",
     "location": "be81e3f8275b4129852c4d8d550ae2eb",
-    "maximum_boiler_temperature": {
+    "boiler_temperature": {
       "current": 54.0,
       "lower_bound": 50.0,
       "resolution": 1.0,

--- a/tests/test_adam.py
+++ b/tests/test_adam.py
@@ -47,7 +47,7 @@ class TestPlugwiseAdam(TestPlugwise):  # pylint: disable=attribute-defined-outsi
 
         test_items = await self.device_test(api, "2025-10-12 00:00:01", testdata)
         assert api.gateway_id == "da224107914542988a88561b4452b0f6"
-        assert self.entity_items == 234
+        assert self.entity_items == 230
         assert test_items == self.entity_items
         assert self.entity_list == [
             "da224107914542988a88561b4452b0f6",
@@ -357,7 +357,7 @@ class TestPlugwiseAdam(TestPlugwise):  # pylint: disable=attribute-defined-outsi
         server, api, client = await self.connect_wrapper()
 
         test_items = await self.device_test(api, "2022-01-02 00:00:01", testdata)
-        assert self.entity_items == 543
+        assert self.entity_items == 535
         assert test_items == self.entity_items
         assert self.cooling_present
         assert self._cooling_enabled
@@ -381,7 +381,7 @@ class TestPlugwiseAdam(TestPlugwise):  # pylint: disable=attribute-defined-outsi
         )
 
         test_items = await self.device_test(api, "2022-01-02 00:00:01", testdata)
-        assert self.entity_items == 74
+        assert self.entity_items == 66
         assert test_items == self.entity_items
         assert self.cooling_present
         # assert self._cooling_enabled - no cooling_enabled indication present
@@ -406,7 +406,7 @@ class TestPlugwiseAdam(TestPlugwise):  # pylint: disable=attribute-defined-outsi
 
         test_items = await self.device_test(api, "2020-03-22 00:00:01", testdata)
         assert api.gateway_id == "b128b4bbbd1f47e9bf4d756e8fb5ee94"
-        assert self.entity_items == 85
+        assert self.entity_items == 81
         assert test_items == self.entity_items
         assert "6fb89e35caeb4b1cb275184895202d84" in self.notifications
 
@@ -447,7 +447,7 @@ class TestPlugwiseAdam(TestPlugwise):  # pylint: disable=attribute-defined-outsi
 
         test_items = await self.device_test(api, "2021-06-20 00:00:01", testdata)
         assert api.gateway_id == "b5c2386c6f6342669e50fe49dd05b188"
-        assert self.entity_items == 273
+        assert self.entity_items == 265
         assert test_items == self.entity_items
 
         # Negative test

--- a/tests/test_adam.py
+++ b/tests/test_adam.py
@@ -47,7 +47,7 @@ class TestPlugwiseAdam(TestPlugwise):  # pylint: disable=attribute-defined-outsi
 
         test_items = await self.device_test(api, "2025-10-12 00:00:01", testdata)
         assert api.gateway_id == "da224107914542988a88561b4452b0f6"
-        assert self.entity_items == 230
+        assert self.entity_items == 234
         assert test_items == self.entity_items
         assert self.entity_list == [
             "da224107914542988a88561b4452b0f6",
@@ -357,7 +357,7 @@ class TestPlugwiseAdam(TestPlugwise):  # pylint: disable=attribute-defined-outsi
         server, api, client = await self.connect_wrapper()
 
         test_items = await self.device_test(api, "2022-01-02 00:00:01", testdata)
-        assert self.entity_items == 535
+        assert self.entity_items == 543
         assert test_items == self.entity_items
         assert self.cooling_present
         assert self._cooling_enabled
@@ -381,7 +381,7 @@ class TestPlugwiseAdam(TestPlugwise):  # pylint: disable=attribute-defined-outsi
         )
 
         test_items = await self.device_test(api, "2022-01-02 00:00:01", testdata)
-        assert self.entity_items == 66
+        assert self.entity_items == 74
         assert test_items == self.entity_items
         assert self.cooling_present
         # assert self._cooling_enabled - no cooling_enabled indication present
@@ -406,7 +406,7 @@ class TestPlugwiseAdam(TestPlugwise):  # pylint: disable=attribute-defined-outsi
 
         test_items = await self.device_test(api, "2020-03-22 00:00:01", testdata)
         assert api.gateway_id == "b128b4bbbd1f47e9bf4d756e8fb5ee94"
-        assert self.entity_items == 81
+        assert self.entity_items == 85
         assert test_items == self.entity_items
         assert "6fb89e35caeb4b1cb275184895202d84" in self.notifications
 
@@ -447,7 +447,7 @@ class TestPlugwiseAdam(TestPlugwise):  # pylint: disable=attribute-defined-outsi
 
         test_items = await self.device_test(api, "2021-06-20 00:00:01", testdata)
         assert api.gateway_id == "b5c2386c6f6342669e50fe49dd05b188"
-        assert self.entity_items == 265
+        assert self.entity_items == 273
         assert test_items == self.entity_items
 
         # Negative test

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -495,7 +495,15 @@ class TestPlugwise:  # pylint: disable=attribute-defined-outside-init
             tests = 0
             tested_items = 0
             asserts = 0
-            bsw_list = ["binary_sensors", "central", "climate", "sensors", "switches"]
+            dicts_content = [
+                "binary_sensors",
+                "sensors",
+                "switches",
+                "dhw_temperature",
+                "boiler_temperature",
+                "temperature_offset",
+                "thermostat",
+            ]
             for testitem, measurements in test_dict.items():
                 item_asserts = 0
                 tests += 1
@@ -514,10 +522,7 @@ class TestPlugwise:  # pylint: disable=attribute-defined-outside-init
                                 f"  + Testing {measure_key}/{type(measure_key)} with {details[measure_key]}/{type(details[measure_key])} (should be {measure_assert}/{type(measure_assert)} )",
                             )
                             tests += 1
-                            if (
-                                measure_key in bsw_list
-                                or measure_key in pw_constants.ACTIVE_ACTUATORS
-                            ):
+                            if measure_key in dicts_content:
                                 tests -= 1
                                 for key_1, val_1 in measure_assert.items():
                                     tests += 1

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -938,8 +938,8 @@ class TestPlugwise:  # pylint: disable=attribute-defined-outside-init
         new_temp = 60.0
         _LOGGER.info("- Adjusting temperature to %s", new_temp)
         for test in [
-            "maximum_boiler_temperature",
-            "max_dhw_temperature",
+            "boiler_temperature",
+            "dhw_temperature",
             "bogus_temperature",
         ]:
             _LOGGER.info("  + for %s", test)


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Standardized boiler and domestic hot-water temperature data under clearer, consistent names.
  * Preserved existing temperature readings, limits, and control behavior.
  * Updated temperature controls to use the standardized data fields.

* **Bug Fixes**
  * Improved handling of domestic hot-water modes and nested temperature data across heating and cooling configurations.
  * Ensured active temperature controls are recognized consistently across supported devices.

* **Tests**
  * Updated coverage and sample data to validate consistent temperature handling across supported devices.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->